### PR TITLE
fix(docker): update db filename / point to .env

### DIFF
--- a/Dockerfile-mysql
+++ b/Dockerfile-mysql
@@ -1,3 +1,3 @@
 FROM mysql/mysql-server:5.7
 ADD my.cnf /etc/mysql/my.cnf
-ADD WG-deb-db-1-20-23.sql /docker-entrypoint-initdb.d
+ADD WG-deb-db-1-28-23.sql /docker-entrypoint-initdb.d

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
     links:
       - mysql
     env_file:
-      - dev.env
+      - .env
     depends_on:
       mysql:
         condition: service_healthy


### PR DESCRIPTION
Two quick touchups

1. Updated the docker sql filename
2. Use the `.env` instead of `dev.env` in the dockerfile

Re: \2 - I like having the dev.env as a copy/paste point, but for consistency IMO let's just keep leveraging the `.env` file. Devs can copy the `dev.env` to `.env` in their local, and then not worry about intentionally ignoring the `dev.env` changes when committing.

cc: @HeatherFlux for docker