### PR TITLE
Attempt move scripts to body instead of head

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,5 @@
 # Add this for now to ease transition
-*.handlebars
+# *.handlebars
 
 # Dont format raw assets
 public

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wanderers-guide",
-    "version": "1.9.2",
+    "version": "1.9.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "wanderers-guide",
-            "version": "1.9.2",
+            "version": "1.9.3",
             "license": "GNU",
             "dependencies": {
                 "@creativebulma/bulma-collapsible": "^1.0.4",

--- a/views/builder/build_planner_abc.handlebars
+++ b/views/builder/build_planner_abc.handlebars
@@ -1,142 +1,268 @@
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/build-planner.css" />
+{{/section}}
 
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/build-planner.css">
+{{#section "header"}}
+  <script defer src="/js/build_planner/main.js"></script>
+  <script defer src="/js/build_planner/ui-handler.js"></script>
 
-    <script defer src="/js/build_planner/main.js"></script>
-    <script defer src="/js/build_planner/ui-handler.js"></script>
+  <script defer src="/js/build_planner/processor/core-processor.js"></script>
 
-    <script defer src="/js/build_planner/processor/core-processor.js"></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder-statements.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/sheet-statements.js"
+  ></script>
 
-    <script defer src="/js/build_planner/processor/sub_processors/builder-statements.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/sheet-statements.js"></script>
+  <script defer src="/js/build_planner/scripts/init-variables.js"></script>
+  <script
+    defer
+    src="/js/build_planner/scripts/process-ancestry-stats.js"
+  ></script>
+  <script defer src="/js/build_planner/scripts/process-class-stats.js"></script>
+  <script defer src="/js/build_planner/scripts/unselected-options.js"></script>
+  <script
+    defer
+    src="/js/build_planner/scripts/extra-skills-and-langs.js"
+  ></script>
 
-    <script defer src="/js/build_planner/scripts/init-variables.js"></script>
-    <script defer src="/js/build_planner/scripts/process-ancestry-stats.js"></script>
-    <script defer src="/js/build_planner/scripts/process-class-stats.js"></script>
-    <script defer src="/js/build_planner/scripts/unselected-options.js"></script>
-    <script defer src="/js/build_planner/scripts/extra-skills-and-langs.js"></script>
+  <script defer src="/js/build_planner/libraries/selector.js"></script>
 
-    <script defer src="/js/build_planner/libraries/selector.js"></script>
+  <script defer src="/js/build_planner/data_mapping/data-map.js"></script>
+  <script defer src="/js/build_planner/data_mapping/data-map-ext.js"></script>
+  <script defer src="/js/build_planner/data_mapping/retrieval.js"></script>
 
-    <script defer src="/js/build_planner/data_mapping/data-map.js"></script>
-    <script defer src="/js/build_planner/data_mapping/data-map-ext.js"></script>
-    <script defer src="/js/build_planner/data_mapping/retrieval.js"></script>
+  <script defer src="/js/build_planner/modules/process-ancestry.js"></script>
+  <script defer src="/js/build_planner/modules/process-background.js"></script>
+  <script defer src="/js/build_planner/modules/process-class.js"></script>
 
-    <script defer src="/js/build_planner/modules/process-ancestry.js"></script>
-    <script defer src="/js/build_planner/modules/process-background.js"></script>
-    <script defer src="/js/build_planner/modules/process-class.js"></script>
-    
-    <script defer src="/js/build_planner/modules/process-custom-code.js"></script>
+  <script defer src="/js/build_planner/modules/process-custom-code.js"></script>
 
-    <script defer src="/js/build_planner/scripts/variants/auto-bonus-progression.js"></script>
-    <script defer src="/js/build_planner/scripts/variants/class-archetypes.js"></script>
-    <script defer src="/js/build_planner/scripts/variants/free-archetype.js"></script>
-    <script defer src="/js/build_planner/scripts/variants/gradual-ability-boosts.js"></script>
+  <script
+    defer
+    src="/js/build_planner/scripts/variants/auto-bonus-progression.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/scripts/variants/class-archetypes.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/scripts/variants/free-archetype.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/scripts/variants/gradual-ability-boosts.js"
+  ></script>
 
-    <!-- Dependencies -->
-    <script defer src="/js/wsc/text-processing.js"></script>
-    <script defer src="/js/wsc/add-text-processing.js"></script>
-    <script defer src="/js/wsc/misc-feat-processing.js"></script>
-    <script defer src="/js/wsc/removal-processing.js"></script>
-    <script defer src="/js/wsc/variable-processing.js"></script>
-    <script defer src="/js/sheet/general/stat-manager.js"></script>
-    <script defer src="/js/sheet/general/sheet-states.js"></script>
+  <!-- Dependencies -->
+  <script defer src="/js/wsc/text-processing.js"></script>
+  <script defer src="/js/wsc/add-text-processing.js"></script>
+  <script defer src="/js/wsc/misc-feat-processing.js"></script>
+  <script defer src="/js/wsc/removal-processing.js"></script>
+  <script defer src="/js/wsc/variable-processing.js"></script>
+  <script defer src="/js/sheet/general/stat-manager.js"></script>
+  <script defer src="/js/sheet/general/sheet-states.js"></script>
 
-    <script defer src="/js/wsc/errorHandling.js"></script>
+  <script defer src="/js/wsc/errorHandling.js"></script>
 
+  <script defer src="/js/libraries/modal_selection/modal-selection.js"></script>
 
-    <script defer src="/js/libraries/modal_selection/modal-selection.js"></script>
+  <script defer src="/js/libraries/display_class/display-class.js"></script>
+  <script
+    defer
+    src="/js/libraries/display_ancestry/display-ancestry.js"
+  ></script>
+  <script
+    defer
+    src="/js/libraries/display_archetype/display-archetype.js"
+  ></script>
+  <script
+    defer
+    src="/js/libraries/display_background/display-background.js"
+  ></script>
+  <script
+    defer
+    src="/js/libraries/display_uni_heritage/display-uni-heritage.js"
+  ></script>
+  <script defer src="/js/libraries/confirm_message/confirm-message.js"></script>
 
-    <script defer src="/js/libraries/display_class/display-class.js"></script>
-    <script defer src="/js/libraries/display_ancestry/display-ancestry.js"></script>
-    <script defer src="/js/libraries/display_archetype/display-archetype.js"></script>
-    <script defer src="/js/libraries/display_background/display-background.js"></script>
-    <script defer src="/js/libraries/display_uni_heritage/display-uni-heritage.js"></script>
-    <script defer src="/js/libraries/confirm_message/confirm-message.js"></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-boosts.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-feats.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-class-feature.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-heritage.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-langs.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-lore.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-skills.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-profs.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-spells.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-spells-innate.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-spells-focus.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-resistances.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-domains.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-specializations.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-notes.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-charTags.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-phyFeats.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-senses.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-speeds.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-familiarity.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-keyAbility.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-scfs.js"
+  ></script>
 
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/display-structs.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/feats-selection.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/prereq-parser.js"
+  ></script>
 
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-boosts.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-feats.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-class-feature.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-heritage.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-langs.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-lore.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-skills.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-profs.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-spells.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-spells-innate.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-spells-focus.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-resistances.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-domains.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-specializations.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-notes.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-charTags.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-phyFeats.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-senses.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-speeds.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-familiarity.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-keyAbility.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-scfs.js"></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/expression-processor.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/expression-utils.js"
+  ></script>
 
-    <script defer src="/js/build_planner/processor/sub_processors/builder/display-structs.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/feats-selection.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/prereq-parser.js"></script>
+  <!-- Quickview -->
+  <script defer src="/js/char_builders/wsc/quickview-left.js"></script>
+  <script defer src="/js/sheet/quickviews/_quickviews.js"></script>
+  <script defer src="/js/sheet/quickviews/feat-view.js"></script>
+  <script defer src="/js/sheet/quickviews/language-view.js"></script>
+  <script defer src="/js/sheet/quickviews/spell-view.js"></script>
+  <script defer src="/js/sheet/quickviews/item-view.js"></script>
+  <script defer src="/js/sheet/quickviews/tag-view.js"></script>
+  <script defer src="/js/sheet/quickviews/ability-view.js"></script>
+  <script defer src="/js/sheet/quickviews/condition-view.js"></script>
+  <script defer src="/js/sheet/quickviews/general-breakdown-view.js"></script>
+  <script
+    defer
+    src="/js/sheet/quickviews/hit-points-breakdown-view.js"
+  ></script>
+  <script
+    defer
+    src="/js/sheet/quickviews/ability-scores-breakdown-view.js"
+  ></script>
+  <script defer src="/js/sheet/quickviews/resist-view.js"></script>
 
-    <script defer src="/js/build_planner/processor/sub_processors/expression-processor.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/expression-utils.js"></script>
-
-    <!-- Quickview -->
-    <script defer src="/js/char_builders/wsc/quickview-left.js"></script>
-    <script defer src="/js/sheet/quickviews/_quickviews.js"></script>
-    <script defer src="/js/sheet/quickviews/feat-view.js"></script>
-    <script defer src="/js/sheet/quickviews/language-view.js"></script>
-    <script defer src="/js/sheet/quickviews/spell-view.js"></script>
-    <script defer src="/js/sheet/quickviews/item-view.js"></script>
-    <script defer src="/js/sheet/quickviews/tag-view.js"></script>
-    <script defer src="/js/sheet/quickviews/ability-view.js"></script>
-    <script defer src="/js/sheet/quickviews/condition-view.js"></script>
-    <script defer src="/js/sheet/quickviews/general-breakdown-view.js"></script>
-    <script defer src="/js/sheet/quickviews/hit-points-breakdown-view.js"></script>
-    <script defer src="/js/sheet/quickviews/ability-scores-breakdown-view.js"></script>
-    <script defer src="/js/sheet/quickviews/resist-view.js"></script>
-
-    <script defer src="/js/sheet/general/prof-history-display.js"></script>
-    <script defer src="/js/sheet/utils/item-utils.js"></script>
+  <script defer src="/js/sheet/general/prof-history-display.js"></script>
+  <script defer src="/js/sheet/utils/item-utils.js"></script>
 
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters" class="active">Characters</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+      class="active"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
-
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="">
@@ -156,18 +282,27 @@
   </div>
 </div>
 
-<div class="planner-subpageloader subpageloader-like is-hidden"><div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div></div>
+<div class="planner-subpageloader subpageloader-like is-hidden"><div
+    class="lds-roller"
+  ><div></div><div></div><div></div><div></div><div></div><div></div><div
+    ></div><div></div></div></div>
 
 <div class="container mt-3 pt-3">
 
   <div id="errorDisplay" class="hero is-danger is-hidden text-center">
-      <div class="hero-body is-paddingless py-3">
-          <div id="errorMessage" class="container"></div>
-      </div>
+    <div class="hero-body is-paddingless py-3">
+      <div id="errorMessage" class="container"></div>
+    </div>
   </div>
 
-  <div id="builder-data" data-char-id="{{character.id}}" data-char-lvl="{{character.level}}" data-builder-type="by-abc" data-page-num="{{pageNum}}"></div>
-  
+  <div
+    id="builder-data"
+    data-char-id="{{character.id}}"
+    data-char-lvl="{{character.level}}"
+    data-builder-type="by-abc"
+    data-page-num="{{pageNum}}"
+  ></div>
+
   <div class="tile is-ancestor is-vertical">
     <div class="tile">
 
@@ -177,44 +312,72 @@
 
           <div class="steps">
             <div id="builder-home-step" class="step-item is-completed is-info">
-                <div class="step-marker">
-                <a class="builder-basics-page-btn"><span id="builder-home-step-symbol" class="has-text-bck-color icon"><i class="fas fa-home-alt"></i></span></a>
-                </div>
-                <div class="step-details is-hidden-touch">
-                    <a class="builder-basics-page-btn button is-rounded is-inverted is-tiny is-info"><p class="step-builder-title title-font">Home</p></a>
-                </div>
+              <div class="step-marker">
+                <a class="builder-basics-page-btn"><span
+                    id="builder-home-step-symbol"
+                    class="has-text-bck-color icon"
+                  ><i class="fas fa-home-alt"></i></span></a>
+              </div>
+              <div class="step-details is-hidden-touch">
+                <a
+                  class="builder-basics-page-btn button is-rounded is-inverted is-tiny is-info"
+                ><p class="step-builder-title title-font">Home</p></a>
+              </div>
             </div>
             <div id="builder-ancestry-step" class="step-item">
-                <div class="step-marker"><a class="builder-ancestry-page-btn"><span id="builder-ancestry-step-symbol" class="has-text-bck-color">A</span></a></div>
-                <div class="step-details is-hidden-touch">
-                    <a class="builder-ancestry-page-btn button is-rounded is-inverted is-tiny is-info"><p class="step-builder-title title-font">Ancestry</p></a>
-                </div>
+              <div class="step-marker"><a
+                  class="builder-ancestry-page-btn"
+                ><span
+                    id="builder-ancestry-step-symbol"
+                    class="has-text-bck-color"
+                  >A</span></a></div>
+              <div class="step-details is-hidden-touch">
+                <a
+                  class="builder-ancestry-page-btn button is-rounded is-inverted is-tiny is-info"
+                ><p class="step-builder-title title-font">Ancestry</p></a>
+              </div>
             </div>
             <div id="builder-background-step" class="step-item">
-                <div class="step-marker"><a class="builder-background-page-btn"><span id="builder-background-step-symbol" class="has-text-bck-color">B</span></a></div>
-                <div class="step-details is-hidden-touch">
-                    <a class="builder-background-page-btn button is-rounded is-inverted is-tiny is-info"><p class="step-builder-title title-font">Background</p></a>
-                </div>
+              <div class="step-marker"><a
+                  class="builder-background-page-btn"
+                ><span
+                    id="builder-background-step-symbol"
+                    class="has-text-bck-color"
+                  >B</span></a></div>
+              <div class="step-details is-hidden-touch">
+                <a
+                  class="builder-background-page-btn button is-rounded is-inverted is-tiny is-info"
+                ><p class="step-builder-title title-font">Background</p></a>
+              </div>
             </div>
             <div id="builder-class-step" class="step-item">
-                <div class="step-marker"><a class="builder-class-page-btn"><span id="builder-class-step-symbol" class="has-text-bck-color">C</span></a></div>
-                <div class="step-details is-hidden-touch">
-                    <a class="builder-class-page-btn button is-rounded is-inverted is-tiny is-info"><p class="step-builder-title title-font">Class</p></a>
-                </div>
+              <div class="step-marker"><a class="builder-class-page-btn"><span
+                    id="builder-class-step-symbol"
+                    class="has-text-bck-color"
+                  >C</span></a></div>
+              <div class="step-details is-hidden-touch">
+                <a
+                  class="builder-class-page-btn button is-rounded is-inverted is-tiny is-info"
+                ><p class="step-builder-title title-font">Class</p></a>
+              </div>
             </div>
             <div id="builder-finalize-step" class="step-item">
-                <div class="step-marker">
-                <a class="builder-finalize-page-btn"><span class="has-text-bck-color icon"><i class="fa fa-user-alt"></i></span></a>
-                </div>
-                <div class="step-details is-hidden-touch">
-                    <a class="builder-finalize-page-btn button is-rounded is-inverted is-tiny is-info"><p class="step-builder-title title-font">Sheet</p></a>
-                </div>
+              <div class="step-marker">
+                <a class="builder-finalize-page-btn"><span
+                    class="has-text-bck-color icon"
+                  ><i class="fa fa-user-alt"></i></span></a>
+              </div>
+              <div class="step-details is-hidden-touch">
+                <a
+                  class="builder-finalize-page-btn button is-rounded is-inverted is-tiny is-info"
+                ><p class="step-builder-title title-font">Sheet</p></a>
+              </div>
             </div>
           </div>
         </div>
 
       </div>
-    
+
     </div>
 
     <div class="tile">
@@ -222,61 +385,133 @@
       <div class="tile is-parent is-vertical">
 
         <div class="tile is-child box p-2 is-marginless">
-          
+
           <div class="columns is-mobile is-marginless m-1">
             <div class="column is-paddingless">
-              <p class="has-txt-value-string title-font has-text-centered" id="selected-abc-title">ABC</p>
+              <p
+                class="has-txt-value-string title-font has-text-centered"
+                id="selected-abc-title"
+              >ABC</p>
             </div>
             <div class="column is-7 is-paddingless has-text-centered">
-              <span class="button is-info is-outlined is-small is-fullwidth" id="selected-abc">None</span>
+              <span
+                class="button is-info is-outlined is-small is-fullwidth"
+                id="selected-abc"
+              >None</span>
             </div>
           </div>
 
         </div>
-        
+
         <div class="tile is-child box py-2 pl-2 pr-1">
-          <p class="has-txt-value-string title-font has-text-centered">Statistics</p>
-          <div id="builder-statistics-container" class="use-custom-scrollbar" style="height: 500px; max-height: 500px; overflow-y: scroll;">
-          
+          <p
+            class="has-txt-value-string title-font has-text-centered"
+          >Statistics</p>
+          <div
+            id="builder-statistics-container"
+            class="use-custom-scrollbar"
+            style="height: 500px; max-height: 500px; overflow-y: scroll;"
+          >
+
             <!-- Ability Scores -->
             <div id="ability-scores-body" class="accord-like-button mx-2 mb-2">
-              <div class="columns is-mobile is-centered is-marginless text-center mx-3">
-                <div class="column is-2 is-paddingless"><p class="is-bold-very">Str</p></div>
-                <div class="column is-2 is-paddingless"><p class="is-bold-very">Dex</p></div>
-                <div class="column is-2 is-paddingless"><p class="is-bold-very">Con</p></div>
-                <div class="column is-2 is-paddingless"><p class="is-bold-very">Int</p></div>
-                <div class="column is-2 is-paddingless"><p class="is-bold-very">Wis</p></div>
-                <div class="column is-2 is-paddingless"><p class="is-bold-very">Cha</p></div>
+              <div
+                class="columns is-mobile is-centered is-marginless text-center mx-3"
+              >
+                <div class="column is-2 is-paddingless"><p
+                    class="is-bold-very"
+                  >Str</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    class="is-bold-very"
+                  >Dex</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    class="is-bold-very"
+                  >Con</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    class="is-bold-very"
+                  >Int</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    class="is-bold-very"
+                  >Wis</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    class="is-bold-very"
+                  >Cha</p></div>
               </div>
-              <div class="columns is-mobile is-centered is-marginless text-center mx-3">
-                <div class="column is-2 is-paddingless"><p id="str-score">10</p></div>
-                <div class="column is-2 is-paddingless"><p id="dex-score">10</p></div>
-                <div class="column is-2 is-paddingless"><p id="con-score">10</p></div>
-                <div class="column is-2 is-paddingless"><p id="int-score">10</p></div>
-                <div class="column is-2 is-paddingless"><p id="wis-score">10</p></div>
-                <div class="column is-2 is-paddingless"><p id="cha-score">10</p></div>
+              <div
+                class="columns is-mobile is-centered is-marginless text-center mx-3"
+              >
+                <div class="column is-2 is-paddingless"><p
+                    id="str-score"
+                  >10</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    id="dex-score"
+                  >10</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    id="con-score"
+                  >10</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    id="int-score"
+                  >10</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    id="wis-score"
+                  >10</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    id="cha-score"
+                  >10</p></div>
               </div>
             </div>
 
             <!-- Hit Points -->
-            <div id="hit-points-body" class="accord-like-button columns is-mobile is-marginless my-1">
-              <div class="column is-8 is-paddingless"><span class="title-font pl-2">Hit Points</span></div>
-              <div class="column is-2 is-paddingless"><p id="hit-points-total" class="has-text-centered">130</p></div>
-              <div class="column is-2 is-paddingless"><p class="has-text-centered is-italic has-txt-noted is-size-7-5 pt-2">(at max)</p></div>
+            <div
+              id="hit-points-body"
+              class="accord-like-button columns is-mobile is-marginless my-1"
+            >
+              <div class="column is-8 is-paddingless"><span
+                  class="title-font pl-2"
+                >Hit Points</span></div>
+              <div class="column is-2 is-paddingless"><p
+                  id="hit-points-total"
+                  class="has-text-centered"
+                >130</p></div>
+              <div class="column is-2 is-paddingless"><p
+                  class="has-text-centered is-italic has-txt-noted is-size-7-5 pt-2"
+                >(at max)</p></div>
             </div>
 
             <!-- Class DC -->
-            <div id="class-dc-body" class="accord-like-button columns is-mobile is-marginless my-1">
-              <div class="column is-8 is-paddingless"><span class="title-font pl-2">Class DC</span></div>
-              <div class="column is-2 is-paddingless"><p id="class-dc-total" class="has-text-centered">18</p></div>
-              <div class="column is-2 is-paddingless"><p id="class-dc-rank" class="has-text-centered is-italic has-txt-noted">E</p></div>
+            <div
+              id="class-dc-body"
+              class="accord-like-button columns is-mobile is-marginless my-1"
+            >
+              <div class="column is-8 is-paddingless"><span
+                  class="title-font pl-2"
+                >Class DC</span></div>
+              <div class="column is-2 is-paddingless"><p
+                  id="class-dc-total"
+                  class="has-text-centered"
+                >18</p></div>
+              <div class="column is-2 is-paddingless"><p
+                  id="class-dc-rank"
+                  class="has-text-centered is-italic has-txt-noted"
+                >E</p></div>
             </div>
 
             <!-- Perception -->
-            <div id="perception-body" class="accord-like-button columns is-mobile is-marginless my-1">
-              <div class="column is-8 is-paddingless"><span class="title-font pl-2">Perception</span></div>
-              <div class="column is-2 is-paddingless"><p id="perception-total" class="has-text-centered">+28</p></div>
-              <div class="column is-2 is-paddingless"><p id="perception-rank" class="has-text-centered is-italic has-txt-noted">T</p></div>
+            <div
+              id="perception-body"
+              class="accord-like-button columns is-mobile is-marginless my-1"
+            >
+              <div class="column is-8 is-paddingless"><span
+                  class="title-font pl-2"
+                >Perception</span></div>
+              <div class="column is-2 is-paddingless"><p
+                  id="perception-total"
+                  class="has-text-centered"
+                >+28</p></div>
+              <div class="column is-2 is-paddingless"><p
+                  id="perception-rank"
+                  class="has-text-centered is-italic has-txt-noted"
+                >T</p></div>
             </div>
 
             <!-- Skills -->
@@ -343,7 +578,7 @@
                 <!-- Populated at runtime -->
               </div>
             </div>
-            
+
             <!-- Languages -->
             <div class="accord-container my-1">
               <div class="accord-header">
@@ -356,7 +591,7 @@
                 <!-- Populated at runtime -->
               </div>
             </div>
-            
+
             <!-- Resist & Weaks -->
             <div class="accord-container my-1">
               <div class="accord-header">
@@ -378,8 +613,12 @@
       <div class="tile is-parent is-8">
 
         <div class="tile is-child box py-2 pl-2 pr-1">
-          
-          <div id="creation-section" class="use-custom-scrollbar" style="height: 600px; max-height: 600px; overflow-y: scroll; overflow-x: hidden;">
+
+          <div
+            id="creation-section"
+            class="use-custom-scrollbar"
+            style="height: 600px; max-height: 600px; overflow-y: scroll; overflow-x: hidden;"
+          >
           </div>
 
         </div>
@@ -387,39 +626,41 @@
       </div>
 
     </div>
-    
+
   </div>
 
 </div>
 
-
-{{#section 'overlay'}}
-    <!-- Right Quickview -->
-    <div id="quickviewDefault" class="quickview">
-        <div class="quickview-header">
-            <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
-            <div class="is-inline-flex">
-                <p id="quickViewTitleRight"></p>
-                <p id="quickViewTitleClose"></p>
-            </div>
-        </div>
-        <div class="quickview-body use-custom-scrollbar">
-            <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
-            </div>
-        </div>
+{{#section "overlay"}}
+  <!-- Right Quickview -->
+  <div id="quickviewDefault" class="quickview">
+    <div class="quickview-header">
+      <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
+      <div class="is-inline-flex">
+        <p id="quickViewTitleRight"></p>
+        <p id="quickViewTitleClose"></p>
+      </div>
     </div>
-
-    <!-- Left Quickview -->
-    <div id="quickviewLeftDefault" class="quickview is-left" style="z-index: 34;">
-        <div class="quickview-header">
-            <p id="quickViewLeftTitle" class="title is-size-5 has-txt-value-number">Statistics</p>
-            <div class="is-inline-flex">
-                <p><a id="quickViewLeftTitleClose" class="delete"></a></p>
-            </div>
-        </div>
-        <div class="quickview-body use-custom-scrollbar">
-            <div id="quickViewLeftContent" class="quickview-block pt-1 pb-3 px-3">
-            </div>
-        </div>
+    <div class="quickview-body use-custom-scrollbar">
+      <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
+      </div>
     </div>
+  </div>
+
+  <!-- Left Quickview -->
+  <div id="quickviewLeftDefault" class="quickview is-left" style="z-index: 34;">
+    <div class="quickview-header">
+      <p
+        id="quickViewLeftTitle"
+        class="title is-size-5 has-txt-value-number"
+      >Statistics</p>
+      <div class="is-inline-flex">
+        <p><a id="quickViewLeftTitleClose" class="delete"></a></p>
+      </div>
+    </div>
+    <div class="quickview-body use-custom-scrollbar">
+      <div id="quickViewLeftContent" class="quickview-block pt-1 pb-3 px-3">
+      </div>
+    </div>
+  </div>
 {{/section}}

--- a/views/builder/build_planner_level.handlebars
+++ b/views/builder/build_planner_level.handlebars
@@ -1,142 +1,268 @@
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/build-planner.css" />
+{{/section}}
 
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/build-planner.css">
+{{#section "header"}}
+  <script defer src="/js/build_planner/main.js"></script>
+  <script defer src="/js/build_planner/ui-handler.js"></script>
 
-    <script defer src="/js/build_planner/main.js"></script>
-    <script defer src="/js/build_planner/ui-handler.js"></script>
+  <script defer src="/js/build_planner/processor/core-processor.js"></script>
 
-    <script defer src="/js/build_planner/processor/core-processor.js"></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder-statements.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/sheet-statements.js"
+  ></script>
 
-    <script defer src="/js/build_planner/processor/sub_processors/builder-statements.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/sheet-statements.js"></script>
+  <script defer src="/js/build_planner/scripts/init-variables.js"></script>
+  <script
+    defer
+    src="/js/build_planner/scripts/process-ancestry-stats.js"
+  ></script>
+  <script defer src="/js/build_planner/scripts/process-class-stats.js"></script>
+  <script defer src="/js/build_planner/scripts/unselected-options.js"></script>
+  <script
+    defer
+    src="/js/build_planner/scripts/extra-skills-and-langs.js"
+  ></script>
 
-    <script defer src="/js/build_planner/scripts/init-variables.js"></script>
-    <script defer src="/js/build_planner/scripts/process-ancestry-stats.js"></script>
-    <script defer src="/js/build_planner/scripts/process-class-stats.js"></script>
-    <script defer src="/js/build_planner/scripts/unselected-options.js"></script>
-    <script defer src="/js/build_planner/scripts/extra-skills-and-langs.js"></script>
+  <script defer src="/js/build_planner/libraries/selector.js"></script>
 
-    <script defer src="/js/build_planner/libraries/selector.js"></script>
+  <script defer src="/js/build_planner/data_mapping/data-map.js"></script>
+  <script defer src="/js/build_planner/data_mapping/data-map-ext.js"></script>
+  <script defer src="/js/build_planner/data_mapping/retrieval.js"></script>
 
-    <script defer src="/js/build_planner/data_mapping/data-map.js"></script>
-    <script defer src="/js/build_planner/data_mapping/data-map-ext.js"></script>
-    <script defer src="/js/build_planner/data_mapping/retrieval.js"></script>
+  <script defer src="/js/build_planner/modules/process-ancestry.js"></script>
+  <script defer src="/js/build_planner/modules/process-background.js"></script>
+  <script defer src="/js/build_planner/modules/process-class.js"></script>
 
-    <script defer src="/js/build_planner/modules/process-ancestry.js"></script>
-    <script defer src="/js/build_planner/modules/process-background.js"></script>
-    <script defer src="/js/build_planner/modules/process-class.js"></script>
+  <script defer src="/js/build_planner/modules/process-custom-code.js"></script>
 
-    <script defer src="/js/build_planner/modules/process-custom-code.js"></script>
+  <script
+    defer
+    src="/js/build_planner/scripts/variants/auto-bonus-progression.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/scripts/variants/class-archetypes.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/scripts/variants/free-archetype.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/scripts/variants/gradual-ability-boosts.js"
+  ></script>
 
-    <script defer src="/js/build_planner/scripts/variants/auto-bonus-progression.js"></script>
-    <script defer src="/js/build_planner/scripts/variants/class-archetypes.js"></script>
-    <script defer src="/js/build_planner/scripts/variants/free-archetype.js"></script>
-    <script defer src="/js/build_planner/scripts/variants/gradual-ability-boosts.js"></script>
+  <!-- Dependencies -->
+  <script defer src="/js/wsc/text-processing.js"></script>
+  <script defer src="/js/wsc/add-text-processing.js"></script>
+  <script defer src="/js/wsc/misc-feat-processing.js"></script>
+  <script defer src="/js/wsc/removal-processing.js"></script>
+  <script defer src="/js/wsc/variable-processing.js"></script>
+  <script defer src="/js/sheet/general/stat-manager.js"></script>
+  <script defer src="/js/sheet/general/sheet-states.js"></script>
 
-    <!-- Dependencies -->
-    <script defer src="/js/wsc/text-processing.js"></script>
-    <script defer src="/js/wsc/add-text-processing.js"></script>
-    <script defer src="/js/wsc/misc-feat-processing.js"></script>
-    <script defer src="/js/wsc/removal-processing.js"></script>
-    <script defer src="/js/wsc/variable-processing.js"></script>
-    <script defer src="/js/sheet/general/stat-manager.js"></script>
-    <script defer src="/js/sheet/general/sheet-states.js"></script>
+  <script defer src="/js/wsc/errorHandling.js"></script>
 
-    <script defer src="/js/wsc/errorHandling.js"></script>
+  <script defer src="/js/libraries/modal_selection/modal-selection.js"></script>
 
+  <script defer src="/js/libraries/display_class/display-class.js"></script>
+  <script
+    defer
+    src="/js/libraries/display_ancestry/display-ancestry.js"
+  ></script>
+  <script
+    defer
+    src="/js/libraries/display_archetype/display-archetype.js"
+  ></script>
+  <script
+    defer
+    src="/js/libraries/display_background/display-background.js"
+  ></script>
+  <script
+    defer
+    src="/js/libraries/display_uni_heritage/display-uni-heritage.js"
+  ></script>
+  <script defer src="/js/libraries/confirm_message/confirm-message.js"></script>
 
-    <script defer src="/js/libraries/modal_selection/modal-selection.js"></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-boosts.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-feats.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-class-feature.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-heritage.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-langs.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-lore.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-skills.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-profs.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-spells.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-spells-innate.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-spells-focus.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-resistances.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-domains.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-specializations.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-notes.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-charTags.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-phyFeats.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-senses.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-speeds.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-familiarity.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-keyAbility.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/wsc-scfs.js"
+  ></script>
 
-    <script defer src="/js/libraries/display_class/display-class.js"></script>
-    <script defer src="/js/libraries/display_ancestry/display-ancestry.js"></script>
-    <script defer src="/js/libraries/display_archetype/display-archetype.js"></script>
-    <script defer src="/js/libraries/display_background/display-background.js"></script>
-    <script defer src="/js/libraries/display_uni_heritage/display-uni-heritage.js"></script>
-    <script defer src="/js/libraries/confirm_message/confirm-message.js"></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/display-structs.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/feats-selection.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/builder/prereq-parser.js"
+  ></script>
 
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/expression-processor.js"
+  ></script>
+  <script
+    defer
+    src="/js/build_planner/processor/sub_processors/expression-utils.js"
+  ></script>
 
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-boosts.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-feats.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-class-feature.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-heritage.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-langs.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-lore.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-skills.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-profs.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-spells.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-spells-innate.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-spells-focus.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-resistances.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-domains.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-specializations.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-notes.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-charTags.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-phyFeats.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-senses.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-speeds.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-familiarity.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-keyAbility.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/wsc-scfs.js"></script>
+  <!-- Quickview -->
+  <script defer src="/js/char_builders/wsc/quickview-left.js"></script>
+  <script defer src="/js/sheet/quickviews/_quickviews.js"></script>
+  <script defer src="/js/sheet/quickviews/feat-view.js"></script>
+  <script defer src="/js/sheet/quickviews/language-view.js"></script>
+  <script defer src="/js/sheet/quickviews/spell-view.js"></script>
+  <script defer src="/js/sheet/quickviews/item-view.js"></script>
+  <script defer src="/js/sheet/quickviews/tag-view.js"></script>
+  <script defer src="/js/sheet/quickviews/ability-view.js"></script>
+  <script defer src="/js/sheet/quickviews/condition-view.js"></script>
+  <script defer src="/js/sheet/quickviews/general-breakdown-view.js"></script>
+  <script
+    defer
+    src="/js/sheet/quickviews/hit-points-breakdown-view.js"
+  ></script>
+  <script
+    defer
+    src="/js/sheet/quickviews/ability-scores-breakdown-view.js"
+  ></script>
+  <script defer src="/js/sheet/quickviews/resist-view.js"></script>
 
-    <script defer src="/js/build_planner/processor/sub_processors/builder/display-structs.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/feats-selection.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/builder/prereq-parser.js"></script>
-
-    <script defer src="/js/build_planner/processor/sub_processors/expression-processor.js"></script>
-    <script defer src="/js/build_planner/processor/sub_processors/expression-utils.js"></script>
-
-    <!-- Quickview -->
-    <script defer src="/js/char_builders/wsc/quickview-left.js"></script>
-    <script defer src="/js/sheet/quickviews/_quickviews.js"></script>
-    <script defer src="/js/sheet/quickviews/feat-view.js"></script>
-    <script defer src="/js/sheet/quickviews/language-view.js"></script>
-    <script defer src="/js/sheet/quickviews/spell-view.js"></script>
-    <script defer src="/js/sheet/quickviews/item-view.js"></script>
-    <script defer src="/js/sheet/quickviews/tag-view.js"></script>
-    <script defer src="/js/sheet/quickviews/ability-view.js"></script>
-    <script defer src="/js/sheet/quickviews/condition-view.js"></script>
-    <script defer src="/js/sheet/quickviews/general-breakdown-view.js"></script>
-    <script defer src="/js/sheet/quickviews/hit-points-breakdown-view.js"></script>
-    <script defer src="/js/sheet/quickviews/ability-scores-breakdown-view.js"></script>
-    <script defer src="/js/sheet/quickviews/resist-view.js"></script>
-
-    <script defer src="/js/sheet/general/prof-history-display.js"></script>
-    <script defer src="/js/sheet/utils/item-utils.js"></script>
+  <script defer src="/js/sheet/general/prof-history-display.js"></script>
+  <script defer src="/js/sheet/utils/item-utils.js"></script>
 
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters" class="active">Characters</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+      class="active"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
-
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="">
@@ -156,92 +282,182 @@
   </div>
 </div>
 
-<div class="planner-subpageloader subpageloader-like is-hidden"><div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div></div>
+<div class="planner-subpageloader subpageloader-like is-hidden"><div
+    class="lds-roller"
+  ><div></div><div></div><div></div><div></div><div></div><div></div><div
+    ></div><div></div></div></div>
 
 <div class="container mt-3 pt-3">
 
   <div id="errorDisplay" class="hero is-danger is-hidden text-center">
-      <div class="hero-body is-paddingless py-3">
-          <div id="errorMessage" class="container"></div>
-      </div>
+    <div class="hero-body is-paddingless py-3">
+      <div id="errorMessage" class="container"></div>
+    </div>
   </div>
 
-  <div id="builder-data" data-char-id="{{character.id}}" data-char-lvl="{{character.level}}" data-builder-type="by-level" data-page-num="{{pageNum}}"></div>
-  
+  <div
+    id="builder-data"
+    data-char-id="{{character.id}}"
+    data-char-lvl="{{character.level}}"
+    data-builder-type="by-level"
+    data-page-num="{{pageNum}}"
+  ></div>
+
   <div class="tile is-ancestor">
     <div class="tile is-4">
       <div class="tile is-parent is-vertical">
         <div class="tile is-child box p-2 is-marginless">
-          
+
           <div class="columns is-mobile is-marginless m-1">
             <div class="column is-paddingless">
-              <p class="has-txt-value-string title-font has-text-centered">Ancestry</p>
+              <p
+                class="has-txt-value-string title-font has-text-centered"
+              >Ancestry</p>
             </div>
             <div class="column is-7 is-paddingless has-text-centered">
-              <span class="button is-info is-outlined is-small is-fullwidth" id="selected-ancestry">None</span>
+              <span
+                class="button is-info is-outlined is-small is-fullwidth"
+                id="selected-ancestry"
+              >None</span>
             </div>
           </div>
           <div class="columns is-mobile is-marginless m-1">
             <div class="column is-paddingless">
-              <p class="has-txt-value-string title-font has-text-centered">Background</p>
+              <p
+                class="has-txt-value-string title-font has-text-centered"
+              >Background</p>
             </div>
             <div class="column is-7 is-paddingless has-text-centered">
-              <span class="button is-info is-outlined is-small is-fullwidth" id="selected-background">None</span>
+              <span
+                class="button is-info is-outlined is-small is-fullwidth"
+                id="selected-background"
+              >None</span>
             </div>
           </div>
           <div class="columns is-mobile is-marginless m-1">
             <div class="column is-paddingless">
-              <p class="has-txt-value-string title-font has-text-centered">Class</p>
+              <p
+                class="has-txt-value-string title-font has-text-centered"
+              >Class</p>
             </div>
             <div class="column is-7 is-paddingless has-text-centered">
-              <span class="button is-info is-outlined is-small is-fullwidth" id="selected-class">None</span>
+              <span
+                class="button is-info is-outlined is-small is-fullwidth"
+                id="selected-class"
+              >None</span>
             </div>
           </div>
 
         </div>
         <div class="tile is-child box py-2 pl-2 pr-1">
-          <p class="has-txt-value-string title-font has-text-centered">Statistics</p>
-          <div id="builder-statistics-container" class="use-custom-scrollbar" style="height: 500px; max-height: 500px; overflow-y: scroll;">
-          
+          <p
+            class="has-txt-value-string title-font has-text-centered"
+          >Statistics</p>
+          <div
+            id="builder-statistics-container"
+            class="use-custom-scrollbar"
+            style="height: 500px; max-height: 500px; overflow-y: scroll;"
+          >
+
             <!-- Ability Scores -->
             <div id="ability-scores-body" class="accord-like-button mx-2 mb-2">
-              <div class="columns is-mobile is-centered is-marginless text-center mx-3">
-                <div class="column is-2 is-paddingless"><p class="is-bold-very">Str</p></div>
-                <div class="column is-2 is-paddingless"><p class="is-bold-very">Dex</p></div>
-                <div class="column is-2 is-paddingless"><p class="is-bold-very">Con</p></div>
-                <div class="column is-2 is-paddingless"><p class="is-bold-very">Int</p></div>
-                <div class="column is-2 is-paddingless"><p class="is-bold-very">Wis</p></div>
-                <div class="column is-2 is-paddingless"><p class="is-bold-very">Cha</p></div>
+              <div
+                class="columns is-mobile is-centered is-marginless text-center mx-3"
+              >
+                <div class="column is-2 is-paddingless"><p
+                    class="is-bold-very"
+                  >Str</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    class="is-bold-very"
+                  >Dex</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    class="is-bold-very"
+                  >Con</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    class="is-bold-very"
+                  >Int</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    class="is-bold-very"
+                  >Wis</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    class="is-bold-very"
+                  >Cha</p></div>
               </div>
-              <div class="columns is-mobile is-centered is-marginless text-center mx-3">
-                <div class="column is-2 is-paddingless"><p id="str-score">10</p></div>
-                <div class="column is-2 is-paddingless"><p id="dex-score">10</p></div>
-                <div class="column is-2 is-paddingless"><p id="con-score">10</p></div>
-                <div class="column is-2 is-paddingless"><p id="int-score">10</p></div>
-                <div class="column is-2 is-paddingless"><p id="wis-score">10</p></div>
-                <div class="column is-2 is-paddingless"><p id="cha-score">10</p></div>
+              <div
+                class="columns is-mobile is-centered is-marginless text-center mx-3"
+              >
+                <div class="column is-2 is-paddingless"><p
+                    id="str-score"
+                  >10</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    id="dex-score"
+                  >10</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    id="con-score"
+                  >10</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    id="int-score"
+                  >10</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    id="wis-score"
+                  >10</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    id="cha-score"
+                  >10</p></div>
               </div>
             </div>
 
             <!-- Hit Points -->
-            <div id="hit-points-body" class="accord-like-button columns is-mobile is-marginless my-1">
-              <div class="column is-8 is-paddingless"><span class="title-font pl-2">Hit Points</span></div>
-              <div class="column is-2 is-paddingless"><p id="hit-points-total" class="has-text-centered">130</p></div>
-              <div class="column is-2 is-paddingless"><p class="has-text-centered is-italic has-txt-noted is-size-7-5 pt-2">(at max)</p></div>
+            <div
+              id="hit-points-body"
+              class="accord-like-button columns is-mobile is-marginless my-1"
+            >
+              <div class="column is-8 is-paddingless"><span
+                  class="title-font pl-2"
+                >Hit Points</span></div>
+              <div class="column is-2 is-paddingless"><p
+                  id="hit-points-total"
+                  class="has-text-centered"
+                >130</p></div>
+              <div class="column is-2 is-paddingless"><p
+                  class="has-text-centered is-italic has-txt-noted is-size-7-5 pt-2"
+                >(at max)</p></div>
             </div>
 
             <!-- Class DC -->
-            <div id="class-dc-body" class="accord-like-button columns is-mobile is-marginless my-1">
-              <div class="column is-8 is-paddingless"><span class="title-font pl-2">Class DC</span></div>
-              <div class="column is-2 is-paddingless"><p id="class-dc-total" class="has-text-centered">18</p></div>
-              <div class="column is-2 is-paddingless"><p id="class-dc-rank" class="has-text-centered is-italic has-txt-noted">E</p></div>
+            <div
+              id="class-dc-body"
+              class="accord-like-button columns is-mobile is-marginless my-1"
+            >
+              <div class="column is-8 is-paddingless"><span
+                  class="title-font pl-2"
+                >Class DC</span></div>
+              <div class="column is-2 is-paddingless"><p
+                  id="class-dc-total"
+                  class="has-text-centered"
+                >18</p></div>
+              <div class="column is-2 is-paddingless"><p
+                  id="class-dc-rank"
+                  class="has-text-centered is-italic has-txt-noted"
+                >E</p></div>
             </div>
 
             <!-- Perception -->
-            <div id="perception-body" class="accord-like-button columns is-mobile is-marginless my-1">
-              <div class="column is-8 is-paddingless"><span class="title-font pl-2">Perception</span></div>
-              <div class="column is-2 is-paddingless"><p id="perception-total" class="has-text-centered">+28</p></div>
-              <div class="column is-2 is-paddingless"><p id="perception-rank" class="has-text-centered is-italic has-txt-noted">T</p></div>
+            <div
+              id="perception-body"
+              class="accord-like-button columns is-mobile is-marginless my-1"
+            >
+              <div class="column is-8 is-paddingless"><span
+                  class="title-font pl-2"
+                >Perception</span></div>
+              <div class="column is-2 is-paddingless"><p
+                  id="perception-total"
+                  class="has-text-centered"
+                >+28</p></div>
+              <div class="column is-2 is-paddingless"><p
+                  id="perception-rank"
+                  class="has-text-centered is-italic has-txt-noted"
+                >T</p></div>
             </div>
 
             <!-- Skills -->
@@ -308,7 +524,7 @@
                 <!-- Populated at runtime -->
               </div>
             </div>
-            
+
             <!-- Languages -->
             <div class="accord-container my-1">
               <div class="accord-header">
@@ -321,7 +537,7 @@
                 <!-- Populated at runtime -->
               </div>
             </div>
-            
+
             <!-- Resist & Weaks -->
             <div class="accord-container my-1">
               <div class="accord-header">
@@ -344,34 +560,50 @@
         <div class="tile is-child box py-2 pl-2 pr-1">
 
           <div class="steps">
-              <div class="step-item is-completed is-info">
-                  <div class="step-marker">
-                  <a class="builder-basics-page-btn"><span class="has-text-bck-color icon"><i class="fas fa-home-alt"></i></span></a>
-                  </div>
-                  <div class="step-details is-hidden-touch">
-                      <a class="builder-basics-page-btn button is-rounded is-inverted is-tiny is-info"><p class="step-builder-title title-font">Home</p></a>
-                  </div>
+            <div class="step-item is-completed is-info">
+              <div class="step-marker">
+                <a class="builder-basics-page-btn"><span
+                    class="has-text-bck-color icon"
+                  ><i class="fas fa-home-alt"></i></span></a>
               </div>
-              <div class="step-item is-active is-info">
-                  <div class="step-marker"><a class="builder-creation-page-btn"><span class="has-text-info">C</span></a></div>
-                  <div class="step-details is-hidden-touch">
-                      <a class="builder-creation-page-btn button is-rounded is-inverted is-tiny is-info"><p class="step-builder-title title-font">Creation</p></a>
-                  </div>
+              <div class="step-details is-hidden-touch">
+                <a
+                  class="builder-basics-page-btn button is-rounded is-inverted is-tiny is-info"
+                ><p class="step-builder-title title-font">Home</p></a>
               </div>
-              <div class="step-item">
-                  <div class="step-marker">
-                  <a class="builder-finalize-page-btn"><span class="has-text-bck-color icon"><i class="fa fa-user-alt"></i></span></a>
-                  </div>
-                  <div class="step-details is-hidden-touch">
-                      <a class="builder-finalize-page-btn button is-rounded is-inverted is-tiny is-info"><p class="step-builder-title title-font">Sheet</p></a>
-                  </div>
+            </div>
+            <div class="step-item is-active is-info">
+              <div class="step-marker"><a
+                  class="builder-creation-page-btn"
+                ><span class="has-text-info">C</span></a></div>
+              <div class="step-details is-hidden-touch">
+                <a
+                  class="builder-creation-page-btn button is-rounded is-inverted is-tiny is-info"
+                ><p class="step-builder-title title-font">Creation</p></a>
               </div>
+            </div>
+            <div class="step-item">
+              <div class="step-marker">
+                <a class="builder-finalize-page-btn"><span
+                    class="has-text-bck-color icon"
+                  ><i class="fa fa-user-alt"></i></span></a>
+              </div>
+              <div class="step-details is-hidden-touch">
+                <a
+                  class="builder-finalize-page-btn button is-rounded is-inverted is-tiny is-info"
+                ><p class="step-builder-title title-font">Sheet</p></a>
+              </div>
+            </div>
           </div>
 
         </div>
         <div class="tile is-child box py-2 pl-2 pr-1">
-          
-          <div id="creation-section" class="use-custom-scrollbar" style="height: 600px; max-height: 600px; overflow-y: scroll; overflow-x: hidden;">
+
+          <div
+            id="creation-section"
+            class="use-custom-scrollbar"
+            style="height: 600px; max-height: 600px; overflow-y: scroll; overflow-x: hidden;"
+          >
           </div>
 
         </div>
@@ -381,34 +613,36 @@
 
 </div>
 
-
-{{#section 'overlay'}}
-    <!-- Right Quickview -->
-    <div id="quickviewDefault" class="quickview">
-        <div class="quickview-header">
-            <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
-            <div class="is-inline-flex">
-                <p id="quickViewTitleRight"></p>
-                <p id="quickViewTitleClose"></p>
-            </div>
-        </div>
-        <div class="quickview-body use-custom-scrollbar">
-            <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
-            </div>
-        </div>
+{{#section "overlay"}}
+  <!-- Right Quickview -->
+  <div id="quickviewDefault" class="quickview">
+    <div class="quickview-header">
+      <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
+      <div class="is-inline-flex">
+        <p id="quickViewTitleRight"></p>
+        <p id="quickViewTitleClose"></p>
+      </div>
     </div>
-
-    <!-- Left Quickview -->
-    <div id="quickviewLeftDefault" class="quickview is-left" style="z-index: 34;">
-        <div class="quickview-header">
-            <p id="quickViewLeftTitle" class="title is-size-5 has-txt-value-number">Statistics</p>
-            <div class="is-inline-flex">
-                <p><a id="quickViewLeftTitleClose" class="delete"></a></p>
-            </div>
-        </div>
-        <div class="quickview-body use-custom-scrollbar">
-            <div id="quickViewLeftContent" class="quickview-block pt-1 pb-3 px-3">
-            </div>
-        </div>
+    <div class="quickview-body use-custom-scrollbar">
+      <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
+      </div>
     </div>
+  </div>
+
+  <!-- Left Quickview -->
+  <div id="quickviewLeftDefault" class="quickview is-left" style="z-index: 34;">
+    <div class="quickview-header">
+      <p
+        id="quickViewLeftTitle"
+        class="title is-size-5 has-txt-value-number"
+      >Statistics</p>
+      <div class="is-inline-flex">
+        <p><a id="quickViewLeftTitleClose" class="delete"></a></p>
+      </div>
+    </div>
+    <div class="quickview-body use-custom-scrollbar">
+      <div id="quickViewLeftContent" class="quickview-block pt-1 pb-3 px-3">
+      </div>
+    </div>
+  </div>
 {{/section}}

--- a/views/builds/build_creator.handlebars
+++ b/views/builds/build_creator.handlebars
@@ -1,145 +1,214 @@
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/build-planner.css" />
+{{/section}}
 
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/build-planner.css">
+{{#section "header"}}
+  <script src="/js/build_planner/main.js"></script>
+  <script src="/js/build_planner/ui-handler.js"></script>
 
-    <script src="/js/build_planner/main.js"></script>
-    <script src="/js/build_planner/ui-handler.js"></script>
+  <script src="/js/build_planner/processor/core-processor.js"></script>
 
-    <script src="/js/build_planner/processor/core-processor.js"></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder-statements.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/sheet-statements.js"
+  ></script>
 
-    <script src="/js/build_planner/processor/sub_processors/builder-statements.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/sheet-statements.js"></script>
+  <script src="/js/build_planner/scripts/init-variables.js"></script>
+  <script src="/js/build_planner/scripts/process-ancestry-stats.js"></script>
+  <script src="/js/build_planner/scripts/process-class-stats.js"></script>
+  <script src="/js/build_planner/scripts/unselected-options.js"></script>
+  <script src="/js/build_planner/scripts/extra-skills-and-langs.js"></script>
 
-    <script src="/js/build_planner/scripts/init-variables.js"></script>
-    <script src="/js/build_planner/scripts/process-ancestry-stats.js"></script>
-    <script src="/js/build_planner/scripts/process-class-stats.js"></script>
-    <script src="/js/build_planner/scripts/unselected-options.js"></script>
-    <script src="/js/build_planner/scripts/extra-skills-and-langs.js"></script>
+  <script src="/js/build_planner/libraries/selector.js"></script>
 
-    <script src="/js/build_planner/libraries/selector.js"></script>
+  <script src="/js/build_planner/data_mapping/data-map.js"></script>
+  <script src="/js/build_planner/data_mapping/data-map-ext.js"></script>
+  <script src="/js/build_planner/data_mapping/retrieval.js"></script>
 
-    <script src="/js/build_planner/data_mapping/data-map.js"></script>
-    <script src="/js/build_planner/data_mapping/data-map-ext.js"></script>
-    <script src="/js/build_planner/data_mapping/retrieval.js"></script>
+  <script src="/js/build_planner/modules/process-ancestry.js"></script>
+  <script src="/js/build_planner/modules/process-background.js"></script>
+  <script src="/js/build_planner/modules/process-class.js"></script>
 
-    <script src="/js/build_planner/modules/process-ancestry.js"></script>
-    <script src="/js/build_planner/modules/process-background.js"></script>
-    <script src="/js/build_planner/modules/process-class.js"></script>
+  <script src="/js/build_planner/modules/process-custom-code.js"></script>
 
-    <script src="/js/build_planner/modules/process-custom-code.js"></script>
+  <script
+    src="/js/build_planner/scripts/variants/auto-bonus-progression.js"
+  ></script>
+  <script src="/js/build_planner/scripts/variants/class-archetypes.js"></script>
+  <script src="/js/build_planner/scripts/variants/free-archetype.js"></script>
+  <script
+    src="/js/build_planner/scripts/variants/gradual-ability-boosts.js"
+  ></script>
 
-    <script src="/js/build_planner/scripts/variants/auto-bonus-progression.js"></script>
-    <script src="/js/build_planner/scripts/variants/class-archetypes.js"></script>
-    <script src="/js/build_planner/scripts/variants/free-archetype.js"></script>
-    <script src="/js/build_planner/scripts/variants/gradual-ability-boosts.js"></script>
+  <!-- Dependencies -->
+  <script src="/js/wsc/text-processing.js"></script>
+  <script src="/js/wsc/add-text-processing.js"></script>
+  <script src="/js/wsc/misc-feat-processing.js"></script>
+  <script src="/js/wsc/removal-processing.js"></script>
+  <script src="/js/wsc/variable-processing.js"></script>
+  <script src="/js/sheet/general/stat-manager.js"></script>
+  <script src="/js/sheet/general/sheet-states.js"></script>
 
-    <!-- Dependencies -->
-    <script src="/js/wsc/text-processing.js"></script>
-    <script src="/js/wsc/add-text-processing.js"></script>
-    <script src="/js/wsc/misc-feat-processing.js"></script>
-    <script src="/js/wsc/removal-processing.js"></script>
-    <script src="/js/wsc/variable-processing.js"></script>
-    <script src="/js/sheet/general/stat-manager.js"></script>
-    <script src="/js/sheet/general/sheet-states.js"></script>
+  <script src="/js/wsc/errorHandling.js"></script>
 
-    <script src="/js/wsc/errorHandling.js"></script>
+  <script src="/js/libraries/modal_selection/modal-selection.js"></script>
 
+  <script src="/js/libraries/display_class/display-class.js"></script>
+  <script src="/js/libraries/display_ancestry/display-ancestry.js"></script>
+  <script src="/js/libraries/display_archetype/display-archetype.js"></script>
+  <script src="/js/libraries/display_background/display-background.js"></script>
+  <script
+    src="/js/libraries/display_uni_heritage/display-uni-heritage.js"
+  ></script>
+  <script src="/js/libraries/confirm_message/confirm-message.js"></script>
 
-    <script src="/js/libraries/modal_selection/modal-selection.js"></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-boosts.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-feats.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-class-feature.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-heritage.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-langs.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-lore.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-skills.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-profs.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-spells.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-spells-innate.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-spells-focus.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-resistances.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-domains.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-specializations.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-notes.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-charTags.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-phyFeats.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-senses.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-speeds.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-familiarity.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-keyAbility.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/wsc-scfs.js"
+  ></script>
 
-    <script src="/js/libraries/display_class/display-class.js"></script>
-    <script src="/js/libraries/display_ancestry/display-ancestry.js"></script>
-    <script src="/js/libraries/display_archetype/display-archetype.js"></script>
-    <script src="/js/libraries/display_background/display-background.js"></script>
-    <script src="/js/libraries/display_uni_heritage/display-uni-heritage.js"></script>
-    <script src="/js/libraries/confirm_message/confirm-message.js"></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/display-structs.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/feats-selection.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/builder/prereq-parser.js"
+  ></script>
 
+  <script
+    src="/js/build_planner/processor/sub_processors/expression-processor.js"
+  ></script>
+  <script
+    src="/js/build_planner/processor/sub_processors/expression-utils.js"
+  ></script>
 
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-boosts.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-feats.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-class-feature.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-heritage.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-langs.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-lore.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-skills.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-profs.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-spells.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-spells-innate.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-spells-focus.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-resistances.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-domains.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-specializations.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-notes.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-charTags.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-phyFeats.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-senses.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-speeds.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-familiarity.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-keyAbility.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/wsc-scfs.js"></script>
+  <!-- Build Creator Augment -->
+  <script src="/js/builds/build-creator-augment.js"></script>
 
-    <script src="/js/build_planner/processor/sub_processors/builder/display-structs.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/feats-selection.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/builder/prereq-parser.js"></script>
+  <!-- Quickview -->
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/quickview-left.js"
+  ></script>
+  <script src="/js/sheet/quickviews/_quickviews.js"></script>
+  <script src="/js/sheet/quickviews/feat-view.js"></script>
+  <script src="/js/sheet/quickviews/language-view.js"></script>
+  <script src="/js/sheet/quickviews/spell-view.js"></script>
+  <script src="/js/sheet/quickviews/item-view.js"></script>
+  <script src="/js/sheet/quickviews/tag-view.js"></script>
+  <script src="/js/sheet/quickviews/ability-view.js"></script>
+  <script src="/js/sheet/quickviews/condition-view.js"></script>
+  <script src="/js/sheet/quickviews/general-breakdown-view.js"></script>
+  <script src="/js/sheet/quickviews/hit-points-breakdown-view.js"></script>
+  <script src="/js/sheet/quickviews/ability-scores-breakdown-view.js"></script>
+  <script src="/js/sheet/quickviews/resist-view.js"></script>
 
-    <script src="/js/build_planner/processor/sub_processors/expression-processor.js"></script>
-    <script src="/js/build_planner/processor/sub_processors/expression-utils.js"></script>
-
-    <!-- Build Creator Augment -->
-    <script src="/js/builds/build-creator-augment.js"></script>
-
-    <!-- Quickview -->
-    <script type="text/javascript" src="/js/char_builders/wsc/quickview-left.js"></script>
-    <script src="/js/sheet/quickviews/_quickviews.js"></script>
-    <script src="/js/sheet/quickviews/feat-view.js"></script>
-    <script src="/js/sheet/quickviews/language-view.js"></script>
-    <script src="/js/sheet/quickviews/spell-view.js"></script>
-    <script src="/js/sheet/quickviews/item-view.js"></script>
-    <script src="/js/sheet/quickviews/tag-view.js"></script>
-    <script src="/js/sheet/quickviews/ability-view.js"></script>
-    <script src="/js/sheet/quickviews/condition-view.js"></script>
-    <script src="/js/sheet/quickviews/general-breakdown-view.js"></script>
-    <script src="/js/sheet/quickviews/hit-points-breakdown-view.js"></script>
-    <script src="/js/sheet/quickviews/ability-scores-breakdown-view.js"></script>
-    <script src="/js/sheet/quickviews/resist-view.js"></script>
-
-    <script src="/js/sheet/general/prof-history-display.js"></script>
-    <script src="/js/sheet/utils/item-utils.js"></script>
+  <script src="/js/sheet/general/prof-history-display.js"></script>
+  <script src="/js/sheet/utils/item-utils.js"></script>
 
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds" class="active">Builds</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds" class="active">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
-
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="">
@@ -159,92 +228,183 @@
   </div>
 </div>
 
-<div class="planner-subpageloader subpageloader-like is-hidden"><div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div></div>
+<div class="planner-subpageloader subpageloader-like is-hidden"><div
+    class="lds-roller"
+  ><div></div><div></div><div></div><div></div><div></div><div></div><div
+    ></div><div></div></div></div>
 
 <div class="container mt-3 pt-3">
 
   <div id="errorDisplay" class="hero is-danger is-hidden text-center">
-      <div class="hero-body is-paddingless py-3">
-          <div id="errorMessage" class="container"></div>
-      </div>
+    <div class="hero-body is-paddingless py-3">
+      <div id="errorMessage" class="container"></div>
+    </div>
   </div>
 
-  <div id="builder-data" data-build-id="{{build.id}}" data-char-id="none" data-char-lvl="none" data-builder-type="by-level" data-page-num="2"></div>
-  
+  <div
+    id="builder-data"
+    data-build-id="{{build.id}}"
+    data-char-id="none"
+    data-char-lvl="none"
+    data-builder-type="by-level"
+    data-page-num="2"
+  ></div>
+
   <div class="tile is-ancestor">
     <div class="tile is-4">
       <div class="tile is-parent is-vertical">
         <div class="tile is-child box p-2 is-marginless">
-          
+
           <div class="columns is-mobile is-marginless m-1">
             <div class="column is-paddingless">
-              <p class="has-txt-value-string title-font has-text-centered">Ancestry</p>
+              <p
+                class="has-txt-value-string title-font has-text-centered"
+              >Ancestry</p>
             </div>
             <div class="column is-7 is-paddingless has-text-centered">
-              <span class="button is-info is-outlined is-small is-fullwidth" id="selected-ancestry">None</span>
+              <span
+                class="button is-info is-outlined is-small is-fullwidth"
+                id="selected-ancestry"
+              >None</span>
             </div>
           </div>
           <div class="columns is-mobile is-marginless m-1">
             <div class="column is-paddingless">
-              <p class="has-txt-value-string title-font has-text-centered">Background</p>
+              <p
+                class="has-txt-value-string title-font has-text-centered"
+              >Background</p>
             </div>
             <div class="column is-7 is-paddingless has-text-centered">
-              <span class="button is-info is-outlined is-small is-fullwidth" id="selected-background">None</span>
+              <span
+                class="button is-info is-outlined is-small is-fullwidth"
+                id="selected-background"
+              >None</span>
             </div>
           </div>
           <div class="columns is-mobile is-marginless m-1">
             <div class="column is-paddingless">
-              <p class="has-txt-value-string title-font has-text-centered">Class</p>
+              <p
+                class="has-txt-value-string title-font has-text-centered"
+              >Class</p>
             </div>
             <div class="column is-7 is-paddingless has-text-centered">
-              <span class="button is-info is-outlined is-small is-fullwidth" id="selected-class">None</span>
+              <span
+                class="button is-info is-outlined is-small is-fullwidth"
+                id="selected-class"
+              >None</span>
             </div>
           </div>
 
         </div>
         <div class="tile is-child box py-2 pl-2 pr-1">
-          <p class="has-txt-value-string title-font has-text-centered">Statistics</p>
-          <div id="builder-statistics-container" class="use-custom-scrollbar" style="height: 500px; max-height: 500px; overflow-y: scroll;">
-          
+          <p
+            class="has-txt-value-string title-font has-text-centered"
+          >Statistics</p>
+          <div
+            id="builder-statistics-container"
+            class="use-custom-scrollbar"
+            style="height: 500px; max-height: 500px; overflow-y: scroll;"
+          >
+
             <!-- Ability Scores -->
             <div id="ability-scores-body" class="accord-like-button mx-2 mb-2">
-              <div class="columns is-mobile is-centered is-marginless text-center mx-3">
-                <div class="column is-2 is-paddingless"><p class="is-bold-very">Str</p></div>
-                <div class="column is-2 is-paddingless"><p class="is-bold-very">Dex</p></div>
-                <div class="column is-2 is-paddingless"><p class="is-bold-very">Con</p></div>
-                <div class="column is-2 is-paddingless"><p class="is-bold-very">Int</p></div>
-                <div class="column is-2 is-paddingless"><p class="is-bold-very">Wis</p></div>
-                <div class="column is-2 is-paddingless"><p class="is-bold-very">Cha</p></div>
+              <div
+                class="columns is-mobile is-centered is-marginless text-center mx-3"
+              >
+                <div class="column is-2 is-paddingless"><p
+                    class="is-bold-very"
+                  >Str</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    class="is-bold-very"
+                  >Dex</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    class="is-bold-very"
+                  >Con</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    class="is-bold-very"
+                  >Int</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    class="is-bold-very"
+                  >Wis</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    class="is-bold-very"
+                  >Cha</p></div>
               </div>
-              <div class="columns is-mobile is-centered is-marginless text-center mx-3">
-                <div class="column is-2 is-paddingless"><p id="str-score">10</p></div>
-                <div class="column is-2 is-paddingless"><p id="dex-score">10</p></div>
-                <div class="column is-2 is-paddingless"><p id="con-score">10</p></div>
-                <div class="column is-2 is-paddingless"><p id="int-score">10</p></div>
-                <div class="column is-2 is-paddingless"><p id="wis-score">10</p></div>
-                <div class="column is-2 is-paddingless"><p id="cha-score">10</p></div>
+              <div
+                class="columns is-mobile is-centered is-marginless text-center mx-3"
+              >
+                <div class="column is-2 is-paddingless"><p
+                    id="str-score"
+                  >10</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    id="dex-score"
+                  >10</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    id="con-score"
+                  >10</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    id="int-score"
+                  >10</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    id="wis-score"
+                  >10</p></div>
+                <div class="column is-2 is-paddingless"><p
+                    id="cha-score"
+                  >10</p></div>
               </div>
             </div>
 
             <!-- Hit Points -->
-            <div id="hit-points-body" class="accord-like-button columns is-mobile is-marginless my-1">
-              <div class="column is-8 is-paddingless"><span class="title-font pl-2">Hit Points</span></div>
-              <div class="column is-2 is-paddingless"><p id="hit-points-total" class="has-text-centered">130</p></div>
-              <div class="column is-2 is-paddingless"><p class="has-text-centered is-italic has-txt-noted is-size-7-5 pt-2">(at max)</p></div>
+            <div
+              id="hit-points-body"
+              class="accord-like-button columns is-mobile is-marginless my-1"
+            >
+              <div class="column is-8 is-paddingless"><span
+                  class="title-font pl-2"
+                >Hit Points</span></div>
+              <div class="column is-2 is-paddingless"><p
+                  id="hit-points-total"
+                  class="has-text-centered"
+                >130</p></div>
+              <div class="column is-2 is-paddingless"><p
+                  class="has-text-centered is-italic has-txt-noted is-size-7-5 pt-2"
+                >(at max)</p></div>
             </div>
 
             <!-- Class DC -->
-            <div id="class-dc-body" class="accord-like-button columns is-mobile is-marginless my-1">
-              <div class="column is-8 is-paddingless"><span class="title-font pl-2">Class DC</span></div>
-              <div class="column is-2 is-paddingless"><p id="class-dc-total" class="has-text-centered">18</p></div>
-              <div class="column is-2 is-paddingless"><p id="class-dc-rank" class="has-text-centered is-italic has-txt-noted">E</p></div>
+            <div
+              id="class-dc-body"
+              class="accord-like-button columns is-mobile is-marginless my-1"
+            >
+              <div class="column is-8 is-paddingless"><span
+                  class="title-font pl-2"
+                >Class DC</span></div>
+              <div class="column is-2 is-paddingless"><p
+                  id="class-dc-total"
+                  class="has-text-centered"
+                >18</p></div>
+              <div class="column is-2 is-paddingless"><p
+                  id="class-dc-rank"
+                  class="has-text-centered is-italic has-txt-noted"
+                >E</p></div>
             </div>
 
             <!-- Perception -->
-            <div id="perception-body" class="accord-like-button columns is-mobile is-marginless my-1">
-              <div class="column is-8 is-paddingless"><span class="title-font pl-2">Perception</span></div>
-              <div class="column is-2 is-paddingless"><p id="perception-total" class="has-text-centered">+28</p></div>
-              <div class="column is-2 is-paddingless"><p id="perception-rank" class="has-text-centered is-italic has-txt-noted">T</p></div>
+            <div
+              id="perception-body"
+              class="accord-like-button columns is-mobile is-marginless my-1"
+            >
+              <div class="column is-8 is-paddingless"><span
+                  class="title-font pl-2"
+                >Perception</span></div>
+              <div class="column is-2 is-paddingless"><p
+                  id="perception-total"
+                  class="has-text-centered"
+                >+28</p></div>
+              <div class="column is-2 is-paddingless"><p
+                  id="perception-rank"
+                  class="has-text-centered is-italic has-txt-noted"
+                >T</p></div>
             </div>
 
             <!-- Skills -->
@@ -311,7 +471,7 @@
                 <!-- Populated at runtime -->
               </div>
             </div>
-            
+
             <!-- Languages -->
             <div class="accord-container my-1">
               <div class="accord-header">
@@ -324,7 +484,7 @@
                 <!-- Populated at runtime -->
               </div>
             </div>
-            
+
             <!-- Resist & Weaks -->
             <div class="accord-container my-1">
               <div class="accord-header">
@@ -347,34 +507,50 @@
         <div class="tile is-child box py-2 pl-2 pr-1">
 
           <div class="steps">
-              <div class="step-item is-completed is-info">
-                  <div class="step-marker">
-                  <a class="builder-build-home-page-btn"><span class="has-text-bck-color icon"><i class="fas fa-home-alt"></i></span></a>
-                  </div>
-                  <div class="step-details is-hidden-touch">
-                      <a class="builder-build-home-page-btn button is-rounded is-inverted is-tiny is-info"><p class="step-builder-title title-font">Home</p></a>
-                  </div>
+            <div class="step-item is-completed is-info">
+              <div class="step-marker">
+                <a class="builder-build-home-page-btn"><span
+                    class="has-text-bck-color icon"
+                  ><i class="fas fa-home-alt"></i></span></a>
               </div>
-              <div class="step-item is-active is-info">
-                  <div class="step-marker"><a class="builder-build-creation-page-btn"><span class="has-text-info">C</span></a></div>
-                  <div class="step-details is-hidden-touch">
-                      <a class="builder-build-creation-page-btn button is-rounded is-inverted is-tiny is-info"><p class="step-builder-title title-font">Creation</p></a>
-                  </div>
+              <div class="step-details is-hidden-touch">
+                <a
+                  class="builder-build-home-page-btn button is-rounded is-inverted is-tiny is-info"
+                ><p class="step-builder-title title-font">Home</p></a>
               </div>
-              <div class="step-item">
-                  <div class="step-marker">
-                  <a class="builder-build-publish-page-btn"><span class="has-text-bck-color icon"><i class="fa fa-user-alt"></i></span></a>
-                  </div>
-                  <div class="step-details is-hidden-touch">
-                      <a class="builder-build-publish-page-btn button is-rounded is-inverted is-tiny is-info"><p class="step-builder-title title-font">Publish</p></a>
-                  </div>
+            </div>
+            <div class="step-item is-active is-info">
+              <div class="step-marker"><a
+                  class="builder-build-creation-page-btn"
+                ><span class="has-text-info">C</span></a></div>
+              <div class="step-details is-hidden-touch">
+                <a
+                  class="builder-build-creation-page-btn button is-rounded is-inverted is-tiny is-info"
+                ><p class="step-builder-title title-font">Creation</p></a>
               </div>
+            </div>
+            <div class="step-item">
+              <div class="step-marker">
+                <a class="builder-build-publish-page-btn"><span
+                    class="has-text-bck-color icon"
+                  ><i class="fa fa-user-alt"></i></span></a>
+              </div>
+              <div class="step-details is-hidden-touch">
+                <a
+                  class="builder-build-publish-page-btn button is-rounded is-inverted is-tiny is-info"
+                ><p class="step-builder-title title-font">Publish</p></a>
+              </div>
+            </div>
           </div>
 
         </div>
         <div class="tile is-child box py-2 pl-2 pr-1">
-          
-          <div id="creation-section" class="use-custom-scrollbar" style="height: 600px; max-height: 600px; overflow-y: scroll; overflow-x: hidden;">
+
+          <div
+            id="creation-section"
+            class="use-custom-scrollbar"
+            style="height: 600px; max-height: 600px; overflow-y: scroll; overflow-x: hidden;"
+          >
           </div>
 
         </div>
@@ -384,34 +560,36 @@
 
 </div>
 
-
-{{#section 'overlay'}}
-    <!-- Right Quickview -->
-    <div id="quickviewDefault" class="quickview">
-        <div class="quickview-header">
-            <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
-            <div class="is-inline-flex">
-                <p id="quickViewTitleRight"></p>
-                <p id="quickViewTitleClose"></p>
-            </div>
-        </div>
-        <div class="quickview-body use-custom-scrollbar">
-            <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
-            </div>
-        </div>
+{{#section "overlay"}}
+  <!-- Right Quickview -->
+  <div id="quickviewDefault" class="quickview">
+    <div class="quickview-header">
+      <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
+      <div class="is-inline-flex">
+        <p id="quickViewTitleRight"></p>
+        <p id="quickViewTitleClose"></p>
+      </div>
     </div>
-
-    <!-- Left Quickview -->
-    <div id="quickviewLeftDefault" class="quickview is-left" style="z-index: 34;">
-        <div class="quickview-header">
-            <p id="quickViewLeftTitle" class="title is-size-5 has-txt-value-number">Statistics</p>
-            <div class="is-inline-flex">
-                <p><a id="quickViewLeftTitleClose" class="delete"></a></p>
-            </div>
-        </div>
-        <div class="quickview-body use-custom-scrollbar">
-            <div id="quickViewLeftContent" class="quickview-block pt-1 pb-3 px-3">
-            </div>
-        </div>
+    <div class="quickview-body use-custom-scrollbar">
+      <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
+      </div>
     </div>
+  </div>
+
+  <!-- Left Quickview -->
+  <div id="quickviewLeftDefault" class="quickview is-left" style="z-index: 34;">
+    <div class="quickview-header">
+      <p
+        id="quickViewLeftTitle"
+        class="title is-size-5 has-txt-value-number"
+      >Statistics</p>
+      <div class="is-inline-flex">
+        <p><a id="quickViewLeftTitleClose" class="delete"></a></p>
+      </div>
+    </div>
+    <div class="quickview-body use-custom-scrollbar">
+      <div id="quickViewLeftContent" class="quickview-block pt-1 pb-3 px-3">
+      </div>
+    </div>
+  </div>
 {{/section}}

--- a/views/builds/build_creator_init.handlebars
+++ b/views/builds/build_creator_init.handlebars
@@ -1,67 +1,79 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/char-builder.css">
-    <script type="text/javascript" src="/js/builds/build-creator-init.js"></script>
-
-    <script src="/js/require-signin.js"></script>
-
-    <script src="/js/libraries/confirm_message/confirm-message.js"></script>
-    
-    <script type="text/javascript" src="/js/wsc/text-processing.js"></script>
-    <script type="text/javascript" src="/js/wsc/errorHandling.js"></script>
-
-    <script type="text/javascript" src="/js/char_builders/top-stickies.js"></script>
-    <script type="text/javascript" src="/js/char_builders/utils.js"></script>
-
-    <!-- Build Creator Augment -->
-    <script src="/js/builds/build-creator-augment.js"></script>
-    
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/char-builder.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script
+    type="text/javascript"
+    src="/js/builds/build-creator-init.js"
+  ></script>
+
+  <script src="/js/require-signin.js"></script>
+
+  <script src="/js/libraries/confirm_message/confirm-message.js"></script>
+
+  <script type="text/javascript" src="/js/wsc/text-processing.js"></script>
+  <script type="text/javascript" src="/js/wsc/errorHandling.js"></script>
+
+  <script
+    type="text/javascript"
+    src="/js/char_builders/top-stickies.js"
+  ></script>
+  <script type="text/javascript" src="/js/char_builders/utils.js"></script>
+
+  <!-- Build Creator Augment -->
+  <script src="/js/builds/build-creator-augment.js"></script>
+
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds" class="active">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds" class="active">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
 
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="pageloader">
-    <div class="lds-roller" style="margin-bottom: 20%;"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+  <div class="lds-roller" style="margin-bottom: 20%;"><div></div><div></div><div
+    ></div><div></div><div></div><div></div><div></div><div></div></div>
 </div>
 
 <div class="sticky_buttons_shell sticky_button_right">
-    <button class="button is-info is-rounded sticky_button" id="nextButton">
-        <span class="icon">
-            <i class="fas fa-arrow-right"></i>
-        </span>
-    </button>
+  <button class="button is-info is-rounded sticky_button" id="nextButton">
+    <span class="icon">
+      <i class="fas fa-arrow-right"></i>
+    </span>
+  </button>
 </div>
 
 <div id="char-builder-container" data-build-id="{{build.id}}">
@@ -69,503 +81,865 @@
 
 <div id="char-builder" class="container py-4 text-center">
 
-    <div id="errorDisplay" class="hero is-danger is-hidden">
-        <div class="hero-body is-paddingless py-3">
-            <div id="errorMessage" class="container"></div>
-        </div>
+  <div id="errorDisplay" class="hero is-danger is-hidden">
+    <div class="hero-body is-paddingless py-3">
+      <div id="errorMessage" class="container"></div>
     </div>
+  </div>
 
-    <div class="box">
+  <div class="box">
 
-        <h1 class="title is-2 has-txt-listing">Build Creator</h1>
+    <h1 class="title is-2 has-txt-listing">Build Creator</h1>
 
-        <div class="steps">
-            <div class="step-item is-active is-info">
-                <div class="step-marker">
-                <a class="builder-build-home-page-btn"><span class="icon"><i class="fas fa-home-alt"></i></span></a>
-                </div>
-                <div class="step-details is-hidden-touch">
-                    <a class="builder-build-home-page-btn button is-rounded is-inverted is-info"><p class="step-title">Home</p></a>
-                </div>
-            </div>
-            <div class="step-item is-builder-type-by-level">
-                <div class="step-marker"><a class="builder-creation-page-btn"><span class="has-text-bck-color">C</span></a></div>
-                <div class="step-details is-hidden-touch">
-                    <a class="builder-creation-page-btn button is-rounded is-inverted is-info"><p class="step-title">Creation</p></a>
-                </div>
-            </div>
-            <div class="step-item">
-                <div class="step-marker">
-                <a class="builder-build-publish-page-btn"><span class="has-text-bck-color icon"><i class="fa fa-user-alt"></i></span></a>
-                </div>
-                <div class="step-details is-hidden-touch">
-                    <a class="builder-build-publish-page-btn button is-rounded is-inverted is-info"><p class="step-title">Publish</p></a>
-                </div>
-            </div>
+    <div class="steps">
+      <div class="step-item is-active is-info">
+        <div class="step-marker">
+          <a class="builder-build-home-page-btn"><span class="icon"><i
+                class="fas fa-home-alt"
+              ></i></span></a>
         </div>
-
-        <div class="columns is-marginless">
-            <div class="column is-4 is-offset-4">
-
-              <div class="field">
-                <div id="charNameControlShell" class="control has-icons-left has-icons-right">
-                  <input class="input" type="text" placeholder="Build Name" spellcheck="false" id="charName" maxlength="28" value="{{build.name}}" style="text-align:center;">
-                  <span class="icon is-small is-right">
-                    <i id="charNameSideIcon" class="fas fa-exclamation-triangle is-hidden"></i>
-                  </span>
-                </div>
-              </div>
-
-            </div>
+        <div class="step-details is-hidden-touch">
+          <a
+            class="builder-build-home-page-btn button is-rounded is-inverted is-info"
+          ><p class="step-title">Home</p></a>
         </div>
-
-        <div class="columns is-marginless">
-            <div class="column is-paddingless is-8 is-offset-2" style="padding-left: 0.75rem!important; padding-right: 0.75rem!important;">
-              
-              <div class="control py-1">
-                <textarea id="buildDescription" class="textarea use-custom-scrollbar" placeholder="Build Description">{{build.description}}</textarea>
-              </div>
-
-            </div>
+      </div>
+      <div class="step-item is-builder-type-by-level">
+        <div class="step-marker"><a class="builder-creation-page-btn"><span
+              class="has-text-bck-color"
+            >C</span></a></div>
+        <div class="step-details is-hidden-touch">
+          <a
+            class="builder-creation-page-btn button is-rounded is-inverted is-info"
+          ><p class="step-title">Creation</p></a>
         </div>
-
-        <div class="columns is-marginless py-1">
-          <div class="column is-paddingless is-8 is-offset-2 px-4">
-            <p class="has-text-left has-txt-partial-noted is-size-6-5">
-              You can write notes for specific feats you've selected by writing at the end of the description, each on their own line: "{feat name}: {notes}"
-            </p>
-            <p class="has-text-left has-txt-noted is-size-7 is-italic">
-              Example.
-            </p>
-            <p class="has-text-left has-txt-noted is-size-7">
-              Goblin Song: A great option for easily lowering an enemy's Perception and Will saves, this can be an amazing tool in helping rogues and casters alike.
-            </p>
-          </div>
+      </div>
+      <div class="step-item">
+        <div class="step-marker">
+          <a class="builder-build-publish-page-btn"><span
+              class="has-text-bck-color icon"
+            ><i class="fa fa-user-alt"></i></span></a>
         </div>
-
-        <div class="columns is-marginless">
-            <div class="column is-4 is-offset-4">
-
-              <div class="control py-1">
-                <input id="buildContactInfo" class="input" type="text" placeholder="Contact Info" autocomplete="off" value="{{build.contactInfo}}">
-              </div>
-
-            </div>
-        </div>
-
-        <div class="columns is-marginless">
-            <div class="column is-paddingless is-4 is-offset-4" style="padding-left: 0.75rem!important; padding-right: 0.75rem!important;">
-              
-              <div class="control py-1">
-                <input id="buildArtworkURL" class="input isURL" type="text" maxlength="200" placeholder="Image URL" spellcheck="false" autocomplete="off" value="{{build.artworkURL}}">
-              </div>
-
-            </div>
-        </div>
-
-    </div>
-
-    
-
-
-    <div class="box p-2">
-
-        <div class="columns is-centered">
-            <div class="column is-4">
-                <div class="pb-2">
-                    <h4>Books</h4>
-                </div>
-                
-                <div id="booksColumn" class="columns is-mobile first-page-container my-1 use-custom-scrollbar">
-                    <span id="enableAllBooksBtn" class="button is-tiny is-info is-outlined pos-absolute pos-t-10 pos-r-10">Enable All</span>
-                    <div class="column is-3"></div>
-                    <div class="column is-9 text-left">
-
-                        <div class="field">
-                            <input id="contentSrc-CRB" type="checkbox" name="contentSrc-CRB" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1" disabled>
-                            <label for="contentSrc-CRB">
-                                Core Rulebook
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-ADV-PLAYER-GUIDE" type="checkbox" name="contentSrc-ADV-PLAYER-GUIDE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-ADV-PLAYER-GUIDE">
-                                Advanced Player’s Guide
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-GM-GUIDE" type="checkbox" name="contentSrc-GM-GUIDE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-GM-GUIDE">
-                                Gamemastery Guide
-                            </label>
-                        </div>
-
-                        <hr class="m-2">
-
-                        <div class="field">
-                            <input id="contentSrc-BOOK-OF-DEAD" type="checkbox" name="contentSrc-BOOK-OF-DEAD" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-BOOK-OF-DEAD">
-                                Book of the Dead
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-DARK-ARCHIVE" type="checkbox" name="contentSrc-DARK-ARCHIVE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-DARK-ARCHIVE">
-                                Dark Archive
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-GUNS-AND-GEARS" type="checkbox" name="contentSrc-GUNS-AND-GEARS" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-GUNS-AND-GEARS">
-                                Guns & Gears
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-RAGE-OF-ELEMENTS" type="checkbox" name="contentSrc-RAGE-OF-ELEMENTS" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-RAGE-OF-ELEMENTS">
-                                Rage of Elements <sup class="is-thin">(in playtest)</sup>
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-SECRETS-OF-MAGIC" type="checkbox" name="contentSrc-SECRETS-OF-MAGIC" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-SECRETS-OF-MAGIC">
-                                Secrets of Magic
-                            </label>
-                        </div>
-
-                        <div class="pl-4">
-                            <p>Lost Omens</p>
-                        </div>
-                        <hr class="mt-0 mb-2 mx-2">
-                        <div class="field">
-                            <input id="contentSrc-LOST-ANCESTRY-GUIDE" type="checkbox" name="contentSrc-LOST-ANCESTRY-GUIDE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-ANCESTRY-GUIDE">
-                                Ancestry Guide
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-CHAR-GUIDE" type="checkbox" name="contentSrc-LOST-CHAR-GUIDE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-CHAR-GUIDE">
-                                Character Guide
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-CITY-ABSALOM" type="checkbox" name="contentSrc-LOST-CITY-ABSALOM" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-CITY-ABSALOM">
-                                City of Absalom
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-GOD-MAGIC" type="checkbox" name="contentSrc-LOST-GOD-MAGIC" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-GOD-MAGIC">
-                                Gods & Magic
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-GRAND-BAZAAR" type="checkbox" name="contentSrc-LOST-GRAND-BAZAAR" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-GRAND-BAZAAR">
-                                Grand Bazaar
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-IMPOSSIBLE-LANDS" type="checkbox" name="contentSrc-LOST-IMPOSSIBLE-LANDS" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-IMPOSSIBLE-LANDS">
-                                Impossible Lands
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-KNIGHTS-WALL" type="checkbox" name="contentSrc-LOST-KNIGHTS-WALL" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-KNIGHTS-WALL">
-                                Knights of Lastwall
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-LEGENDS" type="checkbox" name="contentSrc-LOST-LEGENDS" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-LEGENDS">
-                                Legends
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-MONSTERS-MYTH" type="checkbox" name="contentSrc-LOST-MONSTERS-MYTH" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-MONSTERS-MYTH">
-                                Monsters of Myth
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-MWANGI" type="checkbox" name="contentSrc-LOST-MWANGI" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-MWANGI">
-                                The Mwangi Expanse
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-SOCIETY-GUIDE" type="checkbox" name="contentSrc-LOST-SOCIETY-GUIDE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-SOCIETY-GUIDE">
-                                Pathfinder Society Guide
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-TRAVEL-GUIDE" type="checkbox" name="contentSrc-LOST-TRAVEL-GUIDE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-TRAVEL-GUIDE">
-                                Travel Guide
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-WORLD-GUIDE" type="checkbox" name="contentSrc-LOST-WORLD-GUIDE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-WORLD-GUIDE">
-                                World Guide
-                            </label>
-                        </div>
-
-                        <div class="pl-4">
-                            <p>Adventure Paths</p>
-                        </div>
-                        <hr class="mt-0 mb-2 mx-2">
-
-                        <div class="field">
-                            <input id="contentSrc-ABOMINATION-VAULTS" type="checkbox" name="contentSrc-ABOMINATION-VAULTS" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-ABOMINATION-VAULTS">
-                                Abomination Vaults
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-AGENTS-OF-EDGEWATCH" type="checkbox" name="contentSrc-AGENTS-OF-EDGEWATCH" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-AGENTS-OF-EDGEWATCH">
-                                Agents of Edgewatch
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-AGE-OF-ASHES" type="checkbox" name="contentSrc-AGE-OF-ASHES" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-AGE-OF-ASHES">
-                                Age of Ashes
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-BLOOD-LORDS" type="checkbox" name="contentSrc-BLOOD-LORDS" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-BLOOD-LORDS">
-                                Blood Lords <sup class="is-thin">(in progress)</sup>
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-EXTINCTION-CURSE" type="checkbox" name="contentSrc-EXTINCTION-CURSE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-EXTINCTION-CURSE">
-                                Extinction Curse
-                            </label>
-                        </div>
-                        
-                        <div class="field">
-                            <input id="contentSrc-FIST-PHOENIX" type="checkbox" name="contentSrc-FIST-PHOENIX" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-FIST-PHOENIX">
-                                Fists of the Ruby Phoenix
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-KINGMAKER" type="checkbox" name="contentSrc-KINGMAKER" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-KINGMAKER">
-                                Kingmaker
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-OUTLAWS-ALKENSTAR" type="checkbox" name="contentSrc-OUTLAWS-ALKENSTAR" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-OUTLAWS-ALKENSTAR">
-                                Outlaws of Alkenstar
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-QUEST-FROZEN-FLAME" type="checkbox" name="contentSrc-QUEST-FROZEN-FLAME" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-QUEST-FROZEN-FLAME">
-                                Quest for the Frozen Flame
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-STRENGTH-THOUSANDS" type="checkbox" name="contentSrc-STRENGTH-THOUSANDS" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-STRENGTH-THOUSANDS">
-                                Strength of Thousands
-                            </label>
-                        </div>
-
-                        <div class="pl-4">
-                            <p>Standalone Adventures</p>
-                        </div>
-                        <hr class="mt-0 mb-2 mx-2">
-                        <div class="field">
-                            <input id="contentSrc-CROWN-OF-KOBOLD-KING" type="checkbox" name="contentSrc-CROWN-OF-KOBOLD-KING" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-CROWN-OF-KOBOLD-KING">
-                                Crown of the Kobold King
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-FALL-OF-PLAGUE" type="checkbox" name="contentSrc-FALL-OF-PLAGUE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-FALL-OF-PLAGUE">
-                                The Fall of Plaguestone
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-MALEVOLENCE" type="checkbox" name="contentSrc-MALEVOLENCE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-MALEVOLENCE">
-                                Malevolence
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-NIGHT-GRAY-DEATH" type="checkbox" name="contentSrc-NIGHT-GRAY-DEATH" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-NIGHT-GRAY-DEATH">
-                                Night of the Gray Death
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-SLITHERING" type="checkbox" name="contentSrc-SLITHERING" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-SLITHERING">
-                                The Slithering
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-THRESHOLD-KNOWLEDGE" type="checkbox" name="contentSrc-THRESHOLD-KNOWLEDGE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-THRESHOLD-KNOWLEDGE">
-                                Threshold of Knowledge
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-TROUBLES-IN-OTARI" type="checkbox" name="contentSrc-TROUBLES-IN-OTARI" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-TROUBLES-IN-OTARI">
-                                Troubles in Otari
-                            </label>
-                        </div>
-
-
-                        <div class="pl-4">
-                            <p>Other</p>
-                        </div>
-                        <hr class="mt-0 mb-2 mx-2">
-                        <div class="field">
-                            <input id="contentSrc-PATH-SOCIETY" type="checkbox" name="contentSrc-PATH-SOCIETY" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-PATH-SOCIETY">
-                                Pathfinder Society - Extras
-                            </label>
-                        </div>
-
-                        
-
-                    </div>
-                </div>
-            </div>
-            <div class="column is-4" style="position: relative;">
-                <div class="pb-2">
-                    <h4>Homebrew</h4>
-                    <span id="noHomebrewMessage" class="is-hidden is-size-7 has-txt-noted is-italic has-text-centered">Your homebrew collection is empty.</span>
-                </div>
-
-                <div id="homebrewColumn" class="columns is-mobile first-page-container my-1 use-custom-scrollbar">
-                    <div class="column is-3"></div>
-                    <div class="column is-9 text-left">
-                      <div id="homebrewCollectionContainer"></div>
-                      <div style="position: absolute; left: 50%;">
-                        <div style="position: relative; left: -50%;">
-                          <span id="viewBrowseHomebrewBtn" class="is-hidden button is-rounded is-info is-very-small">Browse</span>
-                          <span id="viewHomebrewCollectionBtn" class="is-hidden button is-rounded is-info is-very-small">Go To Collection</span>
-                        </div>
-                      </div>
-                    </div>
-                </div>
-
-            </div>
-            <div class="column is-4">
-
-                <div class="pb-2">
-                    <h4>Variants</h4>
-                </div>
-
-                <div id="variantsColumn" class="columns is-mobile first-page-split-container is-top my-1 use-custom-scrollbar">
-                    <div class="column is-3"></div>
-                    <div class="column is-9 text-left">
-
-                        <div class="field">
-                            <input id="variantAncestryParagon" type="checkbox" name="variantAncestryParagon" class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch" value="1">
-                            <label for="variantAncestryParagon">Ancestry Paragon</label>
-                        </div>
-                        <div class="field">
-                            <input id="variantFreeArchetype" type="checkbox" name="variantFreeArchetype" class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch" value="1">
-                            <label for="variantFreeArchetype">Free Archetype</label>
-                        </div>
-                        <div class="field">
-                            <input id="variantGradualAbilityBoosts" type="checkbox" name="variantGradualAbilityBoosts" class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch" value="1">
-                            <label for="variantGradualAbilityBoosts">Gradual Ability Boosts</label>
-                        </div>
-                        <div class="field">
-                            <input id="variantStamina" type="checkbox" name="variantStamina" class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch" value="1">
-                            <label for="variantStamina">Stamina</label>
-                        </div>
-
-                    </div>
-                </div>
-
-                <div class="pb-2">
-                    <h4>Options</h4>
-                </div>
-
-                <div id="optionsColumn" class="columns is-mobile first-page-split-container is-top is-bottom my-1 use-custom-scrollbar">
-                    <div class="column is-3"></div>
-                    <div class="column is-9 text-left">
-
-                        <div class="field">
-                            <input id="optionClassArchetypes" type="checkbox" name="optionClassArchetypes" class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch" value="1">
-                            <label for="optionClassArchetypes">Class Archetypes</label>
-                        </div>
-
-                        <div class="field">
-                            <input id="optionCustomCodeBlock" type="checkbox" name="optionCustomCodeBlock" class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch" value="1">
-                            <label for="optionCustomCodeBlock">Custom Code Block</label>
-                            <p id="optionCustomCodeBlockInfo" class="help is-info is-italic text-center is-hidden">A WSC block is enabled, the code is run under Initial Stats section and sheet.</p>
-                        </div>
-
-                    </div>
-                </div>
-            </div>
-        </div>
-
-    </div>
-
-    <div id="option-custom-code-block-container" class="box p-0 is-hidden">
-      <div class="field pos-relative">
-        <label class="label">
-          <span class="is-size-5 has-txt-listing">Custom Code</span>
-          <a href="/wsc_docs/#code_basics" target="_blank" class="pl-1"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-          <span class="code-block-statement-display">Builder & Sheet Statements</span>
-        </label>
-        <div class="control">
-          <textarea id="inputCustomCodeBlock" class="textarea nanum-coding use-custom-scrollbar" placeholder="Insert code here, which will be executed on the Finalize page and sheet." rows="3" spellcheck="false" maxlength="1990">{{build.customCode}}</textarea>
+        <div class="step-details is-hidden-touch">
+          <a
+            class="builder-build-publish-page-btn button is-rounded is-inverted is-info"
+          ><p class="step-title">Publish</p></a>
         </div>
       </div>
     </div>
+
+    <div class="columns is-marginless">
+      <div class="column is-4 is-offset-4">
+
+        <div class="field">
+          <div
+            id="charNameControlShell"
+            class="control has-icons-left has-icons-right"
+          >
+            <input
+              class="input"
+              type="text"
+              placeholder="Build Name"
+              spellcheck="false"
+              id="charName"
+              maxlength="28"
+              value="{{build.name}}"
+              style="text-align:center;"
+            />
+            <span class="icon is-small is-right">
+              <i
+                id="charNameSideIcon"
+                class="fas fa-exclamation-triangle is-hidden"
+              ></i>
+            </span>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+    <div class="columns is-marginless">
+      <div
+        class="column is-paddingless is-8 is-offset-2"
+        style="padding-left: 0.75rem!important; padding-right: 0.75rem!important;"
+      >
+
+        <div class="control py-1">
+          <textarea
+            id="buildDescription"
+            class="textarea use-custom-scrollbar"
+            placeholder="Build Description"
+          >{{build.description}}</textarea>
+        </div>
+
+      </div>
+    </div>
+
+    <div class="columns is-marginless py-1">
+      <div class="column is-paddingless is-8 is-offset-2 px-4">
+        <p class="has-text-left has-txt-partial-noted is-size-6-5">
+          You can write notes for specific feats you've selected by writing at
+          the end of the description, each on their own line: "{feat name}:
+          {notes}"
+        </p>
+        <p class="has-text-left has-txt-noted is-size-7 is-italic">
+          Example.
+        </p>
+        <p class="has-text-left has-txt-noted is-size-7">
+          Goblin Song: A great option for easily lowering an enemy's Perception
+          and Will saves, this can be an amazing tool in helping rogues and
+          casters alike.
+        </p>
+      </div>
+    </div>
+
+    <div class="columns is-marginless">
+      <div class="column is-4 is-offset-4">
+
+        <div class="control py-1">
+          <input
+            id="buildContactInfo"
+            class="input"
+            type="text"
+            placeholder="Contact Info"
+            autocomplete="off"
+            value="{{build.contactInfo}}"
+          />
+        </div>
+
+      </div>
+    </div>
+
+    <div class="columns is-marginless">
+      <div
+        class="column is-paddingless is-4 is-offset-4"
+        style="padding-left: 0.75rem!important; padding-right: 0.75rem!important;"
+      >
+
+        <div class="control py-1">
+          <input
+            id="buildArtworkURL"
+            class="input isURL"
+            type="text"
+            maxlength="200"
+            placeholder="Image URL"
+            spellcheck="false"
+            autocomplete="off"
+            value="{{build.artworkURL}}"
+          />
+        </div>
+
+      </div>
+    </div>
+
+  </div>
+
+  <div class="box p-2">
+
+    <div class="columns is-centered">
+      <div class="column is-4">
+        <div class="pb-2">
+          <h4>Books</h4>
+        </div>
+
+        <div
+          id="booksColumn"
+          class="columns is-mobile first-page-container my-1 use-custom-scrollbar"
+        >
+          <span
+            id="enableAllBooksBtn"
+            class="button is-tiny is-info is-outlined pos-absolute pos-t-10 pos-r-10"
+          >Enable All</span>
+          <div class="column is-3"></div>
+          <div class="column is-9 text-left">
+
+            <div class="field">
+              <input
+                id="contentSrc-CRB"
+                type="checkbox"
+                name="contentSrc-CRB"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+                disabled
+              />
+              <label for="contentSrc-CRB">
+                Core Rulebook
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-ADV-PLAYER-GUIDE"
+                type="checkbox"
+                name="contentSrc-ADV-PLAYER-GUIDE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-ADV-PLAYER-GUIDE">
+                Advanced Player’s Guide
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-GM-GUIDE"
+                type="checkbox"
+                name="contentSrc-GM-GUIDE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-GM-GUIDE">
+                Gamemastery Guide
+              </label>
+            </div>
+
+            <hr class="m-2" />
+
+            <div class="field">
+              <input
+                id="contentSrc-BOOK-OF-DEAD"
+                type="checkbox"
+                name="contentSrc-BOOK-OF-DEAD"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-BOOK-OF-DEAD">
+                Book of the Dead
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-DARK-ARCHIVE"
+                type="checkbox"
+                name="contentSrc-DARK-ARCHIVE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-DARK-ARCHIVE">
+                Dark Archive
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-GUNS-AND-GEARS"
+                type="checkbox"
+                name="contentSrc-GUNS-AND-GEARS"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-GUNS-AND-GEARS">
+                Guns & Gears
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-RAGE-OF-ELEMENTS"
+                type="checkbox"
+                name="contentSrc-RAGE-OF-ELEMENTS"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-RAGE-OF-ELEMENTS">
+                Rage of Elements
+                <sup class="is-thin">(in playtest)</sup>
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-SECRETS-OF-MAGIC"
+                type="checkbox"
+                name="contentSrc-SECRETS-OF-MAGIC"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-SECRETS-OF-MAGIC">
+                Secrets of Magic
+              </label>
+            </div>
+
+            <div class="pl-4">
+              <p>Lost Omens</p>
+            </div>
+            <hr class="mt-0 mb-2 mx-2" />
+            <div class="field">
+              <input
+                id="contentSrc-LOST-ANCESTRY-GUIDE"
+                type="checkbox"
+                name="contentSrc-LOST-ANCESTRY-GUIDE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-ANCESTRY-GUIDE">
+                Ancestry Guide
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-CHAR-GUIDE"
+                type="checkbox"
+                name="contentSrc-LOST-CHAR-GUIDE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-CHAR-GUIDE">
+                Character Guide
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-CITY-ABSALOM"
+                type="checkbox"
+                name="contentSrc-LOST-CITY-ABSALOM"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-CITY-ABSALOM">
+                City of Absalom
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-GOD-MAGIC"
+                type="checkbox"
+                name="contentSrc-LOST-GOD-MAGIC"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-GOD-MAGIC">
+                Gods & Magic
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-GRAND-BAZAAR"
+                type="checkbox"
+                name="contentSrc-LOST-GRAND-BAZAAR"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-GRAND-BAZAAR">
+                Grand Bazaar
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-IMPOSSIBLE-LANDS"
+                type="checkbox"
+                name="contentSrc-LOST-IMPOSSIBLE-LANDS"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-IMPOSSIBLE-LANDS">
+                Impossible Lands
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-KNIGHTS-WALL"
+                type="checkbox"
+                name="contentSrc-LOST-KNIGHTS-WALL"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-KNIGHTS-WALL">
+                Knights of Lastwall
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-LEGENDS"
+                type="checkbox"
+                name="contentSrc-LOST-LEGENDS"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-LEGENDS">
+                Legends
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-MONSTERS-MYTH"
+                type="checkbox"
+                name="contentSrc-LOST-MONSTERS-MYTH"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-MONSTERS-MYTH">
+                Monsters of Myth
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-MWANGI"
+                type="checkbox"
+                name="contentSrc-LOST-MWANGI"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-MWANGI">
+                The Mwangi Expanse
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-SOCIETY-GUIDE"
+                type="checkbox"
+                name="contentSrc-LOST-SOCIETY-GUIDE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-SOCIETY-GUIDE">
+                Pathfinder Society Guide
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-TRAVEL-GUIDE"
+                type="checkbox"
+                name="contentSrc-LOST-TRAVEL-GUIDE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-TRAVEL-GUIDE">
+                Travel Guide
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-WORLD-GUIDE"
+                type="checkbox"
+                name="contentSrc-LOST-WORLD-GUIDE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-WORLD-GUIDE">
+                World Guide
+              </label>
+            </div>
+
+            <div class="pl-4">
+              <p>Adventure Paths</p>
+            </div>
+            <hr class="mt-0 mb-2 mx-2" />
+
+            <div class="field">
+              <input
+                id="contentSrc-ABOMINATION-VAULTS"
+                type="checkbox"
+                name="contentSrc-ABOMINATION-VAULTS"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-ABOMINATION-VAULTS">
+                Abomination Vaults
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-AGENTS-OF-EDGEWATCH"
+                type="checkbox"
+                name="contentSrc-AGENTS-OF-EDGEWATCH"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-AGENTS-OF-EDGEWATCH">
+                Agents of Edgewatch
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-AGE-OF-ASHES"
+                type="checkbox"
+                name="contentSrc-AGE-OF-ASHES"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-AGE-OF-ASHES">
+                Age of Ashes
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-BLOOD-LORDS"
+                type="checkbox"
+                name="contentSrc-BLOOD-LORDS"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-BLOOD-LORDS">
+                Blood Lords
+                <sup class="is-thin">(in progress)</sup>
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-EXTINCTION-CURSE"
+                type="checkbox"
+                name="contentSrc-EXTINCTION-CURSE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-EXTINCTION-CURSE">
+                Extinction Curse
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-FIST-PHOENIX"
+                type="checkbox"
+                name="contentSrc-FIST-PHOENIX"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-FIST-PHOENIX">
+                Fists of the Ruby Phoenix
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-KINGMAKER"
+                type="checkbox"
+                name="contentSrc-KINGMAKER"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-KINGMAKER">
+                Kingmaker
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-OUTLAWS-ALKENSTAR"
+                type="checkbox"
+                name="contentSrc-OUTLAWS-ALKENSTAR"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-OUTLAWS-ALKENSTAR">
+                Outlaws of Alkenstar
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-QUEST-FROZEN-FLAME"
+                type="checkbox"
+                name="contentSrc-QUEST-FROZEN-FLAME"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-QUEST-FROZEN-FLAME">
+                Quest for the Frozen Flame
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-STRENGTH-THOUSANDS"
+                type="checkbox"
+                name="contentSrc-STRENGTH-THOUSANDS"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-STRENGTH-THOUSANDS">
+                Strength of Thousands
+              </label>
+            </div>
+
+            <div class="pl-4">
+              <p>Standalone Adventures</p>
+            </div>
+            <hr class="mt-0 mb-2 mx-2" />
+            <div class="field">
+              <input
+                id="contentSrc-CROWN-OF-KOBOLD-KING"
+                type="checkbox"
+                name="contentSrc-CROWN-OF-KOBOLD-KING"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-CROWN-OF-KOBOLD-KING">
+                Crown of the Kobold King
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-FALL-OF-PLAGUE"
+                type="checkbox"
+                name="contentSrc-FALL-OF-PLAGUE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-FALL-OF-PLAGUE">
+                The Fall of Plaguestone
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-MALEVOLENCE"
+                type="checkbox"
+                name="contentSrc-MALEVOLENCE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-MALEVOLENCE">
+                Malevolence
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-NIGHT-GRAY-DEATH"
+                type="checkbox"
+                name="contentSrc-NIGHT-GRAY-DEATH"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-NIGHT-GRAY-DEATH">
+                Night of the Gray Death
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-SLITHERING"
+                type="checkbox"
+                name="contentSrc-SLITHERING"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-SLITHERING">
+                The Slithering
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-THRESHOLD-KNOWLEDGE"
+                type="checkbox"
+                name="contentSrc-THRESHOLD-KNOWLEDGE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-THRESHOLD-KNOWLEDGE">
+                Threshold of Knowledge
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-TROUBLES-IN-OTARI"
+                type="checkbox"
+                name="contentSrc-TROUBLES-IN-OTARI"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-TROUBLES-IN-OTARI">
+                Troubles in Otari
+              </label>
+            </div>
+
+            <div class="pl-4">
+              <p>Other</p>
+            </div>
+            <hr class="mt-0 mb-2 mx-2" />
+            <div class="field">
+              <input
+                id="contentSrc-PATH-SOCIETY"
+                type="checkbox"
+                name="contentSrc-PATH-SOCIETY"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-PATH-SOCIETY">
+                Pathfinder Society - Extras
+              </label>
+            </div>
+
+          </div>
+        </div>
+      </div>
+      <div class="column is-4" style="position: relative;">
+        <div class="pb-2">
+          <h4>Homebrew</h4>
+          <span
+            id="noHomebrewMessage"
+            class="is-hidden is-size-7 has-txt-noted is-italic has-text-centered"
+          >Your homebrew collection is empty.</span>
+        </div>
+
+        <div
+          id="homebrewColumn"
+          class="columns is-mobile first-page-container my-1 use-custom-scrollbar"
+        >
+          <div class="column is-3"></div>
+          <div class="column is-9 text-left">
+            <div id="homebrewCollectionContainer"></div>
+            <div style="position: absolute; left: 50%;">
+              <div style="position: relative; left: -50%;">
+                <span
+                  id="viewBrowseHomebrewBtn"
+                  class="is-hidden button is-rounded is-info is-very-small"
+                >Browse</span>
+                <span
+                  id="viewHomebrewCollectionBtn"
+                  class="is-hidden button is-rounded is-info is-very-small"
+                >Go To Collection</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+      <div class="column is-4">
+
+        <div class="pb-2">
+          <h4>Variants</h4>
+        </div>
+
+        <div
+          id="variantsColumn"
+          class="columns is-mobile first-page-split-container is-top my-1 use-custom-scrollbar"
+        >
+          <div class="column is-3"></div>
+          <div class="column is-9 text-left">
+
+            <div class="field">
+              <input
+                id="variantAncestryParagon"
+                type="checkbox"
+                name="variantAncestryParagon"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch"
+                value="1"
+              />
+              <label for="variantAncestryParagon">Ancestry Paragon</label>
+            </div>
+            <div class="field">
+              <input
+                id="variantFreeArchetype"
+                type="checkbox"
+                name="variantFreeArchetype"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch"
+                value="1"
+              />
+              <label for="variantFreeArchetype">Free Archetype</label>
+            </div>
+            <div class="field">
+              <input
+                id="variantGradualAbilityBoosts"
+                type="checkbox"
+                name="variantGradualAbilityBoosts"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch"
+                value="1"
+              />
+              <label for="variantGradualAbilityBoosts">Gradual Ability Boosts</label>
+            </div>
+            <div class="field">
+              <input
+                id="variantStamina"
+                type="checkbox"
+                name="variantStamina"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch"
+                value="1"
+              />
+              <label for="variantStamina">Stamina</label>
+            </div>
+
+          </div>
+        </div>
+
+        <div class="pb-2">
+          <h4>Options</h4>
+        </div>
+
+        <div
+          id="optionsColumn"
+          class="columns is-mobile first-page-split-container is-top is-bottom my-1 use-custom-scrollbar"
+        >
+          <div class="column is-3"></div>
+          <div class="column is-9 text-left">
+
+            <div class="field">
+              <input
+                id="optionClassArchetypes"
+                type="checkbox"
+                name="optionClassArchetypes"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch"
+                value="1"
+              />
+              <label for="optionClassArchetypes">Class Archetypes</label>
+            </div>
+
+            <div class="field">
+              <input
+                id="optionCustomCodeBlock"
+                type="checkbox"
+                name="optionCustomCodeBlock"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch"
+                value="1"
+              />
+              <label for="optionCustomCodeBlock">Custom Code Block</label>
+              <p
+                id="optionCustomCodeBlockInfo"
+                class="help is-info is-italic text-center is-hidden"
+              >A WSC block is enabled, the code is run under Initial Stats
+                section and sheet.</p>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div id="option-custom-code-block-container" class="box p-0 is-hidden">
+    <div class="field pos-relative">
+      <label class="label">
+        <span class="is-size-5 has-txt-listing">Custom Code</span>
+        <a href="/wsc_docs/#code_basics" target="_blank" class="pl-1"><span
+            class="icon is-small has-text-info has-tooltip-top"
+            data-tooltip="WSC Docs"
+          ><i class="fas fa-book"></i></span></a>
+        <span class="code-block-statement-display">Builder & Sheet Statements</span>
+      </label>
+      <div class="control">
+        <textarea
+          id="inputCustomCodeBlock"
+          class="textarea nanum-coding use-custom-scrollbar"
+          placeholder="Insert code here, which will be executed on the Finalize page and sheet."
+          rows="3"
+          spellcheck="false"
+          maxlength="1990"
+        >{{build.customCode}}</textarea>
+      </div>
+    </div>
+  </div>
 
 </div>

--- a/views/builds/builds.handlebars
+++ b/views/builds/builds.handlebars
@@ -1,110 +1,124 @@
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/homebrew.css" />
+  <link rel="stylesheet" href="/css/build-planner.css" />
+  <link rel="stylesheet" href="/css/browse.css" />
+{{/section}}
 
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/homebrew.css">
-    <link rel="stylesheet" href="/css/build-planner.css">
-    <link rel="stylesheet" href="/css/browse.css">
+{{#section "header"}}
+  <script src="/js/builds/general-builds.js"></script>
+  <script src="/js/builds/user-content.js"></script>
+  <script src="/js/builds/builds-browse.js"></script>
+  <script src="/js/browse/browse-utils.js"></script>
 
-    <script src="/js/builds/general-builds.js"></script>
-    <script src="/js/builds/user-content.js"></script>
-    <script src="/js/builds/builds-browse.js"></script>
-    <script src="/js/browse/browse-utils.js"></script>
+  <script src="/js/libraries/display_class/display-class.js"></script>
+  <script src="/js/libraries/display_ancestry/display-ancestry.js"></script>
+  <script src="/js/libraries/display_archetype/display-archetype.js"></script>
+  <script src="/js/libraries/display_background/display-background.js"></script>
+  <script
+    src="/js/libraries/display_uni_heritage/display-uni-heritage.js"
+  ></script>
 
-    <script src="/js/libraries/display_class/display-class.js"></script>
-    <script src="/js/libraries/display_ancestry/display-ancestry.js"></script>
-    <script src="/js/libraries/display_archetype/display-archetype.js"></script>
-    <script src="/js/libraries/display_background/display-background.js"></script>
-    <script src="/js/libraries/display_uni_heritage/display-uni-heritage.js"></script>
+  <script src="/js/builds/build-view.js"></script>
 
-    <script src="/js/builds/build-view.js"></script>
+  <script src="/js/libraries/confirm_message/confirm-message.js"></script>
 
-    <script src="/js/libraries/confirm_message/confirm-message.js"></script>
+  <!-- Quickview -->
+  <script src="/js/sheet/quickviews/_quickviews.js"></script>
+  <script src="/js/sheet/quickviews/feat-view.js"></script>
+  <script src="/js/sheet/quickviews/language-view.js"></script>
+  <script src="/js/sheet/quickviews/spell-view.js"></script>
+  <script src="/js/sheet/quickviews/item-view.js"></script>
+  <script src="/js/sheet/quickviews/tag-view.js"></script>
+  <script src="/js/sheet/quickviews/ability-view.js"></script>
+  <script src="/js/sheet/quickviews/condition-view.js"></script>
+  <script src="/js/sheet/quickviews/warnings-view.js"></script>
+  <script src="/js/sheet/utils/item-utils.js"></script>
+  <script src="/js/sheet/utils/material-utils.js"></script>
+  <script src="/js/wsc/text-processing.js"></script>
+  <script src="/js/wsc/add-text-processing.js"></script>
+  <script src="/js/wsc/expression-utils.js"></script>
 
-    <!-- Quickview -->
-    <script src="/js/sheet/quickviews/_quickviews.js"></script>
-    <script src="/js/sheet/quickviews/feat-view.js"></script>
-    <script src="/js/sheet/quickviews/language-view.js"></script>
-    <script src="/js/sheet/quickviews/spell-view.js"></script>
-    <script src="/js/sheet/quickviews/item-view.js"></script>
-    <script src="/js/sheet/quickviews/tag-view.js"></script>
-    <script src="/js/sheet/quickviews/ability-view.js"></script>
-    <script src="/js/sheet/quickviews/condition-view.js"></script>
-    <script src="/js/sheet/quickviews/warnings-view.js"></script>
-    <script src="/js/sheet/utils/item-utils.js"></script>
-    <script src="/js/sheet/utils/material-utils.js"></script>
-    <script src="/js/wsc/text-processing.js"></script>
-    <script src="/js/wsc/add-text-processing.js"></script>
-    <script src="/js/wsc/expression-utils.js"></script>
-
-    <!-- Discord Widget Bot -->
-    <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
-      new Crate({
-        server: '735260060682289254',
-        channel: '735260060682289257'
-      })
-    </script>
+  <!-- Discord Widget Bot -->
+  <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
+    new Crate({ server: '735260060682289254', channel: '735260060682289257' })
+  </script>
 
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds" class="active">Builds</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds" class="active">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
-
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
-<div id="builds-container" class="container" data-view-build-id="{{viewBuildID}}" data-direct-to-tab="{{buildTabName}}" data-user-id="{{user.id}}">
-  
+<div
+  id="builds-container"
+  class="container"
+  data-view-build-id="{{viewBuildID}}"
+  data-direct-to-tab="{{buildTabName}}"
+  data-user-id="{{user.id}}"
+>
+
   <div class="tabs is-centered is-boxed use-custom-scrollbar mb-2">
     <ul class="category-tabs">
       <li><a id="browseTab">Browse Builds</a></li>
       {{#if user}}<li><a id="userContentTab">My Builds</a></li>{{/if}}
     </ul>
   </div>
-  <div id="tabContent" class="mx-3 mb-3"></div><!-- tabContent must be empty! -->
-  <div class="subpageloader mt-5 pt-5 is-hidden"><div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div></div>
+  <div
+    id="tabContent"
+    class="mx-3 mb-3"
+  ></div><!-- tabContent must be empty! -->
+  <div class="subpageloader mt-5 pt-5 is-hidden"><div class="lds-roller"><div
+      ></div><div></div><div></div><div></div><div></div><div></div><div
+      ></div><div></div></div></div>
 
 </div>
 
-{{#section 'overlay'}}
-    <!-- Right Quickview -->
-    <div id="quickviewDefault" class="quickview">
-        <div class="quickview-header">
-            <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
-            <div class="is-inline-flex">
-                <p id="quickViewTitleRight"></p>
-                <p id="quickViewTitleClose"></p>
-            </div>
-        </div>
-        <div class="quickview-body use-custom-scrollbar">
-            <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
-            </div>
-        </div>
+{{#section "overlay"}}
+  <!-- Right Quickview -->
+  <div id="quickviewDefault" class="quickview">
+    <div class="quickview-header">
+      <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
+      <div class="is-inline-flex">
+        <p id="quickViewTitleRight"></p>
+        <p id="quickViewTitleClose"></p>
+      </div>
     </div>
+    <div class="quickview-body use-custom-scrollbar">
+      <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
+      </div>
+    </div>
+  </div>
 {{/section}}

--- a/views/char_builder/char_builder.handlebars
+++ b/views/char_builder/char_builder.handlebars
@@ -1,111 +1,242 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/char-builder.css">
-
-    <script src="/js/require-signin.js"></script>
-
-    <script type="text/javascript" src="/js/char_builders/char-builder-general.js"></script>
-    <script type="text/javascript" src="/js/char_builders/pages/page-2-ancestry.js"></script>
-    <script type="text/javascript" src="/js/char_builders/pages/page-3-background.js"></script>
-    <script type="text/javascript" src="/js/char_builders/pages/page-4-class.js"></script>
-    <script type="text/javascript" src="/js/char_builders/pages/page-5-finalize.js"></script>
-
-    <!--<script type="text/javascript" src="/js/char_builders/pages/page-v-class_2.js"></script>-->
-
-    <script type="text/javascript" src="/js/char_builders/wsc/init-processing.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-boosts.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-feats.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-class-feature.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-heritage.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-langs.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-lore.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-skills.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-profs.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-spells.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-spells-innate.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-spells-focus.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-resistances.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-domains.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-specializations.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-notes.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-charTags.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-phyFeats.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-senses.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-speeds.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-familiarity.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-keyAbility.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/wsc-scfs.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/display-structs.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/feats-selection.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/skill-manager.js"></script>
-    <script type="text/javascript" src="/js/char_builders/wsc/prereq-parser.js"></script>
-
-    <script src="/js/prof/prof-manager.js"></script>
-
-    <script type="text/javascript" src="/js/wsc/text-processing.js"></script>
-    <script type="text/javascript" src="/js/wsc/variable-processing.js"></script>
-    <script type="text/javascript" src="/js/wsc/expression-processing.js"></script>
-    <script type="text/javascript" src="/js/wsc/expression-utils.js"></script>
-    <script type="text/javascript" src="/js/wsc/statement-processing.js"></script>
-    <script type="text/javascript" src="/js/wsc/misc-feat-processing.js"></script>
-    <script type="text/javascript" src="/js/wsc/removal-processing.js"></script>
-    <script type="text/javascript" src="/js/wsc/add-text-processing.js"></script>
-    <script type="text/javascript" src="/js/wsc/errorHandling.js"></script>
-
-    <script type="text/javascript" src="/js/char_builders/top-stickies.js"></script>
-    <script type="text/javascript" src="/js/char_builders/unselected-options.js"></script>
-    <script type="text/javascript" src="/js/char_builders/utils.js"></script>
-
-    <script type="text/javascript" src="/js/char_builders/variants/dual-class.js"></script>
-    <script type="text/javascript" src="/js/char_builders/variants/free-archetype.js"></script>
-    <script type="text/javascript" src="/js/char_builders/variants/auto-bonus-progression.js"></script>
-    <script type="text/javascript" src="/js/char_builders/variants/gradual-ability-boosts.js"></script>
-    <script type="text/javascript" src="/js/char_builders/variants/class-archetypes.js"></script>
-
-    <!-- Quickview -->
-    <script type="text/javascript" src="/js/char_builders/wsc/quickview-left.js"></script>
-    <script src="/js/sheet/quickviews/_quickviews.js"></script>
-    <script src="/js/sheet/quickviews/feat-view.js"></script>
-    <script src="/js/sheet/quickviews/language-view.js"></script>
-    <script src="/js/sheet/quickviews/spell-view.js"></script>
-    <script src="/js/sheet/quickviews/item-view.js"></script>
-    <script src="/js/sheet/quickviews/tag-view.js"></script>
-    <script src="/js/sheet/quickviews/condition-view.js"></script>
-    <script src="/js/sheet/utils/item-utils.js"></script>
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/char-builder.css" />
 
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+
+  <script src="/js/require-signin.js"></script>
+
+  <script
+    type="text/javascript"
+    src="/js/char_builders/char-builder-general.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/pages/page-2-ancestry.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/pages/page-3-background.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/pages/page-4-class.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/pages/page-5-finalize.js"
+  ></script>
+
+  <!--<script type="text/javascript" src="/js/char_builders/pages/page-v-class_2.js"></script>-->
+
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/init-processing.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-boosts.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-feats.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-class-feature.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-heritage.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-langs.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-lore.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-skills.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-profs.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-spells.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-spells-innate.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-spells-focus.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-resistances.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-domains.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-specializations.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-notes.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-charTags.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-phyFeats.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-senses.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-speeds.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-familiarity.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-keyAbility.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/wsc-scfs.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/display-structs.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/feats-selection.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/skill-manager.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/prereq-parser.js"
+  ></script>
+
+  <script src="/js/prof/prof-manager.js"></script>
+
+  <script type="text/javascript" src="/js/wsc/text-processing.js"></script>
+  <script type="text/javascript" src="/js/wsc/variable-processing.js"></script>
+  <script
+    type="text/javascript"
+    src="/js/wsc/expression-processing.js"
+  ></script>
+  <script type="text/javascript" src="/js/wsc/expression-utils.js"></script>
+  <script type="text/javascript" src="/js/wsc/statement-processing.js"></script>
+  <script type="text/javascript" src="/js/wsc/misc-feat-processing.js"></script>
+  <script type="text/javascript" src="/js/wsc/removal-processing.js"></script>
+  <script type="text/javascript" src="/js/wsc/add-text-processing.js"></script>
+  <script type="text/javascript" src="/js/wsc/errorHandling.js"></script>
+
+  <script
+    type="text/javascript"
+    src="/js/char_builders/top-stickies.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/unselected-options.js"
+  ></script>
+  <script type="text/javascript" src="/js/char_builders/utils.js"></script>
+
+  <script
+    type="text/javascript"
+    src="/js/char_builders/variants/dual-class.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/variants/free-archetype.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/variants/auto-bonus-progression.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/variants/gradual-ability-boosts.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/char_builders/variants/class-archetypes.js"
+  ></script>
+
+  <!-- Quickview -->
+  <script
+    type="text/javascript"
+    src="/js/char_builders/wsc/quickview-left.js"
+  ></script>
+  <script src="/js/sheet/quickviews/_quickviews.js"></script>
+  <script src="/js/sheet/quickviews/feat-view.js"></script>
+  <script src="/js/sheet/quickviews/language-view.js"></script>
+  <script src="/js/sheet/quickviews/spell-view.js"></script>
+  <script src="/js/sheet/quickviews/item-view.js"></script>
+  <script src="/js/sheet/quickviews/tag-view.js"></script>
+  <script src="/js/sheet/quickviews/condition-view.js"></script>
+  <script src="/js/sheet/utils/item-utils.js"></script>
+
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters" class="active">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+      class="active"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
 
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="">
@@ -126,76 +257,104 @@
 </div>
 
 <div class="pageloader is-hidden">
-    <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+  <div class="lds-roller"><div></div><div></div><div></div><div></div><div
+    ></div><div></div><div></div><div></div></div>
 </div>
 
 <div class="sticky_buttons_shell sticky_button_left">
   <button class="button is-info is-rounded sticky_button" id="prevButton">
-      <span class="icon">
-          <i class="fas fa-arrow-left"></i>
-      </span>
+    <span class="icon">
+      <i class="fas fa-arrow-left"></i>
+    </span>
   </button>
 </div>
 
 <div class="sticky_buttons_shell sticky_button_right">
   <button class="button is-info is-rounded sticky_button" id="nextButton">
-      <span class="icon">
-          <i class="fas fa-arrow-right"></i>
-      </span>
+    <span class="icon">
+      <i class="fas fa-arrow-right"></i>
+    </span>
   </button>
 </div>
 
 <div class="sticky_buttons_shell sticky_button_right is-hidden">
-    <span class="icon is-medium has-text-info cursor-clickable sticky_button" id="goToCharBigButton">
-        <i class="fas fa-address-card" style="font-size: 2.75em;"></i>
-    </span>
+  <span
+    class="icon is-medium has-text-info cursor-clickable sticky_button"
+    id="goToCharBigButton"
+  >
+    <i class="fas fa-address-card" style="font-size: 2.75em;"></i>
+  </span>
 </div>
 
 <div class="sticky_buttons_shell sticky_button_leftest">
-  <span class="icon is-medium has-text-info cursor-clickable sticky_button is-upper has-tooltip-right" data-tooltip="View Character Stats" id="leftQuickviewButton">
-      <i class="fas fa-2x fa-chart-bar"></i>
+  <span
+    class="icon is-medium has-text-info cursor-clickable sticky_button is-upper has-tooltip-right"
+    data-tooltip="View Character Stats"
+    id="leftQuickviewButton"
+  >
+    <i class="fas fa-2x fa-chart-bar"></i>
   </span>
 </div>
 
 {{#if isPlayable}}
-    <div class="sticky_buttons_shell sticky_button_rightest">
-        <span class="icon is-medium has-text-info cursor-clickable sticky_button is-upper has-tooltip-left" data-tooltip="Go To Sheet" id="goToCharButton">
-            <i class="fas fa-2x fa-address-card"></i>
-        </span>
-    </div>
+  <div class="sticky_buttons_shell sticky_button_rightest">
+    <span
+      class="icon is-medium has-text-info cursor-clickable sticky_button is-upper has-tooltip-left"
+      data-tooltip="Go To Sheet"
+      id="goToCharButton"
+    >
+      <i class="fas fa-2x fa-address-card"></i>
+    </span>
+  </div>
 {{/if}}
 
-<div id="char-builder-container" data-char-id="{{character.id}}" data-page-num="{{pageNum}}">
+<div
+  id="char-builder-container"
+  data-char-id="{{character.id}}"
+  data-page-num="{{pageNum}}"
+>
   <!-- Builder Content -->
 </div>
 
-{{#section 'overlay'}}
-    <!-- Right Quickview -->
-    <div id="quickviewDefault" class="quickview">
-        <div class="quickview-header">
-            <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
-            <div class="is-inline-flex">
-                <p id="quickViewTitleRight"></p>
-                <p id="quickViewTitleClose"></p>
-            </div>
-        </div>
-        <div class="quickview-body use-custom-scrollbar">
-            <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
-            </div>
-        </div>
+{{#section "overlay"}}
+  <!-- Right Quickview -->
+  <div id="quickviewDefault" class="quickview">
+    <div class="quickview-header">
+      <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
+      <div class="is-inline-flex">
+        <p id="quickViewTitleRight"></p>
+        <p id="quickViewTitleClose"></p>
+      </div>
     </div>
+    <div class="quickview-body use-custom-scrollbar">
+      <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
+      </div>
+    </div>
+  </div>
 
-    <!-- Left Quickview -->
-    <div id="quickviewLeftDefault" class="quickview is-left" data-str-base="{{charAbilities.STR}}" data-dex-base="{{charAbilities.DEX}}" data-con-base="{{charAbilities.CON}}" data-int-base="{{charAbilities.INT}}" data-wis-base="{{charAbilities.WIS}}" data-cha-base="{{charAbilities.CHA}}">
-        <div class="quickview-header">
-            <p id="quickViewLeftTitle" class="title is-size-5 has-txt-value-number"></p>
-            <div class="is-inline-flex">
-                <p id="quickViewLeftTitleClose"></p>
-            </div>
-        </div>
-        <div class="quickview-body use-custom-scrollbar">
-            <div id="quickViewLeftContent" class="quickview-block pt-1 pb-3 px-3">
-            </div>
-        </div>
+  <!-- Left Quickview -->
+  <div
+    id="quickviewLeftDefault"
+    class="quickview is-left"
+    data-str-base="{{charAbilities.STR}}"
+    data-dex-base="{{charAbilities.DEX}}"
+    data-con-base="{{charAbilities.CON}}"
+    data-int-base="{{charAbilities.INT}}"
+    data-wis-base="{{charAbilities.WIS}}"
+    data-cha-base="{{charAbilities.CHA}}"
+  >
+    <div class="quickview-header">
+      <p
+        id="quickViewLeftTitle"
+        class="title is-size-5 has-txt-value-number"
+      ></p>
+      <div class="is-inline-flex">
+        <p id="quickViewLeftTitleClose"></p>
+      </div>
     </div>
+    <div class="quickview-body use-custom-scrollbar">
+      <div id="quickViewLeftContent" class="quickview-block pt-1 pb-3 px-3">
+      </div>
+    </div>
+  </div>
 {{/section}}

--- a/views/char_builder/char_builder_init.handlebars
+++ b/views/char_builder/char_builder_init.handlebars
@@ -1,63 +1,76 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/char-builder.css">
-    <script type="text/javascript" src="/js/char_builders/char-builder-init.js"></script>
-
-    <script src="/js/require-signin.js"></script>
-
-    <script src="/js/libraries/confirm_message/confirm-message.js"></script>
-    
-    <script type="text/javascript" src="/js/wsc/text-processing.js"></script>
-    <script type="text/javascript" src="/js/wsc/errorHandling.js"></script>
-
-    <script type="text/javascript" src="/js/char_builders/top-stickies.js"></script>
-    <script type="text/javascript" src="/js/char_builders/utils.js"></script>
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/char-builder.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script
+    type="text/javascript"
+    src="/js/char_builders/char-builder-init.js"
+  ></script>
+
+  <script src="/js/require-signin.js"></script>
+
+  <script src="/js/libraries/confirm_message/confirm-message.js"></script>
+
+  <script type="text/javascript" src="/js/wsc/text-processing.js"></script>
+  <script type="text/javascript" src="/js/wsc/errorHandling.js"></script>
+
+  <script
+    type="text/javascript"
+    src="/js/char_builders/top-stickies.js"
+  ></script>
+  <script type="text/javascript" src="/js/char_builders/utils.js"></script>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters" class="active">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+      class="active"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
 
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="pageloader">
-    <div class="lds-roller" style="margin-bottom: 20%;"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+  <div class="lds-roller" style="margin-bottom: 20%;"><div></div><div></div><div
+    ></div><div></div><div></div><div></div><div></div><div></div></div>
 </div>
 
 <div class="sticky_buttons_shell sticky_button_right">
-    <button class="button is-info is-rounded sticky_button" id="nextButton">
-        <span class="icon">
-            <i class="fas fa-arrow-right"></i>
-        </span>
-    </button>
+  <button class="button is-info is-rounded sticky_button" id="nextButton">
+    <span class="icon">
+      <i class="fas fa-arrow-right"></i>
+    </span>
+  </button>
 </div>
 
 <div id="char-builder-container" data-char-id="{{character.id}}">
@@ -65,654 +78,1200 @@
 
 <div id="char-builder" class="container py-4 text-center">
 
-    <div id="errorDisplay" class="hero is-danger is-hidden">
-        <div class="hero-body is-paddingless py-3">
-            <div id="errorMessage" class="container"></div>
+  <div id="errorDisplay" class="hero is-danger is-hidden">
+    <div class="hero-body is-paddingless py-3">
+      <div id="errorMessage" class="container"></div>
+    </div>
+  </div>
+
+  <div class="box">
+
+    <h1 class="title is-2 has-txt-listing">Character Builder</h1>
+
+    <div class="steps">
+      <div class="step-item is-active is-info">
+        <div class="step-marker">
+          <a class="builder-basics-page-btn"><span class="icon"><i
+                class="fas fa-home-alt"
+              ></i></span></a>
         </div>
+        <div class="step-details is-hidden-touch">
+          <a
+            class="builder-basics-page-btn button is-rounded is-inverted is-info"
+          ><p class="step-title">Home</p></a>
+        </div>
+      </div>
+      <div class="step-item is-builder-type-by-abc">
+        <div class="step-marker"><a class="builder-ancestry-page-btn"><span
+              class="has-text-bck-color"
+            >A</span></a></div>
+        <div class="step-details is-hidden-touch">
+          <a
+            class="builder-ancestry-page-btn button is-rounded is-inverted is-info"
+          ><p class="step-title">Ancestry</p></a>
+        </div>
+      </div>
+      <div class="step-item is-builder-type-by-abc">
+        <div class="step-marker"><a class="builder-background-page-btn"><span
+              class="has-text-bck-color"
+            >B</span></a></div>
+        <div class="step-details is-hidden-touch">
+          <a
+            class="builder-background-page-btn button is-rounded is-inverted is-info"
+          ><p class="step-title">Background</p></a>
+        </div>
+      </div>
+      <div class="step-item is-builder-type-by-abc">
+        <div class="step-marker"><a class="builder-class-page-btn"><span
+              class="has-text-bck-color"
+            >C</span></a></div>
+        <div class="step-details is-hidden-touch">
+          <a
+            class="builder-class-page-btn button is-rounded is-inverted is-info"
+          ><p class="step-title">Class</p></a>
+        </div>
+      </div>
+      <div class="step-item is-builder-type-by-level">
+        <div class="step-marker"><a class="builder-ancestry-page-btn"><span
+              class="has-text-bck-color"
+            >C</span></a></div>
+        <div class="step-details is-hidden-touch">
+          <a
+            class="builder-ancestry-page-btn button is-rounded is-inverted is-info"
+          ><p class="step-title">Creation</p></a>
+        </div>
+      </div>
+      <div class="step-item">
+        <div class="step-marker">
+          <a class="builder-finalize-page-btn"><span
+              class="has-text-bck-color icon"
+            ><i class="fa fa-user-alt"></i></span></a>
+        </div>
+        <div class="step-details is-hidden-touch">
+          <a
+            class="builder-finalize-page-btn button is-rounded is-inverted is-info"
+          ><p class="step-title">Sheet</p></a>
+        </div>
+      </div>
     </div>
 
-    <div class="box">
+    <div class="columns py-2 pos-relative">
 
-        <h1 class="title is-2 has-txt-listing">Character Builder</h1>
+      <div class="pos-absolute pos-b-5 pos-l-5">
+        <h6>Campaign</h6>
 
-        <div class="steps">
-            <div class="step-item is-active is-info">
-                <div class="step-marker">
-                <a class="builder-basics-page-btn"><span class="icon"><i class="fas fa-home-alt"></i></span></a>
-                </div>
-                <div class="step-details is-hidden-touch">
-                    <a class="builder-basics-page-btn button is-rounded is-inverted is-info"><p class="step-title">Home</p></a>
-                </div>
+        <div id="campaign-container-join">
+          <div
+            class="field has-addons has-addons-centered"
+            style="width: 137px;"
+          >
+            <div class="control">
+              <input
+                id="campaign-access-code-input"
+                class="input is-info is-very-small"
+                type="text"
+                maxlength="15"
+                spellcheck="false"
+                autocomplete="off"
+                placeholder="Access Code"
+              />
             </div>
-            <div class="step-item is-builder-type-by-abc">
-                <div class="step-marker"><a class="builder-ancestry-page-btn"><span class="has-text-bck-color">A</span></a></div>
-                <div class="step-details is-hidden-touch">
-                    <a class="builder-ancestry-page-btn button is-rounded is-inverted is-info"><p class="step-title">Ancestry</p></a>
-                </div>
+            <div class="control">
+              <button
+                id="campaign-access-code-btn"
+                type="submit"
+                class="button is-very-small is-info is-rounded is-outlined"
+              >Join</button>
             </div>
-            <div class="step-item is-builder-type-by-abc">
-                <div class="step-marker"><a class="builder-background-page-btn"><span class="has-text-bck-color">B</span></a></div>
-                <div class="step-details is-hidden-touch">
-                    <a class="builder-background-page-btn button is-rounded is-inverted is-info"><p class="step-title">Background</p></a>
-                </div>
+          </div>
+        </div>
+        <div id="campaign-container-leave" class="is-hidden">
+          <div
+            class="field has-addons has-addons-centered"
+            style="width: 137px;"
+          >
+            <div class="control text-overflow-ellipsis" style="cursor: text;">
+              <button
+                id="campaign-name"
+                class="button is-static is-very-small is-extra border-darker"
+                style="user-select: text;"
+              >
+              </button>
             </div>
-            <div class="step-item is-builder-type-by-abc">
-                <div class="step-marker"><a class="builder-class-page-btn"><span class="has-text-bck-color">C</span></a></div>
-                <div class="step-details is-hidden-touch">
-                    <a class="builder-class-page-btn button is-rounded is-inverted is-info"><p class="step-title">Class</p></a>
-                </div>
+            <div class="control">
+              <button
+                id="campaign-leave-btn"
+                type="submit"
+                class="button is-very-small is-danger is-rounded is-outlined"
+              >
+                <span class="icon is-small">
+                  <i class="fas fa-times"></i>
+                </span>
+              </button>
             </div>
-            <div class="step-item is-builder-type-by-level">
-                <div class="step-marker"><a class="builder-ancestry-page-btn"><span class="has-text-bck-color">C</span></a></div>
-                <div class="step-details is-hidden-touch">
-                    <a class="builder-ancestry-page-btn button is-rounded is-inverted is-info"><p class="step-title">Creation</p></a>
-                </div>
-            </div>
-            <div class="step-item">
-                <div class="step-marker">
-                <a class="builder-finalize-page-btn"><span class="has-text-bck-color icon"><i class="fa fa-user-alt"></i></span></a>
-                </div>
-                <div class="step-details is-hidden-touch">
-                    <a class="builder-finalize-page-btn button is-rounded is-inverted is-info"><p class="step-title">Sheet</p></a>
-                </div>
-            </div>
+          </div>
         </div>
 
-        <div class="columns py-2 pos-relative">
+      </div>
 
-            <div class="pos-absolute pos-b-5 pos-l-5">
-              <h6>Campaign</h6>
-
-              <div id="campaign-container-join">
-                <div class="field has-addons has-addons-centered" style="width: 137px;">
-                  <div class="control">
-                    <input id="campaign-access-code-input" class="input is-info is-very-small" type="text" maxlength="15" spellcheck="false" autocomplete="off" placeholder="Access Code">
-                  </div>
-                  <div class="control">
-                    <button id="campaign-access-code-btn" type="submit" class="button is-very-small is-info is-rounded is-outlined">Join</button>
-                  </div>
-                </div>
-              </div>
-              <div id="campaign-container-leave" class="is-hidden">
-                <div class="field has-addons has-addons-centered" style="width: 137px;">
-                  <div class="control text-overflow-ellipsis" style="cursor: text;">
-                    <button id="campaign-name" class="button is-static is-very-small is-extra border-darker" style="user-select: text;">
-                    </button>
-                  </div>
-                  <div class="control">
-                    <button id="campaign-leave-btn" type="submit" class="button is-very-small is-danger is-rounded is-outlined">
-                      <span class="icon is-small">
-                        <i class="fas fa-times"></i>
-                      </span>
-                    </button>
-                  </div>
-                </div>
-              </div>
-
-            </div>
-
-            <div class="pos-absolute pos-b-5 pos-r-5">
-              <h6>Build</h6>
-              <div class="control">
-                <label class="px-1 is-size-7 cursor-clickable">
-                  <input id="builder-by-abc" type="radio" name="build-type">
-                  by ABC
-                </label>
-                <label class="px-1 is-size-7 cursor-clickable">
-                  <input id="builder-by-level" type="radio" name="build-type">
-                  by Level
-                </label>
-              </div>
-            </div>
-
-            <div class="column is-4 is-offset-4">
-
-                <div class="columns">
-                    <div class="column is-10 is-paddingless p-1">
-
-                        <div>
-                            <h5>Character Name</h5>
-                        </div>
-                        <div class="field">
-                            <div id="charNameControlShell" class="control has-icons-left has-icons-right">
-                                <input class="input" type="text" placeholder="Name" spellcheck="false" id="charName" maxlength="28" value="{{character.name}}" style="text-align:center;">
-                                <span class="icon is-small is-left">
-                                    <i class="fas fa-user"></i>
-                                </span>
-                                <span class="icon is-small is-right">
-                                    <i id="charNameSideIcon" class="fas fa-exclamation-triangle is-hidden"></i>
-                                </span>
-                            </div>
-                        </div>
-                        
-                    </div>
-                    <div class="column is-paddingless p-1">
-
-                        <div>
-                            <h5>Level</h5>
-                        </div>
-                        <div class="select">
-                            <select id="charLevel" name="charLevel">
-                                <option value="1" {{chooseSelection 1 character.level}}>1</option>
-                                <option value="2" {{chooseSelection 2 character.level}}>2</option>
-                                <option value="3" {{chooseSelection 3 character.level}}>3</option>
-                                <option value="4" {{chooseSelection 4 character.level}}>4</option>
-                                <option value="5" {{chooseSelection 5 character.level}}>5</option>
-                                <option value="6" {{chooseSelection 6 character.level}}>6</option>
-                                <option value="7" {{chooseSelection 7 character.level}}>7</option>
-                                <option value="8" {{chooseSelection 8 character.level}}>8</option>
-                                <option value="9" {{chooseSelection 9 character.level}}>9</option>
-                                <option value="10" {{chooseSelection 10 character.level}}>10</option>
-                                <option value="11" {{chooseSelection 11 character.level}}>11</option>
-                                <option value="12" {{chooseSelection 12 character.level}}>12</option>
-                                <option value="13" {{chooseSelection 13 character.level}}>13</option>
-                                <option value="14" {{chooseSelection 14 character.level}}>14</option>
-                                <option value="15" {{chooseSelection 15 character.level}}>15</option>
-                                <option value="16" {{chooseSelection 16 character.level}}>16</option>
-                                <option value="17" {{chooseSelection 17 character.level}}>17</option>
-                                <option value="18" {{chooseSelection 18 character.level}}>18</option>
-                                <option value="19" {{chooseSelection 19 character.level}}>19</option>
-                                <option value="20" {{chooseSelection 20 character.level}}>20</option>
-                            </select>
-                        </div>
-
-
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <p class="is-hidden has-text-centered is-size-6-5 has-txt-partial-noted is-italic">Using <a id="character-build" style="max-width: 300px;" class="btn button-style is-info m-1"></a> Build</p>
-
-    </div>
-
-    <div class="box p-2">
-        <div>
-            <h4>Ability Scores</h4>
-            <p class="help is-info is-italic is-marginless">(usually left unchanged as 10's)</p>
-        </div>
-        <div class="d-flex justify-content-center pb-2">
-            <div class="p-1">
-                <h4>STR</h4>
-                <input class="input abilScoreSet" type="number" name="abilSTR" id="abilSTR" min="0" max="30" value="{{charAbilities.STR}}" >
-            </div>
-            <div class="p-1">
-                <h4>DEX</h4>
-                <input class="input abilScoreSet" type="number" name="abilDEX" id="abilDEX" min="0" max="30" value="{{charAbilities.DEX}}" >
-            </div>
-            <div class="p-1">
-                <h4>CON</h4>
-                <input class="input abilScoreSet" type="number" name="abilCON" id="abilCON" min="0" max="30" value="{{charAbilities.CON}}" >
-            </div>
-            <div class="p-1">
-                <h4>INT</h4>
-                <input class="input abilScoreSet" type="number" name="abilINT" id="abilINT" min="0" max="30" value="{{charAbilities.INT}}" >
-            </div>
-            <div class="p-1">
-                <h4>WIS</h4>
-                <input class="input abilScoreSet" type="number" name="abilWIS" id="abilWIS" min="0" max="30" value="{{charAbilities.WIS}}" >
-            </div>
-            <div class="p-1">
-                <h4>CHA</h4>
-                <input class="input abilScoreSet" type="number" name="abilCHA" id="abilCHA" min="0" max="30" value="{{charAbilities.CHA}}" >
-            </div>
-        </div>
-    </div>
-
-
-    <div class="box p-2">
-
-        <div class="columns is-centered">
-            <div class="column is-4">
-                <div class="pb-2">
-                    <h4>Books</h4>
-                </div>
-                
-                <div id="booksColumn" class="columns is-mobile first-page-container my-1 use-custom-scrollbar">
-                    <span id="enableAllBooksBtn" class="button is-tiny is-info is-outlined pos-absolute pos-t-10 pos-r-10">Enable All</span>
-                    <div class="column is-3"></div>
-                    <div class="column is-9 text-left">
-
-                        <div class="field">
-                            <input id="contentSrc-CRB" type="checkbox" name="contentSrc-CRB" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1" disabled>
-                            <label for="contentSrc-CRB">
-                                Core Rulebook
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-ADV-PLAYER-GUIDE" type="checkbox" name="contentSrc-ADV-PLAYER-GUIDE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-ADV-PLAYER-GUIDE">
-                                Advanced Player’s Guide
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-GM-GUIDE" type="checkbox" name="contentSrc-GM-GUIDE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-GM-GUIDE">
-                                Gamemastery Guide
-                            </label>
-                        </div>
-
-                        <hr class="m-2">
-
-                        <div class="field">
-                            <input id="contentSrc-BOOK-OF-DEAD" type="checkbox" name="contentSrc-BOOK-OF-DEAD" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-BOOK-OF-DEAD">
-                                Book of the Dead
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-DARK-ARCHIVE" type="checkbox" name="contentSrc-DARK-ARCHIVE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-DARK-ARCHIVE">
-                                Dark Archive
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-GUNS-AND-GEARS" type="checkbox" name="contentSrc-GUNS-AND-GEARS" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-GUNS-AND-GEARS">
-                                Guns & Gears
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-RAGE-OF-ELEMENTS" type="checkbox" name="contentSrc-RAGE-OF-ELEMENTS" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-RAGE-OF-ELEMENTS">
-                                Rage of Elements <sup class="is-thin">(in playtest)</sup>
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-SECRETS-OF-MAGIC" type="checkbox" name="contentSrc-SECRETS-OF-MAGIC" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-SECRETS-OF-MAGIC">
-                                Secrets of Magic
-                            </label>
-                        </div>
-
-                        <div class="pl-4">
-                            <p>Lost Omens</p>
-                        </div>
-                        <hr class="mt-0 mb-2 mx-2">
-                        <div class="field">
-                            <input id="contentSrc-LOST-ANCESTRY-GUIDE" type="checkbox" name="contentSrc-LOST-ANCESTRY-GUIDE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-ANCESTRY-GUIDE">
-                                Ancestry Guide
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-CHAR-GUIDE" type="checkbox" name="contentSrc-LOST-CHAR-GUIDE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-CHAR-GUIDE">
-                                Character Guide
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-CITY-ABSALOM" type="checkbox" name="contentSrc-LOST-CITY-ABSALOM" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-CITY-ABSALOM">
-                                City of Absalom
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-GOD-MAGIC" type="checkbox" name="contentSrc-LOST-GOD-MAGIC" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-GOD-MAGIC">
-                                Gods & Magic
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-GRAND-BAZAAR" type="checkbox" name="contentSrc-LOST-GRAND-BAZAAR" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-GRAND-BAZAAR">
-                                Grand Bazaar
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-IMPOSSIBLE-LANDS" type="checkbox" name="contentSrc-LOST-IMPOSSIBLE-LANDS" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-IMPOSSIBLE-LANDS">
-                                Impossible Lands
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-KNIGHTS-WALL" type="checkbox" name="contentSrc-LOST-KNIGHTS-WALL" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-KNIGHTS-WALL">
-                                Knights of Lastwall
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-LEGENDS" type="checkbox" name="contentSrc-LOST-LEGENDS" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-LEGENDS">
-                                Legends
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-MONSTERS-MYTH" type="checkbox" name="contentSrc-LOST-MONSTERS-MYTH" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-MONSTERS-MYTH">
-                                Monsters of Myth
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-MWANGI" type="checkbox" name="contentSrc-LOST-MWANGI" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-MWANGI">
-                                The Mwangi Expanse
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-SOCIETY-GUIDE" type="checkbox" name="contentSrc-LOST-SOCIETY-GUIDE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-SOCIETY-GUIDE">
-                                Pathfinder Society Guide
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-TRAVEL-GUIDE" type="checkbox" name="contentSrc-LOST-TRAVEL-GUIDE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-TRAVEL-GUIDE">
-                                Travel Guide
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-LOST-WORLD-GUIDE" type="checkbox" name="contentSrc-LOST-WORLD-GUIDE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-LOST-WORLD-GUIDE">
-                                World Guide
-                            </label>
-                        </div>
-
-                        <div class="pl-4">
-                            <p>Adventure Paths</p>
-                        </div>
-                        <hr class="mt-0 mb-2 mx-2">
-
-                        <div class="field">
-                            <input id="contentSrc-ABOMINATION-VAULTS" type="checkbox" name="contentSrc-ABOMINATION-VAULTS" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-ABOMINATION-VAULTS">
-                                Abomination Vaults
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-AGENTS-OF-EDGEWATCH" type="checkbox" name="contentSrc-AGENTS-OF-EDGEWATCH" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-AGENTS-OF-EDGEWATCH">
-                                Agents of Edgewatch
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-AGE-OF-ASHES" type="checkbox" name="contentSrc-AGE-OF-ASHES" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-AGE-OF-ASHES">
-                                Age of Ashes
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-BLOOD-LORDS" type="checkbox" name="contentSrc-BLOOD-LORDS" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-BLOOD-LORDS">
-                                Blood Lords <sup class="is-thin">(in progress)</sup>
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-EXTINCTION-CURSE" type="checkbox" name="contentSrc-EXTINCTION-CURSE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-EXTINCTION-CURSE">
-                                Extinction Curse
-                            </label>
-                        </div>
-                        
-                        <div class="field">
-                            <input id="contentSrc-FIST-PHOENIX" type="checkbox" name="contentSrc-FIST-PHOENIX" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-FIST-PHOENIX">
-                                Fists of the Ruby Phoenix
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-KINGMAKER" type="checkbox" name="contentSrc-KINGMAKER" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-KINGMAKER">
-                                Kingmaker
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-OUTLAWS-ALKENSTAR" type="checkbox" name="contentSrc-OUTLAWS-ALKENSTAR" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-OUTLAWS-ALKENSTAR">
-                                Outlaws of Alkenstar
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-QUEST-FROZEN-FLAME" type="checkbox" name="contentSrc-QUEST-FROZEN-FLAME" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-QUEST-FROZEN-FLAME">
-                                Quest for the Frozen Flame
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-STRENGTH-THOUSANDS" type="checkbox" name="contentSrc-STRENGTH-THOUSANDS" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-STRENGTH-THOUSANDS">
-                                Strength of Thousands
-                            </label>
-                        </div>
-
-                        <div class="pl-4">
-                            <p>Standalone Adventures</p>
-                        </div>
-                        <hr class="mt-0 mb-2 mx-2">
-                        <div class="field">
-                            <input id="contentSrc-CROWN-OF-KOBOLD-KING" type="checkbox" name="contentSrc-CROWN-OF-KOBOLD-KING" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-CROWN-OF-KOBOLD-KING">
-                                Crown of the Kobold King
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-FALL-OF-PLAGUE" type="checkbox" name="contentSrc-FALL-OF-PLAGUE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-FALL-OF-PLAGUE">
-                                The Fall of Plaguestone
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-MALEVOLENCE" type="checkbox" name="contentSrc-MALEVOLENCE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-MALEVOLENCE">
-                                Malevolence
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-NIGHT-GRAY-DEATH" type="checkbox" name="contentSrc-NIGHT-GRAY-DEATH" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-NIGHT-GRAY-DEATH">
-                                Night of the Gray Death
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-SLITHERING" type="checkbox" name="contentSrc-SLITHERING" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-SLITHERING">
-                                The Slithering
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-THRESHOLD-KNOWLEDGE" type="checkbox" name="contentSrc-THRESHOLD-KNOWLEDGE" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-THRESHOLD-KNOWLEDGE">
-                                Threshold of Knowledge
-                            </label>
-                        </div>
-
-                        <div class="field">
-                            <input id="contentSrc-TROUBLES-IN-OTARI" type="checkbox" name="contentSrc-TROUBLES-IN-OTARI" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-TROUBLES-IN-OTARI">
-                                Troubles in Otari
-                            </label>
-                        </div>
-
-
-                        <div class="pl-4">
-                            <p>Other</p>
-                        </div>
-                        <hr class="mt-0 mb-2 mx-2">
-                        <div class="field">
-                            <input id="contentSrc-PATH-SOCIETY" type="checkbox" name="contentSrc-PATH-SOCIETY" class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch" value="1">
-                            <label for="contentSrc-PATH-SOCIETY">
-                                Pathfinder Society - Extras
-                            </label>
-                        </div>
-
-                        
-
-                    </div>
-                </div>
-            </div>
-            <div class="column is-4" style="position: relative;">
-                <div class="pb-2">
-                    <h4>Homebrew</h4>
-                    <span id="noHomebrewMessage" class="is-hidden is-size-7 has-txt-noted is-italic has-text-centered">Your homebrew collection is empty.</span>
-                </div>
-
-                <div id="homebrewColumn" class="columns is-mobile first-page-container my-1 use-custom-scrollbar">
-                    <div class="column is-3"></div>
-                    <div class="column is-9 text-left">
-                      <div id="homebrewCollectionContainer"></div>
-                      <div style="position: absolute; left: 50%;">
-                        <div style="position: relative; left: -50%;">
-                          <span id="viewBrowseHomebrewBtn" class="is-hidden button is-rounded is-info is-very-small">Browse</span>
-                          <span id="viewHomebrewCollectionBtn" class="is-hidden button is-rounded is-info is-very-small">Go To Collection</span>
-                        </div>
-                      </div>
-                    </div>
-                </div>
-
-            </div>
-            <div class="column is-4">
-
-                <div class="pb-2">
-                    <h4>Variants</h4>
-                </div>
-
-                <div id="variantsColumn" class="columns is-mobile first-page-split-container is-top my-1 use-custom-scrollbar">
-                    <div class="column is-3"></div>
-                    <div class="column is-9 text-left">
-
-                        <div class="field">
-                            <input id="variantAncestryParagon" type="checkbox" name="variantAncestryParagon" class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch" value="1">
-                            <label for="variantAncestryParagon">Ancestry Paragon</label>
-                        </div>
-                        <div class="field">
-                            <input id="variantAutoBonusProgression" type="checkbox" name="variantAutoBonusProgression" class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch" value="1">
-                            <label for="variantAutoBonusProgression">Auto Bonus Progression</label>
-                        </div>
-                        <div class="field">
-                            <input id="variantFreeArchetype" type="checkbox" name="variantFreeArchetype" class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch" value="1">
-                            <label for="variantFreeArchetype">Free Archetype</label>
-                        </div>
-                        <div class="field">
-                            <input id="variantGradualAbilityBoosts" type="checkbox" name="variantGradualAbilityBoosts" class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch" value="1">
-                            <label for="variantGradualAbilityBoosts">Gradual Ability Boosts</label>
-                        </div>
-                        <div class="field">
-                            <input id="variantProficiencyWithoutLevel" type="checkbox" name="variantProficiencyWithoutLevel" class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch" value="1">
-                            <label for="variantProficiencyWithoutLevel">Proficiency Without Level</label>
-                        </div>
-                        <div class="field">
-                            <input id="variantStamina" type="checkbox" name="variantStamina" class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch" value="1">
-                            <label for="variantStamina">Stamina</label>
-                        </div>
-
-                    </div>
-                </div>
-
-                <div class="pb-2">
-                    <h4>Options</h4>
-                </div>
-
-                <div id="optionsColumn" class="columns is-mobile first-page-split-container is-top is-bottom my-1 use-custom-scrollbar">
-                    <div class="column is-3"></div>
-                    <div class="column is-9 text-left">
-
-                        <div class="field">
-                            <input id="optionPublicCharacter" type="checkbox" name="optionPublicCharacter" class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch" value="1">
-                            <label for="optionPublicCharacter">Publicly Visible</label>
-                            <p id="optionPublicCharacterInfo" class="help is-info is-italic text-center is-hidden">Anyone can view the character using the sheet URL.</p>
-                        </div>
-
-                        <div class="field">
-                            <input id="optionAltAbilityBoosts" type="checkbox" name="optionAltAbilityBoosts" class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch" value="1">
-                            <label for="optionAltAbilityBoosts">Alternative Ability Boosts</label>
-                        </div>
-
-                        <div class="field">
-                            <input id="optionAutoDetectPreReqs" type="checkbox" name="optionAutoDetectPreReqs" class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch" value="1">
-                            <label for="optionAutoDetectPreReqs">Auto-Detect Prerequisites</label>
-                        </div>
-
-                        <div class="field">
-                            <input id="optionAutoHeightenSpells" type="checkbox" name="optionAutoHeightenSpells" class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch" value="1">
-                            <label for="optionAutoHeightenSpells">Auto-Heighten Spells</label>
-                        </div>
-
-                        <div class="field">
-                            <input id="optionClassArchetypes" type="checkbox" name="optionClassArchetypes" class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch" value="1">
-                            <label for="optionClassArchetypes">Class Archetypes</label>
-                        </div>
-
-                        <div class="field">
-                            <input id="optionCustomCodeBlock" type="checkbox" name="optionCustomCodeBlock" class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch" value="1">
-                            <label for="optionCustomCodeBlock">Custom Code Block</label>
-                            <p id="optionCustomCodeBlockInfo" class="help is-info is-italic text-center is-hidden">A WSC block is enabled, the code is run under Initial Stats section and sheet.</p>
-                        </div>
-
-                        <div class="field">
-                            <input id="optionDiceRoller" type="checkbox" name="optionDiceRoller" class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch" value="1">
-                            <label for="optionDiceRoller">Dice Integration</label>
-                        </div>
-
-                        <div class="field">
-                            <input id="optionIgnoreBulk" type="checkbox" name="optionIgnoreBulk" class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch" value="1">
-                            <label for="optionIgnoreBulk">Ignore Bulk</label>
-                        </div>
-
-                    </div>
-                </div>
-            </div>
-        </div>
-
-    </div>
-
-    <div id="option-custom-code-block-container" class="box p-0 is-hidden">
-      <div class="field pos-relative">
-        <label class="label">
-          <span class="is-size-5 has-txt-listing">Custom Code</span>
-          <a href="/wsc_docs/#code_basics" target="_blank" class="pl-1"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-          <span class="code-block-statement-display">Builder & Sheet Statements</span>
-        </label>
+      <div class="pos-absolute pos-b-5 pos-r-5">
+        <h6>Build</h6>
         <div class="control">
-          <textarea id="inputCustomCodeBlock" class="textarea nanum-coding use-custom-scrollbar" placeholder="Insert code here, which will be executed on the Finalize page and sheet." rows="3" spellcheck="false" maxlength="1990">{{character.customCode}}</textarea>
+          <label class="px-1 is-size-7 cursor-clickable">
+            <input id="builder-by-abc" type="radio" name="build-type" />
+            by ABC
+          </label>
+          <label class="px-1 is-size-7 cursor-clickable">
+            <input id="builder-by-level" type="radio" name="build-type" />
+            by Level
+          </label>
+        </div>
+      </div>
+
+      <div class="column is-4 is-offset-4">
+
+        <div class="columns">
+          <div class="column is-10 is-paddingless p-1">
+
+            <div>
+              <h5>Character Name</h5>
+            </div>
+            <div class="field">
+              <div
+                id="charNameControlShell"
+                class="control has-icons-left has-icons-right"
+              >
+                <input
+                  class="input"
+                  type="text"
+                  placeholder="Name"
+                  spellcheck="false"
+                  id="charName"
+                  maxlength="28"
+                  value="{{character.name}}"
+                  style="text-align:center;"
+                />
+                <span class="icon is-small is-left">
+                  <i class="fas fa-user"></i>
+                </span>
+                <span class="icon is-small is-right">
+                  <i
+                    id="charNameSideIcon"
+                    class="fas fa-exclamation-triangle is-hidden"
+                  ></i>
+                </span>
+              </div>
+            </div>
+
+          </div>
+          <div class="column is-paddingless p-1">
+
+            <div>
+              <h5>Level</h5>
+            </div>
+            <div class="select">
+              <select id="charLevel" name="charLevel">
+                <option
+                  value="1"
+                  {{chooseSelection 1 character.level}}
+                >1</option>
+                <option
+                  value="2"
+                  {{chooseSelection 2 character.level}}
+                >2</option>
+                <option
+                  value="3"
+                  {{chooseSelection 3 character.level}}
+                >3</option>
+                <option
+                  value="4"
+                  {{chooseSelection 4 character.level}}
+                >4</option>
+                <option
+                  value="5"
+                  {{chooseSelection 5 character.level}}
+                >5</option>
+                <option
+                  value="6"
+                  {{chooseSelection 6 character.level}}
+                >6</option>
+                <option
+                  value="7"
+                  {{chooseSelection 7 character.level}}
+                >7</option>
+                <option
+                  value="8"
+                  {{chooseSelection 8 character.level}}
+                >8</option>
+                <option
+                  value="9"
+                  {{chooseSelection 9 character.level}}
+                >9</option>
+                <option
+                  value="10"
+                  {{chooseSelection 10 character.level}}
+                >10</option>
+                <option
+                  value="11"
+                  {{chooseSelection 11 character.level}}
+                >11</option>
+                <option
+                  value="12"
+                  {{chooseSelection 12 character.level}}
+                >12</option>
+                <option
+                  value="13"
+                  {{chooseSelection 13 character.level}}
+                >13</option>
+                <option
+                  value="14"
+                  {{chooseSelection 14 character.level}}
+                >14</option>
+                <option
+                  value="15"
+                  {{chooseSelection 15 character.level}}
+                >15</option>
+                <option
+                  value="16"
+                  {{chooseSelection 16 character.level}}
+                >16</option>
+                <option
+                  value="17"
+                  {{chooseSelection 17 character.level}}
+                >17</option>
+                <option
+                  value="18"
+                  {{chooseSelection 18 character.level}}
+                >18</option>
+                <option
+                  value="19"
+                  {{chooseSelection 19 character.level}}
+                >19</option>
+                <option
+                  value="20"
+                  {{chooseSelection 20 character.level}}
+                >20</option>
+              </select>
+            </div>
+
+          </div>
         </div>
       </div>
     </div>
 
-    <div class="box p-0 character-access-container is-hidden">
+    <p
+      class="is-hidden has-text-centered is-size-6-5 has-txt-partial-noted is-italic"
+    >Using
+      <a
+        id="character-build"
+        style="max-width: 300px;"
+        class="btn button-style is-info m-1"
+      ></a>
+      Build</p>
 
-      <div id="character-access-dropdown" class="columns is-mobile is-gapless is-marginless p-2 cursor-clickable">
-        <div class="column is-narrow is-2"></div>
-        <div class="column is-narrow is-8">
-          <h5>External Character Access</h5>
+  </div>
+
+  <div class="box p-2">
+    <div>
+      <h4>Ability Scores</h4>
+      <p class="help is-info is-italic is-marginless">(usually left unchanged as
+        10's)</p>
+    </div>
+    <div class="d-flex justify-content-center pb-2">
+      <div class="p-1">
+        <h4>STR</h4>
+        <input
+          class="input abilScoreSet"
+          type="number"
+          name="abilSTR"
+          id="abilSTR"
+          min="0"
+          max="30"
+          value="{{charAbilities.STR}}"
+        />
+      </div>
+      <div class="p-1">
+        <h4>DEX</h4>
+        <input
+          class="input abilScoreSet"
+          type="number"
+          name="abilDEX"
+          id="abilDEX"
+          min="0"
+          max="30"
+          value="{{charAbilities.DEX}}"
+        />
+      </div>
+      <div class="p-1">
+        <h4>CON</h4>
+        <input
+          class="input abilScoreSet"
+          type="number"
+          name="abilCON"
+          id="abilCON"
+          min="0"
+          max="30"
+          value="{{charAbilities.CON}}"
+        />
+      </div>
+      <div class="p-1">
+        <h4>INT</h4>
+        <input
+          class="input abilScoreSet"
+          type="number"
+          name="abilINT"
+          id="abilINT"
+          min="0"
+          max="30"
+          value="{{charAbilities.INT}}"
+        />
+      </div>
+      <div class="p-1">
+        <h4>WIS</h4>
+        <input
+          class="input abilScoreSet"
+          type="number"
+          name="abilWIS"
+          id="abilWIS"
+          min="0"
+          max="30"
+          value="{{charAbilities.WIS}}"
+        />
+      </div>
+      <div class="p-1">
+        <h4>CHA</h4>
+        <input
+          class="input abilScoreSet"
+          type="number"
+          name="abilCHA"
+          id="abilCHA"
+          min="0"
+          max="30"
+          value="{{charAbilities.CHA}}"
+        />
+      </div>
+    </div>
+  </div>
+
+  <div class="box p-2">
+
+    <div class="columns is-centered">
+      <div class="column is-4">
+        <div class="pb-2">
+          <h4>Books</h4>
         </div>
-        <div class="column is-narrow is-2">
-          <span class="icon cursor-clickable has-txt-listing">
-            <i id="character-access-chevron" class="fas fa-sm fa-chevron-down"></i>
-          </span>
+
+        <div
+          id="booksColumn"
+          class="columns is-mobile first-page-container my-1 use-custom-scrollbar"
+        >
+          <span
+            id="enableAllBooksBtn"
+            class="button is-tiny is-info is-outlined pos-absolute pos-t-10 pos-r-10"
+          >Enable All</span>
+          <div class="column is-3"></div>
+          <div class="column is-9 text-left">
+
+            <div class="field">
+              <input
+                id="contentSrc-CRB"
+                type="checkbox"
+                name="contentSrc-CRB"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+                disabled
+              />
+              <label for="contentSrc-CRB">
+                Core Rulebook
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-ADV-PLAYER-GUIDE"
+                type="checkbox"
+                name="contentSrc-ADV-PLAYER-GUIDE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-ADV-PLAYER-GUIDE">
+                Advanced Player’s Guide
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-GM-GUIDE"
+                type="checkbox"
+                name="contentSrc-GM-GUIDE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-GM-GUIDE">
+                Gamemastery Guide
+              </label>
+            </div>
+
+            <hr class="m-2" />
+
+            <div class="field">
+              <input
+                id="contentSrc-BOOK-OF-DEAD"
+                type="checkbox"
+                name="contentSrc-BOOK-OF-DEAD"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-BOOK-OF-DEAD">
+                Book of the Dead
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-DARK-ARCHIVE"
+                type="checkbox"
+                name="contentSrc-DARK-ARCHIVE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-DARK-ARCHIVE">
+                Dark Archive
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-GUNS-AND-GEARS"
+                type="checkbox"
+                name="contentSrc-GUNS-AND-GEARS"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-GUNS-AND-GEARS">
+                Guns & Gears
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-RAGE-OF-ELEMENTS"
+                type="checkbox"
+                name="contentSrc-RAGE-OF-ELEMENTS"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-RAGE-OF-ELEMENTS">
+                Rage of Elements
+                <sup class="is-thin">(in playtest)</sup>
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-SECRETS-OF-MAGIC"
+                type="checkbox"
+                name="contentSrc-SECRETS-OF-MAGIC"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-SECRETS-OF-MAGIC">
+                Secrets of Magic
+              </label>
+            </div>
+
+            <div class="pl-4">
+              <p>Lost Omens</p>
+            </div>
+            <hr class="mt-0 mb-2 mx-2" />
+            <div class="field">
+              <input
+                id="contentSrc-LOST-ANCESTRY-GUIDE"
+                type="checkbox"
+                name="contentSrc-LOST-ANCESTRY-GUIDE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-ANCESTRY-GUIDE">
+                Ancestry Guide
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-CHAR-GUIDE"
+                type="checkbox"
+                name="contentSrc-LOST-CHAR-GUIDE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-CHAR-GUIDE">
+                Character Guide
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-CITY-ABSALOM"
+                type="checkbox"
+                name="contentSrc-LOST-CITY-ABSALOM"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-CITY-ABSALOM">
+                City of Absalom
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-GOD-MAGIC"
+                type="checkbox"
+                name="contentSrc-LOST-GOD-MAGIC"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-GOD-MAGIC">
+                Gods & Magic
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-GRAND-BAZAAR"
+                type="checkbox"
+                name="contentSrc-LOST-GRAND-BAZAAR"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-GRAND-BAZAAR">
+                Grand Bazaar
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-IMPOSSIBLE-LANDS"
+                type="checkbox"
+                name="contentSrc-LOST-IMPOSSIBLE-LANDS"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-IMPOSSIBLE-LANDS">
+                Impossible Lands
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-KNIGHTS-WALL"
+                type="checkbox"
+                name="contentSrc-LOST-KNIGHTS-WALL"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-KNIGHTS-WALL">
+                Knights of Lastwall
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-LEGENDS"
+                type="checkbox"
+                name="contentSrc-LOST-LEGENDS"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-LEGENDS">
+                Legends
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-MONSTERS-MYTH"
+                type="checkbox"
+                name="contentSrc-LOST-MONSTERS-MYTH"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-MONSTERS-MYTH">
+                Monsters of Myth
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-MWANGI"
+                type="checkbox"
+                name="contentSrc-LOST-MWANGI"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-MWANGI">
+                The Mwangi Expanse
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-SOCIETY-GUIDE"
+                type="checkbox"
+                name="contentSrc-LOST-SOCIETY-GUIDE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-SOCIETY-GUIDE">
+                Pathfinder Society Guide
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-TRAVEL-GUIDE"
+                type="checkbox"
+                name="contentSrc-LOST-TRAVEL-GUIDE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-TRAVEL-GUIDE">
+                Travel Guide
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-LOST-WORLD-GUIDE"
+                type="checkbox"
+                name="contentSrc-LOST-WORLD-GUIDE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-LOST-WORLD-GUIDE">
+                World Guide
+              </label>
+            </div>
+
+            <div class="pl-4">
+              <p>Adventure Paths</p>
+            </div>
+            <hr class="mt-0 mb-2 mx-2" />
+
+            <div class="field">
+              <input
+                id="contentSrc-ABOMINATION-VAULTS"
+                type="checkbox"
+                name="contentSrc-ABOMINATION-VAULTS"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-ABOMINATION-VAULTS">
+                Abomination Vaults
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-AGENTS-OF-EDGEWATCH"
+                type="checkbox"
+                name="contentSrc-AGENTS-OF-EDGEWATCH"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-AGENTS-OF-EDGEWATCH">
+                Agents of Edgewatch
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-AGE-OF-ASHES"
+                type="checkbox"
+                name="contentSrc-AGE-OF-ASHES"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-AGE-OF-ASHES">
+                Age of Ashes
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-BLOOD-LORDS"
+                type="checkbox"
+                name="contentSrc-BLOOD-LORDS"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-BLOOD-LORDS">
+                Blood Lords
+                <sup class="is-thin">(in progress)</sup>
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-EXTINCTION-CURSE"
+                type="checkbox"
+                name="contentSrc-EXTINCTION-CURSE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-EXTINCTION-CURSE">
+                Extinction Curse
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-FIST-PHOENIX"
+                type="checkbox"
+                name="contentSrc-FIST-PHOENIX"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-FIST-PHOENIX">
+                Fists of the Ruby Phoenix
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-KINGMAKER"
+                type="checkbox"
+                name="contentSrc-KINGMAKER"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-KINGMAKER">
+                Kingmaker
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-OUTLAWS-ALKENSTAR"
+                type="checkbox"
+                name="contentSrc-OUTLAWS-ALKENSTAR"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-OUTLAWS-ALKENSTAR">
+                Outlaws of Alkenstar
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-QUEST-FROZEN-FLAME"
+                type="checkbox"
+                name="contentSrc-QUEST-FROZEN-FLAME"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-QUEST-FROZEN-FLAME">
+                Quest for the Frozen Flame
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-STRENGTH-THOUSANDS"
+                type="checkbox"
+                name="contentSrc-STRENGTH-THOUSANDS"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-STRENGTH-THOUSANDS">
+                Strength of Thousands
+              </label>
+            </div>
+
+            <div class="pl-4">
+              <p>Standalone Adventures</p>
+            </div>
+            <hr class="mt-0 mb-2 mx-2" />
+            <div class="field">
+              <input
+                id="contentSrc-CROWN-OF-KOBOLD-KING"
+                type="checkbox"
+                name="contentSrc-CROWN-OF-KOBOLD-KING"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-CROWN-OF-KOBOLD-KING">
+                Crown of the Kobold King
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-FALL-OF-PLAGUE"
+                type="checkbox"
+                name="contentSrc-FALL-OF-PLAGUE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-FALL-OF-PLAGUE">
+                The Fall of Plaguestone
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-MALEVOLENCE"
+                type="checkbox"
+                name="contentSrc-MALEVOLENCE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-MALEVOLENCE">
+                Malevolence
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-NIGHT-GRAY-DEATH"
+                type="checkbox"
+                name="contentSrc-NIGHT-GRAY-DEATH"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-NIGHT-GRAY-DEATH">
+                Night of the Gray Death
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-SLITHERING"
+                type="checkbox"
+                name="contentSrc-SLITHERING"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-SLITHERING">
+                The Slithering
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-THRESHOLD-KNOWLEDGE"
+                type="checkbox"
+                name="contentSrc-THRESHOLD-KNOWLEDGE"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-THRESHOLD-KNOWLEDGE">
+                Threshold of Knowledge
+              </label>
+            </div>
+
+            <div class="field">
+              <input
+                id="contentSrc-TROUBLES-IN-OTARI"
+                type="checkbox"
+                name="contentSrc-TROUBLES-IN-OTARI"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-TROUBLES-IN-OTARI">
+                Troubles in Otari
+              </label>
+            </div>
+
+            <div class="pl-4">
+              <p>Other</p>
+            </div>
+            <hr class="mt-0 mb-2 mx-2" />
+            <div class="field">
+              <input
+                id="contentSrc-PATH-SOCIETY"
+                type="checkbox"
+                name="contentSrc-PATH-SOCIETY"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch bookSwitch"
+                value="1"
+              />
+              <label for="contentSrc-PATH-SOCIETY">
+                Pathfinder Society - Extras
+              </label>
+            </div>
+
+          </div>
         </div>
       </div>
-      <div id="character-access-content" class="is-hidden"></div>
+      <div class="column is-4" style="position: relative;">
+        <div class="pb-2">
+          <h4>Homebrew</h4>
+          <span
+            id="noHomebrewMessage"
+            class="is-hidden is-size-7 has-txt-noted is-italic has-text-centered"
+          >Your homebrew collection is empty.</span>
+        </div>
+
+        <div
+          id="homebrewColumn"
+          class="columns is-mobile first-page-container my-1 use-custom-scrollbar"
+        >
+          <div class="column is-3"></div>
+          <div class="column is-9 text-left">
+            <div id="homebrewCollectionContainer"></div>
+            <div style="position: absolute; left: 50%;">
+              <div style="position: relative; left: -50%;">
+                <span
+                  id="viewBrowseHomebrewBtn"
+                  class="is-hidden button is-rounded is-info is-very-small"
+                >Browse</span>
+                <span
+                  id="viewHomebrewCollectionBtn"
+                  class="is-hidden button is-rounded is-info is-very-small"
+                >Go To Collection</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+      <div class="column is-4">
+
+        <div class="pb-2">
+          <h4>Variants</h4>
+        </div>
+
+        <div
+          id="variantsColumn"
+          class="columns is-mobile first-page-split-container is-top my-1 use-custom-scrollbar"
+        >
+          <div class="column is-3"></div>
+          <div class="column is-9 text-left">
+
+            <div class="field">
+              <input
+                id="variantAncestryParagon"
+                type="checkbox"
+                name="variantAncestryParagon"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch"
+                value="1"
+              />
+              <label for="variantAncestryParagon">Ancestry Paragon</label>
+            </div>
+            <div class="field">
+              <input
+                id="variantAutoBonusProgression"
+                type="checkbox"
+                name="variantAutoBonusProgression"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch"
+                value="1"
+              />
+              <label for="variantAutoBonusProgression">Auto Bonus Progression</label>
+            </div>
+            <div class="field">
+              <input
+                id="variantFreeArchetype"
+                type="checkbox"
+                name="variantFreeArchetype"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch"
+                value="1"
+              />
+              <label for="variantFreeArchetype">Free Archetype</label>
+            </div>
+            <div class="field">
+              <input
+                id="variantGradualAbilityBoosts"
+                type="checkbox"
+                name="variantGradualAbilityBoosts"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch"
+                value="1"
+              />
+              <label for="variantGradualAbilityBoosts">Gradual Ability Boosts</label>
+            </div>
+            <div class="field">
+              <input
+                id="variantProficiencyWithoutLevel"
+                type="checkbox"
+                name="variantProficiencyWithoutLevel"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch"
+                value="1"
+              />
+              <label for="variantProficiencyWithoutLevel">Proficiency Without
+                Level</label>
+            </div>
+            <div class="field">
+              <input
+                id="variantStamina"
+                type="checkbox"
+                name="variantStamina"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch variantSwitch"
+                value="1"
+              />
+              <label for="variantStamina">Stamina</label>
+            </div>
+
+          </div>
+        </div>
+
+        <div class="pb-2">
+          <h4>Options</h4>
+        </div>
+
+        <div
+          id="optionsColumn"
+          class="columns is-mobile first-page-split-container is-top is-bottom my-1 use-custom-scrollbar"
+        >
+          <div class="column is-3"></div>
+          <div class="column is-9 text-left">
+
+            <div class="field">
+              <input
+                id="optionPublicCharacter"
+                type="checkbox"
+                name="optionPublicCharacter"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch"
+                value="1"
+              />
+              <label for="optionPublicCharacter">Publicly Visible</label>
+              <p
+                id="optionPublicCharacterInfo"
+                class="help is-info is-italic text-center is-hidden"
+              >Anyone can view the character using the sheet URL.</p>
+            </div>
+
+            <div class="field">
+              <input
+                id="optionAltAbilityBoosts"
+                type="checkbox"
+                name="optionAltAbilityBoosts"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch"
+                value="1"
+              />
+              <label for="optionAltAbilityBoosts">Alternative Ability Boosts</label>
+            </div>
+
+            <div class="field">
+              <input
+                id="optionAutoDetectPreReqs"
+                type="checkbox"
+                name="optionAutoDetectPreReqs"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch"
+                value="1"
+              />
+              <label for="optionAutoDetectPreReqs">Auto-Detect Prerequisites</label>
+            </div>
+
+            <div class="field">
+              <input
+                id="optionAutoHeightenSpells"
+                type="checkbox"
+                name="optionAutoHeightenSpells"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch"
+                value="1"
+              />
+              <label for="optionAutoHeightenSpells">Auto-Heighten Spells</label>
+            </div>
+
+            <div class="field">
+              <input
+                id="optionClassArchetypes"
+                type="checkbox"
+                name="optionClassArchetypes"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch"
+                value="1"
+              />
+              <label for="optionClassArchetypes">Class Archetypes</label>
+            </div>
+
+            <div class="field">
+              <input
+                id="optionCustomCodeBlock"
+                type="checkbox"
+                name="optionCustomCodeBlock"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch"
+                value="1"
+              />
+              <label for="optionCustomCodeBlock">Custom Code Block</label>
+              <p
+                id="optionCustomCodeBlockInfo"
+                class="help is-info is-italic text-center is-hidden"
+              >A WSC block is enabled, the code is run under Initial Stats
+                section and sheet.</p>
+            </div>
+
+            <div class="field">
+              <input
+                id="optionDiceRoller"
+                type="checkbox"
+                name="optionDiceRoller"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch"
+                value="1"
+              />
+              <label for="optionDiceRoller">Dice Integration</label>
+            </div>
+
+            <div class="field">
+              <input
+                id="optionIgnoreBulk"
+                type="checkbox"
+                name="optionIgnoreBulk"
+                class="switch is-small is-rounded is-outlined is-info optionSwitch charOptionSwitch"
+                value="1"
+              />
+              <label for="optionIgnoreBulk">Ignore Bulk</label>
+            </div>
+
+          </div>
+        </div>
+      </div>
     </div>
+
+  </div>
+
+  <div id="option-custom-code-block-container" class="box p-0 is-hidden">
+    <div class="field pos-relative">
+      <label class="label">
+        <span class="is-size-5 has-txt-listing">Custom Code</span>
+        <a href="/wsc_docs/#code_basics" target="_blank" class="pl-1"><span
+            class="icon is-small has-text-info has-tooltip-top"
+            data-tooltip="WSC Docs"
+          ><i class="fas fa-book"></i></span></a>
+        <span class="code-block-statement-display">Builder & Sheet Statements</span>
+      </label>
+      <div class="control">
+        <textarea
+          id="inputCustomCodeBlock"
+          class="textarea nanum-coding use-custom-scrollbar"
+          placeholder="Insert code here, which will be executed on the Finalize page and sheet."
+          rows="3"
+          spellcheck="false"
+          maxlength="1990"
+        >{{character.customCode}}</textarea>
+      </div>
+    </div>
+  </div>
+
+  <div class="box p-0 character-access-container is-hidden">
+
+    <div
+      id="character-access-dropdown"
+      class="columns is-mobile is-gapless is-marginless p-2 cursor-clickable"
+    >
+      <div class="column is-narrow is-2"></div>
+      <div class="column is-narrow is-8">
+        <h5>External Character Access</h5>
+      </div>
+      <div class="column is-narrow is-2">
+        <span class="icon cursor-clickable has-txt-listing">
+          <i
+            id="character-access-chevron"
+            class="fas fa-sm fa-chevron-down"
+          ></i>
+        </span>
+      </div>
+    </div>
+    <div id="character-access-content" class="is-hidden"></div>
+  </div>
 
 </div>

--- a/views/docs/api_docs.handlebars
+++ b/views/docs/api_docs.handlebars
@@ -1,6 +1,8 @@
+{{#section 'styles'}}
+    <link rel="stylesheet" href="/css/docs-styles.css">
+{{/section}}
 
 {{#section 'header'}}
-    <link rel="stylesheet" href="/css/docs-styles.css">
     <script src="/js/wsc/docs-page.js"></script>
     <script src="/js/wsc/text-processing.js"></script>
 {{/section}}

--- a/views/docs/guidechar_docs.handlebars
+++ b/views/docs/guidechar_docs.handlebars
@@ -1,196 +1,246 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/docs-styles.css">
-    <script src="/js/wsc/docs-page.js"></script>
-    <script src="/js/wsc/text-processing.js"></script>
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/docs-styles.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script src="/js/wsc/docs-page.js"></script>
+  <script src="/js/wsc/text-processing.js"></script>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
 
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div id="doc_nav_shell">
-    <div id="docs_nav" class="ml-2 mt-2">
-        <aside class="menu">
-            <p class="menu-label">
-                <a href="/guidechar_docs/#guidechar_docs">Version Documentation</a>
-            </p>
-            <ul class="menu-list">
-                <li class="pb-1"><a href="/guidechar_docs/#version_2">Version 2 (latest)</a></li>
-                <li class="pt-1"><a href="/guidechar_docs/#version_1">Version 1</a></li>
-            </ul>
-        </aside>
-    </div>
+  <div id="docs_nav" class="ml-2 mt-2">
+    <aside class="menu">
+      <p class="menu-label">
+        <a href="/guidechar_docs/#guidechar_docs">Version Documentation</a>
+      </p>
+      <ul class="menu-list">
+        <li class="pb-1"><a href="/guidechar_docs/#version_2">Version 2 (latest)</a></li>
+        <li class="pt-1"><a href="/guidechar_docs/#version_1">Version 1</a></li>
+      </ul>
+    </aside>
+  </div>
 </div>
 
-<div id="docs_content" class="tile is-ancestor is-paddingless is-marginless mb-3">
-    <div class="tile is-parent is-2">
-        <div class="tile is-child"></div>
+<div
+  id="docs_content"
+  class="tile is-ancestor is-paddingless is-marginless mb-3"
+>
+  <div class="tile is-parent is-2">
+    <div class="tile is-child"></div>
+  </div>
+  <div class="tile is-parent is-vertical is-8">
+    <div id="guidechar_docs" class="tile is-child">
+      <h1
+        class="main-title is-size-2 is-family-code has-text-centered"
+      >Guidechar File Documentation</h1>
+      <p
+        class="subtitle is-size-6-5 has-txt-listing has-text-centered is-italic p-2"
+      >
+        This documentation is for developering looking to understand the
+        structure of guidechar files.
+      </p>
+      <p class="subtitle is-size-6-5 has-txt-listing">
+        Guidechar files are TEXT type code files that follow a minified JSON
+        file format. To open and read a file, it's recommended to use a text
+        editor (like
+        <a
+          class="has-text-info"
+          href="https://notepad-plus-plus.org/"
+          target="_blank"
+        >Notepad++</a>) and copy the contents over to a JSON formatter (such as
+        <a
+          class="has-text-info"
+          href="https://jsonformatter.org/json-pretty-print"
+          target="_blank"
+        >JSON Pretty Print</a>).
+      </p>
+      <p class="subtitle is-size-6-5 has-txt-listing">
+        When explaining the file structure, not all data will be covered - just
+        the most important data worth noting.
+      </p>
     </div>
-    <div class="tile is-parent is-vertical is-8">
-        <div id="guidechar_docs" class="tile is-child">
-            <h1 class="main-title is-size-2 is-family-code has-text-centered">Guidechar File Documentation</h1>
-            <p class="subtitle is-size-6-5 has-txt-listing has-text-centered is-italic p-2">
-              This documentation is for developering looking to understand the structure of guidechar files.
-            </p>
-            <p class="subtitle is-size-6-5 has-txt-listing">
-              Guidechar files are TEXT type code files that follow a minified JSON file format. To open and read a file, it's recommended to use a text editor (like <a class="has-text-info" href="https://notepad-plus-plus.org/" target="_blank">Notepad++</a>) and copy the contents over to a JSON formatter (such as <a class="has-text-info" href="https://jsonformatter.org/json-pretty-print" target="_blank">JSON Pretty Print</a>).
-            </p>
-            <p class="subtitle is-size-6-5 has-txt-listing">
-              When explaining the file structure, not all data will be covered - just the most important data worth noting. 
-            </p>
+    <div id="version_2" class="tile is-child is-paddingless">
+      <div class="isHideable">
+        <p class="text-center is-bold is-size-5">
+          Version 2 File Structure
+        </p>
+      </div>
+      <div class="mt-4 isHideable">
+
+        <div class="">
+          <p class="has-txt-value-number">version</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">File version.</p>
         </div>
-        <div id="version_2" class="tile is-child is-paddingless">
-            <div class="isHideable">
-                <p class="text-center is-bold is-size-5">
-                  Version 2 File Structure
-                </p>
-            </div>
-            <div class="mt-4 isHideable">
-
-              <div class="">
-                <p class="has-txt-value-number">version</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">File version.</p>
-              </div>
-              <div class="">
-                <p class="has-txt-value-number">character</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">Basic character info.</p>
-              </div>
-
-              <div class="ml-4">
-                <p class="has-txt-value-number">_class</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">Basic information about the character's class (or null if unselected).</p>
-              </div>
-              <div class="ml-4">
-                <p class="has-txt-value-number">_background</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">Basic information about the character's background (or null if unselected).</p>
-              </div>
-              <div class="ml-4">
-                <p class="has-txt-value-number">_ancestry</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">Basic information about the character's ancestry (or null if unselected).</p>
-              </div>
-              <div class="ml-4">
-                <p class="has-txt-value-number">_heritage</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">Basic information about the character's heritage or versatile heritage (or null if unselected).</p>
-              </div>
-
-              <div class="">
-                <p class="has-txt-value-number">build</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">Contains most of the selections made for the character when being built in the character builder. For example, what feats were selected when in the building process.</p>
-              </div>
-
-              <div class="ml-4">
-                <p class="has-txt-value-number">boosts</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">A list of each ability boost (or flaw).</p>
-              </div>
-
-              <div class="ml-4 pl-4">
-                <p class="has-txt-value-number">Ability</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">The name of the targeted ability score.</p>
-              </div>
-              <div class="ml-4 pl-4">
-                <p class="has-txt-value-number">Bonus</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">Whether it is a boost or flaw.</p>
-              </div>
-
-              <div class="ml-4">
-                <p class="has-txt-value-number">domains</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">A list of each domains they have.</p>
-              </div>
-
-              <div class="ml-4 pl-4">
-                <p class="has-txt-value-number">value</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">Information about the domain.</p>
-              </div>
-
-              <div class="ml-4">
-                <p class="has-txt-value-number">feats</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">A list of each feat they have.</p>
-              </div>
-
-              <div class="ml-4 pl-4">
-                <p class="has-txt-value-number">value</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">Information about the feat.</p>
-              </div>
-
-              <div class="ml-4">
-                <p class="has-txt-value-number">languages</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">A list of each language they have.</p>
-              </div>
-
-              <div class="ml-4 pl-4">
-                <p class="has-txt-value-number">value</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">Information about the language.</p>
-              </div>
-
-              <div class="ml-4">
-                <p class="has-txt-value-number">proficiencies</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">A list of each proficiency change.</p>
-              </div>
-
-              <div class="ml-4 pl-4">
-                <p class="has-txt-value-number">For</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">The category of what the proficiency change is going towards ('Skill' for Nature, 'Save' for Will, etc).</p>
-              </div>
-              <div class="ml-4 pl-4">
-                <p class="has-txt-value-number">To</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">What the proficiency change is going towards (a skill, saving throw, weapon, etc).</p>
-              </div>
-              <div class="ml-4 pl-4">
-                <p class="has-txt-value-number">Prof</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">The updated proficiency. 'UP' means a skill increase.</p>
-              </div>
-              <div class="ml-4 pl-4">
-                <p class="has-txt-value-number">SourceName</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">The name of the feat or feature that gave this proficiency change.</p>
-              </div>
-
-              <div class="ml-4">
-                <p class="has-txt-value-number">senses</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">A list of each sense they have. This can include common senses, like darkvision, to things like tremorsense.</p>
-              </div>
-
-              <div class="ml-4 pl-4">
-                <p class="has-txt-value-number">value</p>
-                <p class="is-size-6-5 has-txt-listing is-italic">Information about the sense.</p>
-              </div>
-              
-              
-
-            </div>
+        <div class="">
+          <p class="has-txt-value-number">character</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">Basic character info.</p>
         </div>
+
+        <div class="ml-4">
+          <p class="has-txt-value-number">_class</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">Basic information
+            about the character's class (or null if unselected).</p>
+        </div>
+        <div class="ml-4">
+          <p class="has-txt-value-number">_background</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">Basic information
+            about the character's background (or null if unselected).</p>
+        </div>
+        <div class="ml-4">
+          <p class="has-txt-value-number">_ancestry</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">Basic information
+            about the character's ancestry (or null if unselected).</p>
+        </div>
+        <div class="ml-4">
+          <p class="has-txt-value-number">_heritage</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">Basic information
+            about the character's heritage or versatile heritage (or null if
+            unselected).</p>
+        </div>
+
+        <div class="">
+          <p class="has-txt-value-number">build</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">Contains most of the
+            selections made for the character when being built in the character
+            builder. For example, what feats were selected when in the building
+            process.</p>
+        </div>
+
+        <div class="ml-4">
+          <p class="has-txt-value-number">boosts</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">A list of each
+            ability boost (or flaw).</p>
+        </div>
+
+        <div class="ml-4 pl-4">
+          <p class="has-txt-value-number">Ability</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">The name of the
+            targeted ability score.</p>
+        </div>
+        <div class="ml-4 pl-4">
+          <p class="has-txt-value-number">Bonus</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">Whether it is a boost
+            or flaw.</p>
+        </div>
+
+        <div class="ml-4">
+          <p class="has-txt-value-number">domains</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">A list of each
+            domains they have.</p>
+        </div>
+
+        <div class="ml-4 pl-4">
+          <p class="has-txt-value-number">value</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">Information about the
+            domain.</p>
+        </div>
+
+        <div class="ml-4">
+          <p class="has-txt-value-number">feats</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">A list of each feat
+            they have.</p>
+        </div>
+
+        <div class="ml-4 pl-4">
+          <p class="has-txt-value-number">value</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">Information about the
+            feat.</p>
+        </div>
+
+        <div class="ml-4">
+          <p class="has-txt-value-number">languages</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">A list of each
+            language they have.</p>
+        </div>
+
+        <div class="ml-4 pl-4">
+          <p class="has-txt-value-number">value</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">Information about the
+            language.</p>
+        </div>
+
+        <div class="ml-4">
+          <p class="has-txt-value-number">proficiencies</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">A list of each
+            proficiency change.</p>
+        </div>
+
+        <div class="ml-4 pl-4">
+          <p class="has-txt-value-number">For</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">The category of what
+            the proficiency change is going towards ('Skill' for Nature, 'Save'
+            for Will, etc).</p>
+        </div>
+        <div class="ml-4 pl-4">
+          <p class="has-txt-value-number">To</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">What the proficiency
+            change is going towards (a skill, saving throw, weapon, etc).</p>
+        </div>
+        <div class="ml-4 pl-4">
+          <p class="has-txt-value-number">Prof</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">The updated
+            proficiency. 'UP' means a skill increase.</p>
+        </div>
+        <div class="ml-4 pl-4">
+          <p class="has-txt-value-number">SourceName</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">The name of the feat
+            or feature that gave this proficiency change.</p>
+        </div>
+
+        <div class="ml-4">
+          <p class="has-txt-value-number">senses</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">A list of each sense
+            they have. This can include common senses, like darkvision, to
+            things like tremorsense.</p>
+        </div>
+
+        <div class="ml-4 pl-4">
+          <p class="has-txt-value-number">value</p>
+          <p class="is-size-6-5 has-txt-listing is-italic">Information about the
+            sense.</p>
+        </div>
+
+      </div>
     </div>
-    <div class="tile is-parent is-2">
-        <div class="tile is-child"></div>
-    </div>
+  </div>
+  <div class="tile is-parent is-2">
+    <div class="tile is-child"></div>
+  </div>
 </div>

--- a/views/docs/wsc_docs.handlebars
+++ b/views/docs/wsc_docs.handlebars
@@ -1,6 +1,8 @@
+{{#section 'styles'}}
+    <link rel="stylesheet" href="/css/docs-styles.css">
+{{/section}}
 
 {{#section 'header'}}
-    <link rel="stylesheet" href="/css/docs-styles.css">
     <script src="/js/wsc/docs-page.js"></script>
     <script src="/js/wsc/text-processing.js"></script>
 {{/section}}

--- a/views/error/403_builder_error.handlebars
+++ b/views/error/403_builder_error.handlebars
@@ -1,51 +1,50 @@
+{{#section "header"}}
 
-{{#section 'header'}}
-
-    <!-- Discord Widget Bot -->
-    <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
-      new Crate({
-        server: '735260060682289254',
-        channel: '735260060682289257'
-      })
-    </script>
+  <!-- Discord Widget Bot -->
+  <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
+    new Crate({ server: '735260060682289254', channel: '735260060682289257' })
+  </script>
 
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
-
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="container">
-    <h1>Character Builder - Access Denied - 403</h1>
-    <p>You cannot edit this character.</p>
+  <h1>Character Builder - Access Denied - 403</h1>
+  <p>You cannot edit this character.</p>
 </div>

--- a/views/error/404_error.handlebars
+++ b/views/error/404_error.handlebars
@@ -1,51 +1,50 @@
+{{#section "header"}}
 
-{{#section 'header'}}
-
-    <!-- Discord Widget Bot -->
-    <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
-      new Crate({
-        server: '735260060682289254',
-        channel: '735260060682289257'
-      })
-    </script>
+  <!-- Discord Widget Bot -->
+  <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
+    new Crate({ server: '735260060682289254', channel: '735260060682289257' })
+  </script>
 
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
-
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="container">
-    <h1>Page Not Found - 404</h1>
-    <p>This must not be the page you're looking for, huh.</p>
+  <h1>Page Not Found - 404</h1>
+  <p>This must not be the page you're looking for, huh.</p>
 </div>

--- a/views/error/500_error.handlebars
+++ b/views/error/500_error.handlebars
@@ -1,52 +1,51 @@
+{{#section "header"}}
 
-{{#section 'header'}}
-
-    <!-- Discord Widget Bot -->
-    <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
-      new Crate({
-        server: '735260060682289254',
-        channel: '735260060682289257'
-      })
-    </script>
+  <!-- Discord Widget Bot -->
+  <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
+    new Crate({ server: '735260060682289254', channel: '735260060682289257' })
+  </script>
 
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
-
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="container">
-    <h1>Server Error - 500</h1>
-    <p>Oh no, an interanl server error must have occured.</p>
-    <p>Sorry for the inconvenience :/</p>
+  <h1>Server Error - 500</h1>
+  <p>Oh no, an interanl server error must have occured.</p>
+  <p>Sorry for the inconvenience :/</p>
 </div>

--- a/views/error/patreon_link_error.handlebars
+++ b/views/error/patreon_link_error.handlebars
@@ -1,54 +1,55 @@
+{{#section "header"}}
 
-{{#section 'header'}}
-
-    <!-- Discord Widget Bot -->
-    <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
-      new Crate({
-        server: '735260060682289254',
-        channel: '735260060682289257'
-      })
-    </script>
+  <!-- Discord Widget Bot -->
+  <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
+    new Crate({ server: '735260060682289254', channel: '735260060682289257' })
+  </script>
 
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
-
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="container p-3">
-    <h1>Patreon Account Linking Error</h1>
-    <p>The Patreon account you attempted to link to is already linked to a different account.</p>
-    <p class="is-italic">If you believe this may be an error, please contact us on Patreon.</p>
-    <hr class="m-2">
-    <p> Error: {{error}} </p>
+  <h1>Patreon Account Linking Error</h1>
+  <p>The Patreon account you attempted to link to is already linked to a
+    different account.</p>
+  <p class="is-italic">If you believe this may be an error, please contact us on
+    Patreon.</p>
+  <hr class="m-2" />
+  <p> Error: {{error}} </p>
 </div>

--- a/views/error/private_character_error.handlebars
+++ b/views/error/private_character_error.handlebars
@@ -1,51 +1,50 @@
+{{#section "header"}}
 
-{{#section 'header'}}
-
-    <!-- Discord Widget Bot -->
-    <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
-      new Crate({
-        server: '735260060682289254',
-        channel: '735260060682289257'
-      })
-    </script>
+  <!-- Discord Widget Bot -->
+  <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
+    new Crate({ server: '735260060682289254', channel: '735260060682289257' })
+  </script>
 
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
-
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="container">
-    <h1>Private Character - 403</h1>
-    <p>The character you're trying to view is private, sorry.</p>
+  <h1>Private Character - 403</h1>
+  <p>The character you're trying to view is private, sorry.</p>
 </div>

--- a/views/gm_tools/campaigns.handlebars
+++ b/views/gm_tools/campaigns.handlebars
@@ -1,59 +1,64 @@
-{{#section 'header'}}
+{{#section "styles"}}
 
+  <link rel="stylesheet" href="/css/campaigns.css" />
+  <link rel="stylesheet" href="/css/homebrew-builders.css" />
+{{/section}}
 
-<link rel="stylesheet" href="/css/campaigns.css">
-<link rel="stylesheet" href="/css/homebrew-builders.css">
+{{#section "header"}}
 
+  <script>
+    let rawCampaigns =
+    {{{json campaigns}}};
+  </script>
+  <script src="/js/gm_tools/campaigns/ui-handler.js"></script>
 
-<script>
-  let rawCampaigns = {{{ json campaigns }}};
-</script>
-<script src="/js/gm_tools/campaigns/ui-handler.js"></script>
+  <script src="/js/gm_tools/campaigns/conditions-handler.js"></script>
+  <script src="/js/libraries/display_campaign/display-campaign.js"></script>
+  <script src="/js/wsc/text-processing.js"></script>
+  <script src="/js/gm_tools/encounter_builder/conditions-ui.js"></script>
+  <script src="/js/libraries/confirm_message/confirm-message.js"></script>
 
-<script src="/js/gm_tools/campaigns/conditions-handler.js"></script>
-<script src="/js/libraries/display_campaign/display-campaign.js"></script>
-<script src="/js/wsc/text-processing.js"></script>
-<script src="/js/gm_tools/encounter_builder/conditions-ui.js"></script>
-<script src="/js/libraries/confirm_message/confirm-message.js"></script>
-
-<!-- Quickview -->
-<script src="/js/sheet/quickviews/_quickviews.js"></script>
-<script src="/js/sheet/quickviews/character-view.js"></script>
+  <!-- Quickview -->
+  <script src="/js/sheet/quickviews/_quickviews.js"></script>
+  <script src="/js/sheet/quickviews/character-view.js"></script>
 
 {{/section}}
 
-{{#section 'nav_home'}}
-<li><a href="/">Home</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_characters'}}
-<li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-<li><a href="/builds">Builds</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-<li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-<li><a href="/gm-tools" class="active">GM Tools</a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools" class="active">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-<li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-<li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
-
-
-{{#section 'banner_nav'}}
-<div class="banner_w3lspvt-2"></div>
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="subpageloader is-hidden">
@@ -73,18 +78,34 @@
 
   <div class="columns is-mobile is-centered is-vcentered pt-3 is-marginless">
     <div class="column is-5 is-paddingless">
-      <h1 class="is-size-2 is-inline-block has-txt-value-string title-font">Campaigns</h1>
+      <h1
+        class="is-size-2 is-inline-block has-txt-value-string title-font"
+      >Campaigns</h1>
       {{#ifEqual user.isPatreonMember 0}}
-        <span class="is-size-5 ml-3 has-tooltip-bottom has-tooltip-multiline has-txt-listing" data-tooltip="You can only have one campaign at a time. To get unlimited campaigns, support us and what we're doing on Patreon!">({{campaigns.length}}/{{campaignLimit}})</span>
+        <span
+          class="is-size-5 ml-3 has-tooltip-bottom has-tooltip-multiline has-txt-listing"
+          data-tooltip="You can only have one campaign at a time. To get unlimited campaigns, support us and what we're doing on Patreon!"
+        >({{campaigns.length}}/{{campaignLimit}})</span>
       {{/ifEqual}}
     </div>
     <div class="column is-5 is-paddingless">
       {{#if canMakeCampaign}}
-        <a id="campaign-create-btn" class="is-size-3 is-pulled-right"><span class="icon is-large has-text-info has-tooltip-bottom" data-tooltip="Create Campaign"><i class="fas fa-plus"></i></span></a>
+        <a id="campaign-create-btn" class="is-size-3 is-pulled-right"><span
+            class="icon is-large has-text-info has-tooltip-bottom"
+            data-tooltip="Create Campaign"
+          ><i class="fas fa-plus"></i></span></a>
       {{else}}
-        <a class="is-size-3 is-pulled-right"><span class="icon is-large has-text-danger has-tooltip-bottom" data-tooltip="You have reached your campaign limit."><i class="fas fa-plus"></i></span></a>
+        <a class="is-size-3 is-pulled-right"><span
+            class="icon is-large has-text-danger has-tooltip-bottom"
+            data-tooltip="You have reached your campaign limit."
+          ><i class="fas fa-plus"></i></span></a>
 
-        <a href="https://www.patreon.com/bePatron?u=32932027" target="_blank" class="button is-rounded is-small is-hidden-mobile mt-2 mx-3 is-pulled-right" style="background-color: rgb(255, 66, 77);color: white;">
+        <a
+          href="https://www.patreon.com/bePatron?u=32932027"
+          target="_blank"
+          class="button is-rounded is-small is-hidden-mobile mt-2 mx-3 is-pulled-right"
+          style="background-color: rgb(255, 66, 77);color: white;"
+        >
           <span class="icon is-small">
             <i class="fab fa-patreon"></i>
           </span>
@@ -93,167 +114,244 @@
       {{/if}}
     </div>
   </div>
-  <hr>
-
+  <hr />
 
   <div class="columns is-centered is-multiline is-marginless mb-2">
     {{#each campaigns}}
-    <div class="column is-4">
-      <div class="card campaign-card is-unselectable" data-campaign-id="{{id}}">
+      <div class="column is-4">
+        <div
+          class="card campaign-card is-unselectable"
+          data-campaign-id="{{id}}"
+        >
 
-        <div class="card-content cursor-clickable pt-2">
-          <a>
-            <span class="is-size-8 has-txt-noted campaign-id"># {{id}}</span>
-            <p id="campaign-{{id}}-name" class="is-size-4 has-txt-value-number text-center text-overflow-ellipsis">
-              {{name}}</p>
-            <p class="is-size-7 text-center text-overflow-ellipsis"> {{campaignaccesstokens.length}} characters </p>
-          </a>
-        </div>
+          <div class="card-content cursor-clickable pt-2">
+            <a>
+              <span class="is-size-8 has-txt-noted campaign-id"># {{id}}</span>
+              <p
+                id="campaign-{{id}}-name"
+                class="is-size-4 has-txt-value-number text-center text-overflow-ellipsis"
+              >
+                {{name}}</p>
+              <p class="is-size-7 text-center text-overflow-ellipsis">
+                {{campaignaccesstokens.length}}
+                characters
+              </p>
+            </a>
+          </div>
 
-        <div class="card-footer is-paddingless">
-          <a class="card-footer-item campaign-card-edit has-txt-listing">
-            <span class="is-size-6 pr-2">Edit</span>
-            <span class="icon is-small">
-              <i class="fas fa-edit"></i>
-            </span>
-          </a>
-          <a class="card-footer-item campaign-card-delete has-txt-listing">
-            <span class="is-size-6 pr-1">Delete</span>
-            <span class="icon is-small">
-              <i class="fas fa-trash"></i>
-            </span>
-          </a>
+          <div class="card-footer is-paddingless">
+            <a class="card-footer-item campaign-card-edit has-txt-listing">
+              <span class="is-size-6 pr-2">Edit</span>
+              <span class="icon is-small">
+                <i class="fas fa-edit"></i>
+              </span>
+            </a>
+            <a class="card-footer-item campaign-card-delete has-txt-listing">
+              <span class="is-size-6 pr-1">Delete</span>
+              <span class="icon is-small">
+                <i class="fas fa-trash"></i>
+              </span>
+            </a>
+          </div>
         </div>
       </div>
-    </div>
     {{else}}
-    <div class="column">
-      <p class="has-text-centered is-italic">You have no campaigns.</p>
-    </div>
+      <div class="column">
+        <p class="has-text-centered is-italic">You have no campaigns.</p>
+      </div>
     {{/each}}
   </div>
 
 </div>
 
+{{#section "overlay"}}
 
-{{#section 'overlay'}}
-
-<!-- Right Quickview -->
-<div id="quickviewDefault" class="quickview">
-  <div class="quickview-header">
-    <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
-    <div class="is-inline-flex">
-      <p id="quickViewTitleRight"></p>
-      <p id="quickViewTitleClose"></p>
+  <!-- Right Quickview -->
+  <div id="quickviewDefault" class="quickview">
+    <div class="quickview-header">
+      <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
+      <div class="is-inline-flex">
+        <p id="quickViewTitleRight"></p>
+        <p id="quickViewTitleClose"></p>
+      </div>
+    </div>
+    <div class="quickview-body use-custom-scrollbar">
+      <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
+      </div>
     </div>
   </div>
-  <div class="quickview-body use-custom-scrollbar">
-    <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
-    </div>
-  </div>
-</div>
 
-<!-- Edit Modal -->
-<div id="editModalDefault" name="" class="modal" style="z-index:30;">
-  <div id="editModalBackground" class="modal-background"></div>
-  <div class="modal-card">
-    <div class="modal-card-head">
-      <p id="editModalTitle" class="modal-card-title has-text-centered is-size-4 has-txt-value-number">Edit Campaign</p>
-      <button id="editModalCloseButton" class="delete modal-card-close" aria-label="close"></button>
-    </div>
-    <section class="modal-card-body is-paddingless use-custom-scrollbar p-2 pt-3"
-      style="overflow-y: scroll; overflow-x: hidden;">
-
-      <div class="field">
-        <div class="control">
-          <input id="inputCampaignName" class="input" type="text" placeholder="Name" maxlength="120" spellcheck="false"
-            autocomplete="off">
-        </div>
+  <!-- Edit Modal -->
+  <div id="editModalDefault" name="" class="modal" style="z-index:30;">
+    <div id="editModalBackground" class="modal-background"></div>
+    <div class="modal-card">
+      <div class="modal-card-head">
+        <p
+          id="editModalTitle"
+          class="modal-card-title has-text-centered is-size-4 has-txt-value-number"
+        >Edit Campaign</p>
+        <button
+          id="editModalCloseButton"
+          class="delete modal-card-close"
+          aria-label="close"
+        ></button>
       </div>
+      <section
+        class="modal-card-body is-paddingless use-custom-scrollbar p-2 pt-3"
+        style="overflow-y: scroll; overflow-x: hidden;"
+      >
 
-      <div class="field">
-        <div class="control">
-          <textarea id="inputCampaignDescription" class="textarea use-custom-scrollbar" placeholder="Description"
-            maxlength="3950" spellcheck="false" autocomplete="off"></textarea>
-        </div>
-      </div>
-
-      <div class="field">
-        <div class="control">
-          <input id="inputCampaignImageURL" class="input isURL" type="text" maxlength="290" placeholder="Image URL"
-            spellcheck="false" autocomplete="off">
-        </div>
-      </div>
-
-      <hr class="m-2">
-
-      <div class="field pl-2">
-        <label class="label">Display Player Health to Others</label>
-        <div class="control">
-          <div class="select">
-            <select id="selectCampaignOption-DisplayPlayerHealth">
-              <option value="0">Don't Display</option>
-              <option value="1">Show General Status</option>
-              <option value="2">Show Specific Number</option>
-            </select>
+        <div class="field">
+          <div class="control">
+            <input
+              id="inputCampaignName"
+              class="input"
+              type="text"
+              placeholder="Name"
+              maxlength="120"
+              spellcheck="false"
+              autocomplete="off"
+            />
           </div>
         </div>
+
+        <div class="field">
+          <div class="control">
+            <textarea
+              id="inputCampaignDescription"
+              class="textarea use-custom-scrollbar"
+              placeholder="Description"
+              maxlength="3950"
+              spellcheck="false"
+              autocomplete="off"
+            ></textarea>
+          </div>
+        </div>
+
+        <div class="field">
+          <div class="control">
+            <input
+              id="inputCampaignImageURL"
+              class="input isURL"
+              type="text"
+              maxlength="290"
+              placeholder="Image URL"
+              spellcheck="false"
+              autocomplete="off"
+            />
+          </div>
+        </div>
+
+        <hr class="m-2" />
+
+        <div class="field pl-2">
+          <label class="label">Display Player Health to Others</label>
+          <div class="control">
+            <div class="select">
+              <select id="selectCampaignOption-DisplayPlayerHealth">
+                <option value="0">Don't Display</option>
+                <option value="1">Show General Status</option>
+                <option value="2">Show Specific Number</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+      </section>
+      <div class="modal-card-foot">
       </div>
-
-    </section>
-    <div class="modal-card-foot">
     </div>
   </div>
-</div>
 
-<!-- Conditions Modal -->
-<div id="conditionsModalDefault" name="" class="modal" style="z-index:30;">
-  <div id="conditionsModalBackground" class="modal-background"></div>
-  <div class="modal-card">
-    <div class="modal-card-head">
-      <p id="conditionsModalTitle" class="modal-card-title has-text-centered is-size-4 has-txt-value-number"></p>
-      <a id="conditionsModalRemoveButton" class="is-pulled-right is-size-6"><span
-          class="icon is-medium has-text-danger"><i class="fal fa-minus-circle"></i></span></a>
+  <!-- Conditions Modal -->
+  <div id="conditionsModalDefault" name="" class="modal" style="z-index:30;">
+    <div id="conditionsModalBackground" class="modal-background"></div>
+    <div class="modal-card">
+      <div class="modal-card-head">
+        <p
+          id="conditionsModalTitle"
+          class="modal-card-title has-text-centered is-size-4 has-txt-value-number"
+        ></p>
+        <a
+          id="conditionsModalRemoveButton"
+          class="is-pulled-right is-size-6"
+        ><span class="icon is-medium has-text-danger"><i
+              class="fal fa-minus-circle"
+            ></i></span></a>
+      </div>
+      <section class="modal-card-body py-2">
+        <p id="conditionsModalSourceSection" class="has-text-centered"><strong
+            class="has-txt-listing"
+          >From: </strong><em id="conditionsModalSourceContent"></em></p>
+        <p id="conditionsModalContent"></p>
+      </section>
+      <div
+        id="conditionsModalFooter"
+        class="modal-card-foot buttons is-centered"
+      >
+        <button
+          id="conditionsModalSubtractButton"
+          class="button is-very-small is-info is-rounded"
+        >
+          <span class="icon">
+            <i class="fas fa-heading fa-minus"></i>
+          </span>
+        </button>
+        <button
+          id="conditionsModalValueButton"
+          class="button is-static has-bg-selectable-hover border-dark"
+        >
+          <p id="conditionsModalValue" class="has-txt-value-number"></p>
+        </button>
+        <button
+          id="conditionsModalAddButton"
+          class="button is-very-small is-info is-rounded"
+        >
+          <span class="icon">
+            <i class="fas fa-heading fa-plus"></i>
+          </span>
+        </button>
+      </div>
     </div>
-    <section class="modal-card-body py-2">
-      <p id="conditionsModalSourceSection" class="has-text-centered"><strong class="has-txt-listing">From: </strong><em
-          id="conditionsModalSourceContent"></em></p>
-      <p id="conditionsModalContent"></p>
-    </section>
-    <div id="conditionsModalFooter" class="modal-card-foot buttons is-centered">
-      <button id="conditionsModalSubtractButton" class="button is-very-small is-info is-rounded">
-        <span class="icon">
-          <i class="fas fa-heading fa-minus"></i>
-        </span>
-      </button>
-      <button id="conditionsModalValueButton" class="button is-static has-bg-selectable-hover border-dark">
-        <p id="conditionsModalValue" class="has-txt-value-number"></p>
-      </button>
-      <button id="conditionsModalAddButton" class="button is-very-small is-info is-rounded">
-        <span class="icon">
-          <i class="fas fa-heading fa-plus"></i>
-        </span>
-      </button>
+    <button
+      id="conditionsModalCloseButton"
+      class="modal-close is-large is-hidden-mobile"
+      aria-label="close"
+    ></button>
+  </div>
+
+  <!-- Conditions Select Modal -->
+  <div
+    id="conditionsSelectModalDefault"
+    name=""
+    class="modal"
+    style="z-index:30;"
+  >
+    <div id="conditionsSelectModalBackground" class="modal-background"></div>
+    <div class="modal-card">
+      <div class="modal-card-head">
+        <p
+          id="conditionsSelectModalTitle"
+          class="modal-card-title has-text-centered is-size-4 has-txt-value-number"
+        >
+          Choose a Condition</p>
+        <button
+          id="conditionsSelectModalCloseButton"
+          class="delete modal-card-close"
+          aria-label="close"
+        ></button>
+      </div>
+      <section
+        class="modal-card-body is-paddingless use-invisible-scrollbar p-2"
+      >
+        <div
+          id="conditionsSelectModalContent"
+          class="tile is-ancestor is-vertical"
+        ></div>
+      </section>
+      <div class="modal-card-foot">
+      </div>
     </div>
   </div>
-  <button id="conditionsModalCloseButton" class="modal-close is-large is-hidden-mobile" aria-label="close"></button>
-</div>
-
-<!-- Conditions Select Modal -->
-<div id="conditionsSelectModalDefault" name="" class="modal" style="z-index:30;">
-  <div id="conditionsSelectModalBackground" class="modal-background"></div>
-  <div class="modal-card">
-    <div class="modal-card-head">
-      <p id="conditionsSelectModalTitle" class="modal-card-title has-text-centered is-size-4 has-txt-value-number">
-        Choose a Condition</p>
-      <button id="conditionsSelectModalCloseButton" class="delete modal-card-close" aria-label="close"></button>
-    </div>
-    <section class="modal-card-body is-paddingless use-invisible-scrollbar p-2">
-      <div id="conditionsSelectModalContent" class="tile is-ancestor is-vertical"></div>
-    </section>
-    <div class="modal-card-foot">
-    </div>
-  </div>
-</div>
 
 {{/section}}

--- a/views/gm_tools/encounter_builder.handlebars
+++ b/views/gm_tools/encounter_builder.handlebars
@@ -1,331 +1,501 @@
-{{#section 'header'}}
+{{#section "styles"}}
 
-<link rel="stylesheet" href="/css/encounter-builder.css">
-<link rel="stylesheet" href="/css/homebrew-builders.css">
+  <link rel="stylesheet" href="/css/encounter-builder.css" />
+  <link rel="stylesheet" href="/css/homebrew-builders.css" />
+{{/section}}
 
-<script type="text/javascript" src="/js/gm_tools/encounter_builder/encounter-builder.js"></script>
-<script type="text/javascript" src="/js/gm_tools/encounter_builder/creature-select-quickview.js"></script>
-<script type="text/javascript" src="/js/gm_tools/encounter_builder/roll-initiative.js"></script>
-<script type="text/javascript" src="/js/gm_tools/encounter_builder/creature-utils.js"></script>
-<script type="text/javascript" src="/js/gm_tools/encounter_builder/conditions-ui.js"></script>
-<script type="text/javascript" src="/js/gm_tools/encounter_builder/balance-utils.js"></script>
+{{#section "header"}}
 
-<script type="text/javascript" src="/js/gm_tools/encounter_builder/campaigns-ui.js"></script>
-<script type="text/javascript" src="/js/gm_tools/encounter_builder/campaigns-handler.js"></script>
-<script type="text/javascript" src="/js/libraries/display_campaign/display-campaign.js"></script>
+  <script
+    type="text/javascript"
+    src="/js/gm_tools/encounter_builder/encounter-builder.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/gm_tools/encounter_builder/creature-select-quickview.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/gm_tools/encounter_builder/roll-initiative.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/gm_tools/encounter_builder/creature-utils.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/gm_tools/encounter_builder/conditions-ui.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/gm_tools/encounter_builder/balance-utils.js"
+  ></script>
 
-<script src="/js/libraries/confirm_message/confirm-message.js"></script>
+  <script
+    type="text/javascript"
+    src="/js/gm_tools/encounter_builder/campaigns-ui.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/gm_tools/encounter_builder/campaigns-handler.js"
+  ></script>
+  <script
+    type="text/javascript"
+    src="/js/libraries/display_campaign/display-campaign.js"
+  ></script>
 
-<!-- Quickview -->
-<script src="/js/sheet/quickviews/_quickviews.js"></script>
-<script src="/js/sheet/quickviews/creature-view.js"></script>
-<script src="/js/sheet/quickviews/creature-custom-view.js"></script>
-<script src="/js/sheet/quickviews/ability-view.js"></script>
-<script src="/js/sheet/quickviews/tag-view.js"></script>
-<script src="/js/sheet/quickviews/character-view.js"></script>
+  <script src="/js/libraries/confirm_message/confirm-message.js"></script>
 
-<script src="/js/sheet/quickviews/feat-view.js"></script>
-<script src="/js/sheet/quickviews/spell-view.js"></script>
-<script src="/js/sheet/quickviews/item-view.js"></script>
-<script src="/js/sheet/quickviews/condition-view.js"></script>
-<script src="/js/sheet/utils/item-utils.js"></script>
-<script src="/js/sheet/utils/material-utils.js"></script>
+  <!-- Quickview -->
+  <script src="/js/sheet/quickviews/_quickviews.js"></script>
+  <script src="/js/sheet/quickviews/creature-view.js"></script>
+  <script src="/js/sheet/quickviews/creature-custom-view.js"></script>
+  <script src="/js/sheet/quickviews/ability-view.js"></script>
+  <script src="/js/sheet/quickviews/tag-view.js"></script>
+  <script src="/js/sheet/quickviews/character-view.js"></script>
 
-<script src="/js/wsc/text-processing.js"></script>
+  <script src="/js/sheet/quickviews/feat-view.js"></script>
+  <script src="/js/sheet/quickviews/spell-view.js"></script>
+  <script src="/js/sheet/quickviews/item-view.js"></script>
+  <script src="/js/sheet/quickviews/condition-view.js"></script>
+  <script src="/js/sheet/utils/item-utils.js"></script>
+  <script src="/js/sheet/utils/material-utils.js"></script>
+
+  <script src="/js/wsc/text-processing.js"></script>
 
 {{/section}}
 
-{{#section 'nav_home'}}
-<li><a href="/">Home</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_characters'}}
-<li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-<li><a href="/builds">Builds</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-<li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-<li><a href="/gm-tools" class="active">GM Tools</a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools" class="active">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-<li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-<li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
-
-
-{{#section 'banner_nav'}}
-<div class="banner_w3lspvt-2"></div>
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="pageloader is-hidden">
-    <div class="lds-roller">
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-    </div>
+  <div class="lds-roller">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+  </div>
 </div>
 
 <div class="container py-4 text-center">
 
-    <div class="box pt-0">
+  <div class="box pt-0">
 
-        <p class="has-text-left is-size-4 title-font has-txt-value-string">Encounters</p>
+    <p
+      class="has-text-left is-size-4 title-font has-txt-value-string"
+    >Encounters</p>
 
-        <div class="is-flex" style="justify-content: space-between;">
-            <div id="encounter-tab-list" class="is-flex" style="flex-wrap: wrap;">
-                <!-- Encounter tabs populate here -->
-            </div>
-            <div>
-                <span id="encounter-add-btn" class="icon has-text-info cursor-clickable mb-3 mx-3">
-                    <i class="fal fa-lg fa-plus-circle"></i>
+    <div class="is-flex" style="justify-content: space-between;">
+      <div id="encounter-tab-list" class="is-flex" style="flex-wrap: wrap;">
+        <!-- Encounter tabs populate here -->
+      </div>
+      <div>
+        <span
+          id="encounter-add-btn"
+          class="icon has-text-info cursor-clickable mb-3 mx-3"
+        >
+          <i class="fal fa-lg fa-plus-circle"></i>
+        </span>
+      </div>
+    </div>
+
+    <hr class="my-1 mx-0" />
+
+    <div id="encounter-view">
+
+      <div class="columns is-marginless">
+
+        <div class="column is-3 pl-0 pr-4">
+          <input
+            id="encounter-name-input"
+            class="input"
+            type="text"
+            autocomplete="off"
+            placeholder="Encounter Name"
+          />
+        </div>
+
+        <div class="column is-3 pl-0 is-flex">
+          <div id="encounter-section-party-size" class="field">
+            <p class="control has-icons-left">
+              <input
+                id="encounter-party-size-input"
+                class="input"
+                type="number"
+                autocomplete="off"
+                placeholder="Party"
+                value="4"
+                min="1"
+                max="30"
+              />
+              <span class="icon is-small is-left">
+                <i class="fas fa-users"></i>
+              </span>
+            </p>
+          </div>
+          <div id="encounter-section-party-level" class="field">
+            <p class="control has-icons-left">
+              <input
+                id="encounter-party-level-input"
+                class="input"
+                type="number"
+                autocomplete="off"
+                placeholder="Level"
+                value="1"
+                min="1"
+                max="30"
+              />
+              <span class="icon is-small is-left">
+                <span class="font-bebas-neue">Lvl</span>
+              </span>
+            </p>
+          </div>
+        </div>
+
+        <div
+          class="column is-flex"
+          style="justify-content: space-between; flex-wrap: wrap;"
+        >
+
+          <div>
+            <button
+              id="encounter-roll-initiative-btn"
+              class="button is-info is-rounded is-outlined is-very-small"
+            >
+              <span class="is-italic">Roll Initiative!</span>
+              <span class="icon">
+                <i class="fas fa-dice-d20"></i>
+              </span>
+            </button>
+
+          </div>
+
+          <div class="field has-addons">
+            <p class="control">
+              <button
+                id="encounter-add-creature-btn"
+                class="button is-info is-rounded is-very-small mb-1"
+              >
+                <span>Add Creature</span>
+                <span class="icon">
+                  <i class="fas fa-dragon"></i>
                 </span>
-            </div>
-        </div>
+              </button>
+            </p>
+            <p class="control">
+              <button
+                id="encounter-add-custom-btn"
+                class="button is-info-offcolor is-rounded is-very-small"
+              >
+                <span>Add Custom</span>
+                <span class="icon">
+                  <i class="fas fa-user-crown"></i>
+                </span>
+              </button>
+            </p>
+          </div>
 
-        <hr class="my-1 mx-0">
-
-        <div id="encounter-view">
-
-            <div class="columns is-marginless">
-
-                <div class="column is-3 pl-0 pr-4">
-                    <input id="encounter-name-input" class="input" type="text" autocomplete="off" placeholder="Encounter Name">
-                </div>
-
-                <div class="column is-3 pl-0 is-flex">
-                    <div id="encounter-section-party-size" class="field">
-                        <p class="control has-icons-left">
-                            <input id="encounter-party-size-input" class="input" type="number" autocomplete="off" placeholder="Party" value="4" min="1" max="30">
-                            <span class="icon is-small is-left">
-                                <i class="fas fa-users"></i>
-                            </span>
-                        </p>
-                    </div>
-                    <div id="encounter-section-party-level" class="field">
-                        <p class="control has-icons-left">
-                            <input id="encounter-party-level-input" class="input" type="number" autocomplete="off" placeholder="Level" value="1" min="1" max="30">
-                            <span class="icon is-small is-left">
-                                <span class="font-bebas-neue">Lvl</span>
-                            </span>
-                        </p>
-                    </div>
-                </div>
-
-                <div class="column is-flex" style="justify-content: space-between; flex-wrap: wrap;">
-
-                    <div>
-                        <button id="encounter-roll-initiative-btn" class="button is-info is-rounded is-outlined is-very-small">
-                            <span class="is-italic">Roll Initiative!</span>
-                            <span class="icon">
-                                <i class="fas fa-dice-d20"></i>
-                            </span>
-                        </button>
-                        
-                    </div>
-
-                    <div class="field has-addons">
-                      <p class="control">
-                        <button id="encounter-add-creature-btn" class="button is-info is-rounded is-very-small mb-1">
-                            <span>Add Creature</span>
-                            <span class="icon">
-                                <i class="fas fa-dragon"></i>
-                            </span>
-                        </button>
-                      </p>
-                      <p class="control">
-                        <button id="encounter-add-custom-btn" class="button is-info-offcolor is-rounded is-very-small">
-                            <span>Add Custom</span>
-                            <span class="icon">
-                                <i class="fas fa-user-crown"></i>
-                            </span>
-                        </button>
-                      </p>
-                    </div>
-
-                    <div>
-                      <button id="encounter-set-campaign-btn" class="button is-success is-rounded is-outlined is-very-small">
-                            <span id="encounter-set-campaign-title">Set Campaign</span>
-                        </button>
-                    </div>
-
-                </div>
-
-            </div>
-
-
-
-            <div class="columns is-marginless is-mobile">
-                <div class="column is-1 text-center is-paddingless">
-                    <p class=""><strong class="has-txt-listing">Init.</strong></p>
-                </div>
-                <div class="column is-3 text-left is-paddingless">
-                    <p class="pl-3"><strong class="has-txt-listing">Name</strong></p>
-                </div>
-                <div class="column is-1 is-paddingless">
-                    <!-- View btn -->
-                </div>
-                <div class="column is-2 text-center is-paddingless">
-                    <p><strong class="has-txt-listing">HP</strong></p>
-                </div>
-                <div class="column is-4 text-left is-paddingless">
-                    <p class="pl-3"><strong class="has-txt-listing">Conditions</strong></p>
-                </div>
-                <div class="column is-1 is-paddingless">
-                    <!-- Delete btn -->
-                </div>
-            </div>
-            <div class="is-divider hr-light is-marginless"></div>
-
-            <div id="encounter-members-view">
-                <!-- Encounter members populate here -->
-            </div>
-
-            <div class="pos-relative mt-3" style="width: calc(20% + 100px); margin: auto;">
-                <progress id="encounter-balance-bar" class="progress is-marginless" value="100" max="100">100%</progress>
-                <span id="encounter-balance-display" class="text-white is-size-7-5" style="position: absolute; top: 1px; left: 0; right: 0; margin-left: auto; margin-right: auto;"></span>
-            </div>
+          <div>
+            <button
+              id="encounter-set-campaign-btn"
+              class="button is-success is-rounded is-outlined is-very-small"
+            >
+              <span id="encounter-set-campaign-title">Set Campaign</span>
+            </button>
+          </div>
 
         </div>
+
+      </div>
+
+      <div class="columns is-marginless is-mobile">
+        <div class="column is-1 text-center is-paddingless">
+          <p class=""><strong class="has-txt-listing">Init.</strong></p>
+        </div>
+        <div class="column is-3 text-left is-paddingless">
+          <p class="pl-3"><strong class="has-txt-listing">Name</strong></p>
+        </div>
+        <div class="column is-1 is-paddingless">
+          <!-- View btn -->
+        </div>
+        <div class="column is-2 text-center is-paddingless">
+          <p><strong class="has-txt-listing">HP</strong></p>
+        </div>
+        <div class="column is-4 text-left is-paddingless">
+          <p class="pl-3"><strong
+              class="has-txt-listing"
+            >Conditions</strong></p>
+        </div>
+        <div class="column is-1 is-paddingless">
+          <!-- Delete btn -->
+        </div>
+      </div>
+      <div class="is-divider hr-light is-marginless"></div>
+
+      <div id="encounter-members-view">
+        <!-- Encounter members populate here -->
+      </div>
+
+      <div
+        class="pos-relative mt-3"
+        style="width: calc(20% + 100px); margin: auto;"
+      >
+        <progress
+          id="encounter-balance-bar"
+          class="progress is-marginless"
+          value="100"
+          max="100"
+        >100%</progress>
+        <span
+          id="encounter-balance-display"
+          class="text-white is-size-7-5"
+          style="position: absolute; top: 1px; left: 0; right: 0; margin-left: auto; margin-right: auto;"
+        ></span>
+      </div>
 
     </div>
+
+  </div>
 
 </div>
 
-
-
-{{#section 'overlay'}}
-    <!-- Right Quickview -->
-    <div id="quickviewDefault" class="quickview">
-        <div class="quickview-header">
-            <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
-            <div class="is-inline-flex">
-                <p id="quickViewTitleRight"></p>
-                <p id="quickViewTitleClose"></p>
-            </div>
-        </div>
-        <div class="quickview-body use-custom-scrollbar">
-            <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
-            </div>
-        </div>
+{{#section "overlay"}}
+  <!-- Right Quickview -->
+  <div id="quickviewDefault" class="quickview">
+    <div class="quickview-header">
+      <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
+      <div class="is-inline-flex">
+        <p id="quickViewTitleRight"></p>
+        <p id="quickViewTitleClose"></p>
+      </div>
     </div>
-
-    <!-- Left Quickview -->
-    <div id="quickviewLeftDefault" class="quickview is-left">
-        <div class="quickview-header">
-            <p id="quickViewLeftTitle" class="title is-size-5 has-txt-value-number"></p>
-            <div class="is-inline-flex">
-                <p id="quickViewLeftTitleClose"></p>
-            </div>
-        </div>
-        <div class="quickview-body use-custom-scrollbar">
-            <div id="quickViewLeftContent" class="quickview-block pt-1 pb-3 px-3">
-            </div>
-        </div>
+    <div class="quickview-body use-custom-scrollbar">
+      <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
+      </div>
     </div>
+  </div>
 
+  <!-- Left Quickview -->
+  <div id="quickviewLeftDefault" class="quickview is-left">
+    <div class="quickview-header">
+      <p
+        id="quickViewLeftTitle"
+        class="title is-size-5 has-txt-value-number"
+      ></p>
+      <div class="is-inline-flex">
+        <p id="quickViewLeftTitleClose"></p>
+      </div>
+    </div>
+    <div class="quickview-body use-custom-scrollbar">
+      <div id="quickViewLeftContent" class="quickview-block pt-1 pb-3 px-3">
+      </div>
+    </div>
+  </div>
 
-    <!-- Conditions Modal -->
-    <div id="conditionsModalDefault" name="" class="modal" style="z-index:30;">
+  <!-- Conditions Modal -->
+  <div id="conditionsModalDefault" name="" class="modal" style="z-index:30;">
     <div id="conditionsModalBackground" class="modal-background"></div>
     <div class="modal-card">
-        <div class="modal-card-head">
-        <p id="conditionsModalTitle" class="modal-card-title has-text-centered is-size-4 has-txt-value-number"></p>
-        <a id="conditionsModalRemoveButton" class="is-pulled-right is-size-6"><span class="icon is-medium has-text-danger"><i class="fal fa-minus-circle"></i></span></a>
-        </div>
-        <section class="modal-card-body py-2">
-            <p id="conditionsModalSourceSection" class="has-text-centered"><strong class="has-txt-listing">From: </strong><em id="conditionsModalSourceContent"></em></p>
-            <p id="conditionsModalContent"></p>
-        </section>
-        <div id="conditionsModalFooter" class="modal-card-foot buttons is-centered">
-                <button id="conditionsModalSubtractButton" class="button is-very-small is-info is-rounded">
-                    <span class="icon">
-                        <i class="fas fa-heading fa-minus"></i>
-                    </span>
-                </button>
-                <button id="conditionsModalValueButton" class="button is-static has-bg-selectable-hover border-dark">
-                    <p id="conditionsModalValue" class="has-txt-value-number"></p>
-                </button>
-                <button id="conditionsModalAddButton" class="button is-very-small is-info is-rounded">
-                    <span class="icon">
-                        <i class="fas fa-heading fa-plus"></i>
-                    </span>
-                </button>
-        </div>
+      <div class="modal-card-head">
+        <p
+          id="conditionsModalTitle"
+          class="modal-card-title has-text-centered is-size-4 has-txt-value-number"
+        ></p>
+        <a
+          id="conditionsModalRemoveButton"
+          class="is-pulled-right is-size-6"
+        ><span class="icon is-medium has-text-danger"><i
+              class="fal fa-minus-circle"
+            ></i></span></a>
+      </div>
+      <section class="modal-card-body py-2">
+        <p id="conditionsModalSourceSection" class="has-text-centered"><strong
+            class="has-txt-listing"
+          >From: </strong><em id="conditionsModalSourceContent"></em></p>
+        <p id="conditionsModalContent"></p>
+      </section>
+      <div
+        id="conditionsModalFooter"
+        class="modal-card-foot buttons is-centered"
+      >
+        <button
+          id="conditionsModalSubtractButton"
+          class="button is-very-small is-info is-rounded"
+        >
+          <span class="icon">
+            <i class="fas fa-heading fa-minus"></i>
+          </span>
+        </button>
+        <button
+          id="conditionsModalValueButton"
+          class="button is-static has-bg-selectable-hover border-dark"
+        >
+          <p id="conditionsModalValue" class="has-txt-value-number"></p>
+        </button>
+        <button
+          id="conditionsModalAddButton"
+          class="button is-very-small is-info is-rounded"
+        >
+          <span class="icon">
+            <i class="fas fa-heading fa-plus"></i>
+          </span>
+        </button>
+      </div>
     </div>
-    <button id="conditionsModalCloseButton" class="modal-close is-large is-hidden-mobile" aria-label="close"></button>
-    </div>
+    <button
+      id="conditionsModalCloseButton"
+      class="modal-close is-large is-hidden-mobile"
+      aria-label="close"
+    ></button>
+  </div>
 
-    <!-- Conditions Select Modal -->
-    <div id="conditionsSelectModalDefault" name="" class="modal" style="z-index:30;">
+  <!-- Conditions Select Modal -->
+  <div
+    id="conditionsSelectModalDefault"
+    name=""
+    class="modal"
+    style="z-index:30;"
+  >
     <div id="conditionsSelectModalBackground" class="modal-background"></div>
     <div class="modal-card">
-        <div class="modal-card-head">
-        <p id="conditionsSelectModalTitle" class="modal-card-title has-text-centered is-size-4 has-txt-value-number">Choose a Condition</p>
-        <button id="conditionsSelectModalCloseButton" class="delete modal-card-close" aria-label="close"></button>
-        </div>
-        <section class="modal-card-body is-paddingless use-invisible-scrollbar p-2">
-            <div id="conditionsSelectModalContent" class="tile is-ancestor is-vertical"></div>
-        </section>
-        <div class="modal-card-foot">
-        </div>
+      <div class="modal-card-head">
+        <p
+          id="conditionsSelectModalTitle"
+          class="modal-card-title has-text-centered is-size-4 has-txt-value-number"
+        >Choose a Condition</p>
+        <button
+          id="conditionsSelectModalCloseButton"
+          class="delete modal-card-close"
+          aria-label="close"
+        ></button>
+      </div>
+      <section
+        class="modal-card-body is-paddingless use-invisible-scrollbar p-2"
+      >
+        <div
+          id="conditionsSelectModalContent"
+          class="tile is-ancestor is-vertical"
+        ></div>
+      </section>
+      <div class="modal-card-foot">
+      </div>
     </div>
-    </div>
+  </div>
 
-    <!-- Roll Initiative Modal -->
-    <div id="rollInitiativeModalDefault" name="" class="modal" style="z-index:30;">
+  <!-- Roll Initiative Modal -->
+  <div
+    id="rollInitiativeModalDefault"
+    name=""
+    class="modal"
+    style="z-index:30;"
+  >
     <div id="rollInitiativeModalBackground" class="modal-background"></div>
     <div class="modal-card">
-        <div class="modal-card-head">
-        <p id="rollInitiativeModalTitle" class="modal-card-title has-text-centered is-size-4 has-txt-value-number">Roll Initiative</p>
-        <button id="rollInitiativeModalCloseButton" class="delete modal-card-close" aria-label="close"></button>
+      <div class="modal-card-head">
+        <p
+          id="rollInitiativeModalTitle"
+          class="modal-card-title has-text-centered is-size-4 has-txt-value-number"
+        >Roll Initiative</p>
+        <button
+          id="rollInitiativeModalCloseButton"
+          class="delete modal-card-close"
+          aria-label="close"
+        ></button>
+      </div>
+      <section
+        class="modal-card-body is-paddingless use-custom-scrollbar p-2 pt-3"
+        style="overflow-y: scroll;     overflow-x: hidden;"
+      >
+        <div
+          id="rollInitiativeModalContent"
+          class="tile is-ancestor is-vertical"
+        ></div>
+      </section>
+      <div class="modal-card-foot p-2">
+        <div style="margin: auto;">
+          <button
+            id="rollInitiativeBtn"
+            class="button is-info is-rounded is-small"
+          >
+            <span class="">Roll</span>
+            <span class="icon">
+              <i class="fas fa-dice-d20"></i>
+            </span>
+          </button>
         </div>
-        <section class="modal-card-body is-paddingless use-custom-scrollbar p-2 pt-3" style="overflow-y: scroll;     overflow-x: hidden;">
-            <div id="rollInitiativeModalContent" class="tile is-ancestor is-vertical"></div>
-        </section>
-        <div class="modal-card-foot p-2">
-            <div style="margin: auto;">
-            <button id="rollInitiativeBtn" class="button is-info is-rounded is-small">
-                <span class="">Roll</span>
-                <span class="icon">
-                    <i class="fas fa-dice-d20"></i>
-                </span>
-            </button>
-            </div>
-        </div>
+      </div>
     </div>
-    </div>
+  </div>
 
-    <!-- Campaigns Select Modal -->
-    <div id="campaignsSelectModalDefault" name="" class="modal" style="z-index:30;">
+  <!-- Campaigns Select Modal -->
+  <div
+    id="campaignsSelectModalDefault"
+    name=""
+    class="modal"
+    style="z-index:30;"
+  >
     <div id="campaignsSelectModalBackground" class="modal-background"></div>
     <div class="modal-card">
-        <div class="modal-card-head">
-        <p id="campaignsSelectModalTitle" class="modal-card-title has-text-centered is-size-4 has-txt-value-number">Select Campaign</p>
-        <button id="campaignsSelectModalCloseButton" class="delete modal-card-close" aria-label="close"></button>
-        </div>
-        <section class="modal-card-body is-paddingless use-invisible-scrollbar p-2">
-            <div id="campaignsSelectModalContent" class="tile is-ancestor is-vertical"></div>
-        </section>
-        <div class="modal-card-foot">
-        </div>
+      <div class="modal-card-head">
+        <p
+          id="campaignsSelectModalTitle"
+          class="modal-card-title has-text-centered is-size-4 has-txt-value-number"
+        >Select Campaign</p>
+        <button
+          id="campaignsSelectModalCloseButton"
+          class="delete modal-card-close"
+          aria-label="close"
+        ></button>
+      </div>
+      <section
+        class="modal-card-body is-paddingless use-invisible-scrollbar p-2"
+      >
+        <div
+          id="campaignsSelectModalContent"
+          class="tile is-ancestor is-vertical"
+        ></div>
+      </section>
+      <div class="modal-card-foot">
+      </div>
     </div>
-    </div>
+  </div>
 
 {{/section}}

--- a/views/gm_tools/gm_tools.handlebars
+++ b/views/gm_tools/gm_tools.handlebars
@@ -1,43 +1,46 @@
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/gm_tools.css" />
+{{/section}}
 
-{{#section 'header'}}
-
-  <link rel="stylesheet" href="/css/gm_tools.css">
+{{#section "header"}}
   <script type="text/javascript" src="/js/gm_tools/ui-handler.js"></script>
-
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools" class="active">GM Tools</a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools" class="active">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
-
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="container py-4 text-center">
@@ -47,67 +50,92 @@
     <div class="pos-relative">
 
       <h1 class="title is-2 has-txt-value-string m-0">GM Tools</h1>
-      <hr class="mt-0 mb-2 mx-2">
+      <hr class="mt-0 mb-2 mx-2" />
 
       <!-- has-bg-selectable <span class="pos-absolute pos-t-5 pos-r-10 is-size-7 has-txt-noted is-italic">Coming Soon!</span> -->
-      
+
       <div class="columns is-centered is-multiline m-2">
-        
-          <div id="card-campaigns" class="column is-4 card is-unselectable card-active m-2 cursor-clickable">
-            <div class="card-content pt-2">
-              <a>
-                <p class="is-size-5 has-txt-value-number">Campaigns</p>
-                <p class="is-size-7">Create a collection of your player's characters. Be able to view and edit their health and conditions in a moment's notice. Full integration with encounter builder as well!</p>
-              </a>
-            </div>
+
+        <div
+          id="card-campaigns"
+          class="column is-4 card is-unselectable card-active m-2 cursor-clickable"
+        >
+          <div class="card-content pt-2">
+            <a>
+              <p class="is-size-5 has-txt-value-number">Campaigns</p>
+              <p class="is-size-7">Create a collection of your player's
+                characters. Be able to view and edit their health and conditions
+                in a moment's notice. Full integration with encounter builder as
+                well!</p>
+            </a>
           </div>
+        </div>
 
-          <div id="card-encounter-builder" class="column is-4 card is-unselectable card-active m-2 cursor-clickable">
-            <div class="card-content pt-2">
-              <a>
-                <p class="is-size-5 has-txt-value-number">Encounter Builder</p>
-                <p class="is-size-7">Design encounters for your party, being able to easily measure and balance the difficulty of the encounter. Built-in system for tracking health and conditions of enemies.</p>
-              </a>
-            </div>
+        <div
+          id="card-encounter-builder"
+          class="column is-4 card is-unselectable card-active m-2 cursor-clickable"
+        >
+          <div class="card-content pt-2">
+            <a>
+              <p class="is-size-5 has-txt-value-number">Encounter Builder</p>
+              <p class="is-size-7">Design encounters for your party, being able
+                to easily measure and balance the difficulty of the encounter.
+                Built-in system for tracking health and conditions of enemies.</p>
+            </a>
           </div>
+        </div>
 
-          <div id="card-shop-generator" class="column is-4 card is-unselectable card-active m-2 cursor-clickable">
-            <div class="card-content pt-2">
-              <a>
-                <p class="is-size-5 has-txt-value-number">Shop Generator</p>
-                <p class="is-size-7 pb-1">Choose from one of the 50+ shop presets and generate a shop inventory on the fly!</p>
-                <p class="is-size-7">Patrons also gain access to shop customization, importing / exporting, and homebrew integration.</p>
-              </a>
-            </div>
+        <div
+          id="card-shop-generator"
+          class="column is-4 card is-unselectable card-active m-2 cursor-clickable"
+        >
+          <div class="card-content pt-2">
+            <a>
+              <p class="is-size-5 has-txt-value-number">Shop Generator</p>
+              <p class="is-size-7 pb-1">Choose from one of the 50+ shop presets
+                and generate a shop inventory on the fly!</p>
+              <p class="is-size-7">Patrons also gain access to shop
+                customization, importing / exporting, and homebrew integration.</p>
+            </a>
           </div>
+        </div>
 
-          <div id="card-discord-bot" class="column is-4 card m-2">
-            <div class="card-content pt-2">
-              <div>
-                <p class="is-size-5 has-txt-value-number">Discord Bot</p>
-                <p class="is-size-7">A bot for fetching content from Wanderer's Guide via API and properly displaying / formatting it within Discord.</p>
+        <div id="card-discord-bot" class="column is-4 card m-2">
+          <div class="card-content pt-2">
+            <div>
+              <p class="is-size-5 has-txt-value-number">Discord Bot</p>
+              <p class="is-size-7">A bot for fetching content from Wanderer's
+                Guide via API and properly displaying / formatting it within
+                Discord.</p>
 
-                <div class="field is-grouped is-grouped-centered pt-3">
-                  <div class="control">
-                    <a class="button is-small is-info is-outlined is-rounded" href="https://discord.com/oauth2/authorize?client_id=354022489245876224&permissions=2147567680&scope=bot%20applications.commands" target="_blank">
-                      <span>Invite</span>
-                      <span class="icon"><i class="fab fa-discord"></i></span>
-                    </a>
-                  </div>
-                  <div class="control">
-                    <a class="button is-small is-info is-outlined is-rounded" href="https://github.com/Quzzar/WG-Bot" target="_blank">
-                      <span>Github</span>
-                      <span class="icon"><i class="fab fa-github"></i></span>
-                    </a>
-                  </div>
+              <div class="field is-grouped is-grouped-centered pt-3">
+                <div class="control">
+                  <a
+                    class="button is-small is-info is-outlined is-rounded"
+                    href="https://discord.com/oauth2/authorize?client_id=354022489245876224&permissions=2147567680&scope=bot%20applications.commands"
+                    target="_blank"
+                  >
+                    <span>Invite</span>
+                    <span class="icon"><i class="fab fa-discord"></i></span>
+                  </a>
                 </div>
-
+                <div class="control">
+                  <a
+                    class="button is-small is-info is-outlined is-rounded"
+                    href="https://github.com/Quzzar/WG-Bot"
+                    target="_blank"
+                  >
+                    <span>Github</span>
+                    <span class="icon"><i class="fab fa-github"></i></span>
+                  </a>
+                </div>
               </div>
+
             </div>
           </div>
+        </div>
 
       </div>
-
 
     </div>
 

--- a/views/gm_tools/shop_generator.handlebars
+++ b/views/gm_tools/shop_generator.handlebars
@@ -1,9 +1,9 @@
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/shop-generator.css">
+  <link rel="stylesheet" href="/css/homebrew-builders.css">
+{{/section}}
 
 {{#section 'header'}}
-
-    <link rel="stylesheet" href="/css/shop-generator.css">
-    <link rel="stylesheet" href="/css/homebrew-builders.css">
-
     <script type="text/javascript" src="/js/gm_tools/shop_generator/presets.js"></script>
     <script type="text/javascript" src="/js/gm_tools/shop_generator/shop.js"></script>
 

--- a/views/homebrew/builder_ancestry.handlebars
+++ b/views/homebrew/builder_ancestry.handlebars
@@ -1,475 +1,636 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/homebrew-builders.css">
-    <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
-    <script type="text/javascript" src="/js/homebrew/builder/ancestry/builder-ancestry.js"></script>
-    {{#if ancestryID}}
-        <script type="text/javascript" src="/js/homebrew/builder/ancestry/editor-ancestry.js"></script>
-    {{/if}}
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/homebrew-builders.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
+  <script
+    type="text/javascript"
+    src="/js/homebrew/builder/ancestry/builder-ancestry.js"
+  ></script>
+  {{#if ancestryID}}
+    <script
+      type="text/javascript"
+      src="/js/homebrew/builder/ancestry/editor-ancestry.js"
+    ></script>
+  {{/if}}
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew" class="active">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/homebrew"
+      class="active"
+    >Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
+
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="pageloader">
-    <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+  <div class="lds-roller"><div></div><div></div><div></div><div></div><div
+    ></div><div></div><div></div><div></div></div>
 </div>
 
 <div class="pt-3">
-    <h1 class="title is-2 has-txt-value-number has-text-centered">Ancestry Builder</h1>
+  <h1 class="title is-2 has-txt-value-number has-text-centered">Ancestry Builder</h1>
 </div>
 
-<div id="builder-container" data-user-id="{{user.id}}" data-bundle-id="{{bundleID}}" data-ancestry-id="{{ancestryID}}" class="columns is-mobile is-centered mt-2 mb-3">
-    <div class="column is-8 tile is-ancestor is-vertical">
+<div
+  id="builder-container"
+  data-user-id="{{user.id}}"
+  data-bundle-id="{{bundleID}}"
+  data-ancestry-id="{{ancestryID}}"
+  class="columns is-mobile is-centered mt-2 mb-3"
+>
+  <div class="column is-8 tile is-ancestor is-vertical">
+
+    <div class="tile">
+
+      <div class="tile is-parent is-vertical box is-6 is-marginless mr-2">
+
+        <div class="tile is-child field">
+          <label class="label">Name</label>
+          <div class="control">
+            <input
+              id="inputName"
+              class="input"
+              type="text"
+              placeholder="e.g. Gnome"
+              autocomplete="off"
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Rarity</label>
+          <div class="control">
+            <div class="select">
+              <select id="inputRarity">
+                <option value="COMMON">Common</option>
+                <option value="UNCOMMON">Uncommon</option>
+                <option value="RARE">Rare</option>
+                <option value="UNIQUE">Unique</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Hit Points</label>
+          <div class="control">
+            <input id="inputHitPoints" class="input" type="number" value="8" />
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Size</label>
+          <div class="control">
+            <div class="select">
+              <select id="inputSize">
+                <option value="TINY">Tiny</option>
+                <option value="SMALL">Small</option>
+                <option value="MEDIUM" selected>Medium</option>
+                <option value="LARGE">Large</option>
+                <option value="HUGE">Huge</option>
+                <option value="GARGANTUAN">Gargantuan</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Speed</label>
+          <div class="control">
+            <input
+              id="inputSpeed"
+              class="input"
+              type="number"
+              value="25"
+              step="5"
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Vision Sense</label>
+          <div class="control">
+            <div class="select">
+              <select id="inputVisionSense">
+                {{#each senseTypes}}
+                  {{#ifEqual isVisionType 1}}
+                    <option value="{{id}}">{{name}}</option>
+                  {{/ifEqual}}
+                {{/each}}
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Additional Sense</label>
+          <div class="control">
+            <div class="select">
+              <select id="inputAdditionalSense">
+                <option value="">Choose a Sense</option>
+                {{#each senseTypes}}
+                  {{#ifEqual isVisionType 0}}
+                    <option value="{{id}}">{{name}}</option>
+                  {{/ifEqual}}
+                {{/each}}
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Extra Feature</label>
+          <div class="control">
+            <div class="select">
+              <select id="inputPhysicalFeatureOne">
+                <option value="">Choose a Feature</option>
+                {{#each physicalFeatures}}
+                  <option value="{{id}}">{{name}}</option>
+                {{/each}}
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Extra Feature</label>
+          <div class="control">
+            <div class="select">
+              <select id="inputPhysicalFeatureTwo">
+                <option value="">Choose a Feature</option>
+                {{#each physicalFeatures}}
+                  <option value="{{id}}">{{name}}</option>
+                {{/each}}
+              </select>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <div class="tile is-parent is-vertical box is-6 is-marginless ml-2">
 
         <div class="tile">
-
-            <div class="tile is-parent is-vertical box is-6 is-marginless mr-2">
-
-                <div class="tile is-child field">
-                    <label class="label">Name</label>
-                    <div class="control">
-                        <input id="inputName" class="input" type="text" placeholder="e.g. Gnome" autocomplete="off">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Rarity</label>
-                    <div class="control">
-                        <div class="select">
-                            <select id="inputRarity">
-                                <option value="COMMON">Common</option>
-                                <option value="UNCOMMON">Uncommon</option>
-                                <option value="RARE">Rare</option>
-                                <option value="UNIQUE">Unique</option>
-                            </select>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Hit Points</label>
-                    <div class="control">
-                        <input id="inputHitPoints" class="input" type="number" value="8">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Size</label>
-                    <div class="control">
-                        <div class="select">
-                            <select id="inputSize">
-                                <option value="TINY">Tiny</option>
-                                <option value="SMALL">Small</option>
-                                <option value="MEDIUM" selected>Medium</option>
-                                <option value="LARGE">Large</option>
-                                <option value="HUGE">Huge</option>
-                                <option value="GARGANTUAN">Gargantuan</option>
-                            </select>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Speed</label>
-                    <div class="control">
-                        <input id="inputSpeed" class="input" type="number" value="25" step="5">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Vision Sense</label>
-                    <div class="control">
-                        <div class="select">
-                            <select id="inputVisionSense">
-                                {{#each senseTypes}}
-                                    {{#ifEqual isVisionType 1}}
-                                        <option value="{{id}}">{{name}}</option>
-                                    {{/ifEqual}}
-                                {{/each}}
-                            </select>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Additional Sense</label>
-                    <div class="control">
-                        <div class="select">
-                            <select id="inputAdditionalSense">
-                                <option value="">Choose a Sense</option>
-                                {{#each senseTypes}}
-                                    {{#ifEqual isVisionType 0}}
-                                        <option value="{{id}}">{{name}}</option>
-                                    {{/ifEqual}}
-                                {{/each}}
-                            </select>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Extra Feature</label>
-                    <div class="control">
-                        <div class="select">
-                            <select id="inputPhysicalFeatureOne">
-                                <option value="">Choose a Feature</option>
-                                {{#each physicalFeatures}}
-                                    <option value="{{id}}">{{name}}</option>
-                                {{/each}}
-                            </select>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Extra Feature</label>
-                    <div class="control">
-                        <div class="select">
-                            <select id="inputPhysicalFeatureTwo">
-                                <option value="">Choose a Feature</option>
-                                {{#each physicalFeatures}}
-                                    <option value="{{id}}">{{name}}</option>
-                                {{/each}}
-                            </select>
-                        </div>
-                    </div>
-                </div>
-
+          <div class="tile is-child field">
+            <label class="label">Boosts</label>
+            <div class="control">
+              <div class="select is-multiple">
+                <select
+                  id="inputBoosts"
+                  multiple
+                  size="8"
+                  class="use-invisible-scrollbar"
+                >
+                  <option
+                    id="boostOptionAnything1"
+                    value="Anything"
+                  >Free</option>
+                  <option
+                    id="boostOptionAnything2"
+                    value="Anything"
+                  >Free</option>
+                  <option value="Strength">Strength</option>
+                  <option value="Dexterity">Dexterity</option>
+                  <option value="Constitution">Constitution</option>
+                  <option value="Intelligence">Intelligence</option>
+                  <option value="Wisdom">Wisdom</option>
+                  <option value="Charisma">Charisma</option>
+                </select>
+              </div>
             </div>
+          </div>
 
-            <div class="tile is-parent is-vertical box is-6 is-marginless ml-2">
-
-                <div class="tile">
-                    <div class="tile is-child field">
-                        <label class="label">Boosts</label>
-                        <div class="control">
-                            <div class="select is-multiple">
-                                <select id="inputBoosts" multiple size="8" class="use-invisible-scrollbar">
-                                    <option id="boostOptionAnything1" value="Anything">Free</option>
-                                    <option id="boostOptionAnything2" value="Anything">Free</option>
-                                    <option value="Strength">Strength</option>
-                                    <option value="Dexterity">Dexterity</option>
-                                    <option value="Constitution">Constitution</option>
-                                    <option value="Intelligence">Intelligence</option>
-                                    <option value="Wisdom">Wisdom</option>
-                                    <option value="Charisma">Charisma</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="tile is-child field">
-                        <label class="label">Flaws</label>
-                        <div class="control">
-                            <div class="select is-multiple">
-                                <select id="inputFlaws" multiple size="6" class="use-invisible-scrollbar">
-                                    <option value="Strength">Strength</option>
-                                    <option value="Dexterity">Dexterity</option>
-                                    <option value="Constitution">Constitution</option>
-                                    <option value="Intelligence">Intelligence</option>
-                                    <option value="Wisdom">Wisdom</option>
-                                    <option value="Charisma">Charisma</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile">
-                    <div class="tile is-child">
-                      <label class="label">Languages (known by default)</label>
-                      <select id="inputLangs" data-placeholder="Select Languages" multiple>
-                        {{#each languages}}
-                          <option value="{{id}}" name="{{name}}">{{name}}</option>
-                        {{/each}}
-                      </select>
-                    </div>
-
-                    <div class="tile is-child">
-                      <label class="label">Bonus Languages</label>
-                      <select id="inputBonusLangs" data-placeholder="Select Languages" multiple>
-                        {{#each languages}}
-                          <option value="{{id}}" name="{{name}}">{{name}}</option>
-                        {{/each}}
-                      </select>
-                    </div>
-
-                </div>
-
-                <div class="tile is-vertical">
-
-                    <div class="tile is-child field">
-                        <label class="label">
-                            Description
-                            <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                        </label>
-                        <div class="control">
-                            <textarea id="inputDescription" class="textarea use-custom-scrollbar" placeholder="Always hungry for new experiences..."></textarea>
-                        </div>
-                    </div>
-
-                    <div class="tile is-child field is-marginless">
-                      <div class="control">
-                        <input id="inputImageURL" class="input isURL" type="text" maxlength="200" placeholder="Image URL" spellcheck="false" autocomplete="off">
-                      </div>
-                    </div>
-                    
-                </div>
-
+          <div class="tile is-child field">
+            <label class="label">Flaws</label>
+            <div class="control">
+              <div class="select is-multiple">
+                <select
+                  id="inputFlaws"
+                  multiple
+                  size="6"
+                  class="use-invisible-scrollbar"
+                >
+                  <option value="Strength">Strength</option>
+                  <option value="Dexterity">Dexterity</option>
+                  <option value="Constitution">Constitution</option>
+                  <option value="Intelligence">Intelligence</option>
+                  <option value="Wisdom">Wisdom</option>
+                  <option value="Charisma">Charisma</option>
+                </select>
+              </div>
             </div>
+          </div>
+        </div>
+
+        <div class="tile">
+          <div class="tile is-child">
+            <label class="label">Languages (known by default)</label>
+            <select
+              id="inputLangs"
+              data-placeholder="Select Languages"
+              multiple
+            >
+              {{#each languages}}
+                <option value="{{id}}" name="{{name}}">{{name}}</option>
+              {{/each}}
+            </select>
+          </div>
+
+          <div class="tile is-child">
+            <label class="label">Bonus Languages</label>
+            <select
+              id="inputBonusLangs"
+              data-placeholder="Select Languages"
+              multiple
+            >
+              {{#each languages}}
+                <option value="{{id}}" name="{{name}}">{{name}}</option>
+              {{/each}}
+            </select>
+          </div>
 
         </div>
 
-        <div class="tile is-vertical box mt-3">
+        <div class="tile is-vertical">
 
-                <div class="tile is-child">
-                    <button id="addHeritageButton" class="button is-link">Add Hertiage</button>
-                </div>
+          <div class="tile is-child field">
+            <label class="label">
+              Description
+              <a href="/wsc_docs/#description_fields" target="_blank"><span
+                  class="icon is-small has-text-info has-tooltip-top"
+                  data-tooltip="WSC Docs"
+                ><i class="fas fa-book"></i></span></a>
+            </label>
+            <div class="control">
+              <textarea
+                id="inputDescription"
+                class="textarea use-custom-scrollbar"
+                placeholder="Always hungry for new experiences..."
+              ></textarea>
+            </div>
+          </div>
 
-                <div id="heritageContent" class="tile is-child">
-
-                    <div id="heritageLayout" class="card mb-2 ancestryHeritage is-hidden">
-                        <div class="card-header cursor-clickable">
-                            <p class="card-header-title is-paddingless has-txt-value-number is-size-5">Heritage</p>
-                            <a class="card-header-icon is-paddingless mt-1 delete is-medium"></a>
-                        </div>
-                        <div class="card-content">
-                            <div class="field">
-                                <label class="label">Name</label>
-                                <div class="control">
-                                    <input class="input inputHeritageName" type="text" placeholder="e.g. Wellspring">
-                                </div>
-                            </div>
-                            <div class="field">
-                                <label class="label">
-                                    Description
-                                    <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                </label>
-                                <div class="control">
-                                    <textarea class="textarea inputHeritageDesc" placeholder="Some other source of magic has a greater hold..."></textarea>
-                                </div>
-                            </div>
-                            <div class="field pos-relative">
-                                <label class="label">
-                                    Code
-                                    <a href="/wsc_docs/#code_basics" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                    <span class="code-block-statement-display">Builder & Sheet Statements</span>
-                                </label>
-                                <div class="control">
-                                    <textarea class="textarea inputHeritageCode nanum-coding use-custom-scrollbar" rows="1" spellcheck="false" maxlength="4990"></textarea>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                </div>
+          <div class="tile is-child field is-marginless">
+            <div class="control">
+              <input
+                id="inputImageURL"
+                class="input isURL"
+                type="text"
+                maxlength="200"
+                placeholder="Image URL"
+                spellcheck="false"
+                autocomplete="off"
+              />
+            </div>
+          </div>
 
         </div>
 
-        <div class="tile is-vertical box mt-3">
-
-                <div class="tile is-child">
-                    <button id="addFeatButton" class="button is-link">Add Ancestry Feat</button>
-                </div>
-
-                <div id="featContent" class="tile is-child">
-
-                    <div id="featLayout" class="card mb-2 ancestryFeat is-hidden">
-                        <div class="card-header cursor-clickable">
-                            <p class="card-header-title is-paddingless has-txt-value-number is-size-5">Ancestry Feat</p>
-                            <a class="card-header-icon is-paddingless mt-1 delete is-medium"></a>
-                        </div>
-                        <div class="card-content">
-                            <div class="field">
-                                <label class="label">Name</label>
-                                <div class="control">
-                                    <input class="input inputFeatName" type="text" placeholder="e.g. Grim Insight">
-                                </div>
-                            </div>
-
-                            <div class="columns">
-                                <div class="column field">
-                                    <label class="label">Level</label>
-                                    <div class="control">
-                                        <div class="select">
-                                            <select class="inputFeatLevel">
-                                                <option value="-1">Unselectable</option>
-                                                <option value="1" selected>1</option>
-                                                <option value="5">5</option>
-                                                <option value="9">9</option>
-                                                <option value="13">13</option>
-                                                <option value="17">17</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div class="column field">
-                                    <label class="label">Actions</label>
-                                    <div class="control">
-                                        <div class="select">
-                                            <select class="inputFeatActions pf-icon">
-                                                <option value="NONE">None</option>
-                                                <option value="ACTION">[one-action]</option>
-                                                <option value="TWO_ACTIONS">[two-actions]</option>
-                                                <option value="THREE_ACTIONS">[three-actions]</option>
-                                                <option value="FREE_ACTION">[free-action]</option>
-                                                <option value="REACTION">[reaction]</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div class="column field">
-                                    <label class="label">Rarity</label>
-                                    <div class="control">
-                                        <div class="select">
-                                            <select class="inputFeatRarity">
-                                                <option value="COMMON">Common</option>
-                                                <option value="UNCOMMON">Uncommon</option>
-                                                <option value="RARE">Rare</option>
-                                                <option value="UNIQUE">Unique</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="">
-                                <label class="label">Other Traits</label>
-                                <select class="inputFeatTags" data-placeholder="Select Traits" multiple>
-                                  {{#each tags}}
-                                    <option value="{{id}}">{{name}}</option>
-                                  {{/each}}
-                                </select>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Prerequisites</label>
-                                <div class="control">
-                                    <input class="input inputFeatPrereq" type="text" maxlength="290" placeholder="e.g. umbral gnome heritage">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Requirements</label>
-                                <div class="control">
-                                    <input class="input inputFeatReq" type="text" maxlength="590">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Frequency</label>
-                                <div class="control">
-                                    <input class="input inputFeatFreq" type="text" maxlength="290">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Cost</label>
-                                <div class="control">
-                                    <input class="input inputFeatCost" type="text" maxlength="290">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Trigger</label>
-                                <div class="control">
-                                    <input class="input inputFeatTrigger" type="text" maxlength="290">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">
-                                    Description
-                                    <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                </label>
-                                <div class="control">
-                                    <textarea class="textarea inputFeatDesc" placeholder="Others’ attempts to scare you often grant you insights..."></textarea>
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">
-                                  Special
-                                  <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                </label>
-                                <div class="control">
-                                    <input class="input inputFeatSpecial" type="text" maxlength="590">
-                                </div>
-                            </div>
-
-                            <div class="field pt-1">
-                                <label class="checkbox">
-                                    <input type="checkbox" class="inputFeatSelectMultiple" value="1">
-                                    <strong>Can Choose Multiple Times</strong>
-                                </label>
-                            </div>
-
-                            <div class="field pos-relative">
-                                <label class="label">
-                                    Code
-                                    <a href="/wsc_docs/#code_basics" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                    <span class="code-block-statement-display">Builder & Sheet Statements</span>
-                                </label>
-                                <div class="control">
-                                    <textarea class="textarea inputFeatCode nanum-coding use-custom-scrollbar" rows="1" spellcheck="false" maxlength="4990"></textarea>
-                                </div>
-                            </div>
-
-                        </div>
-                    </div>
-                    
-
-                </div>
-
-        </div>
+      </div>
 
     </div>
+
+    <div class="tile is-vertical box mt-3">
+
+      <div class="tile is-child">
+        <button id="addHeritageButton" class="button is-link">Add Hertiage</button>
+      </div>
+
+      <div id="heritageContent" class="tile is-child">
+
+        <div id="heritageLayout" class="card mb-2 ancestryHeritage is-hidden">
+          <div class="card-header cursor-clickable">
+            <p
+              class="card-header-title is-paddingless has-txt-value-number is-size-5"
+            >Heritage</p>
+            <a
+              class="card-header-icon is-paddingless mt-1 delete is-medium"
+            ></a>
+          </div>
+          <div class="card-content">
+            <div class="field">
+              <label class="label">Name</label>
+              <div class="control">
+                <input
+                  class="input inputHeritageName"
+                  type="text"
+                  placeholder="e.g. Wellspring"
+                />
+              </div>
+            </div>
+            <div class="field">
+              <label class="label">
+                Description
+                <a href="/wsc_docs/#description_fields" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+              </label>
+              <div class="control">
+                <textarea
+                  class="textarea inputHeritageDesc"
+                  placeholder="Some other source of magic has a greater hold..."
+                ></textarea>
+              </div>
+            </div>
+            <div class="field pos-relative">
+              <label class="label">
+                Code
+                <a href="/wsc_docs/#code_basics" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+                <span class="code-block-statement-display">Builder & Sheet
+                  Statements</span>
+              </label>
+              <div class="control">
+                <textarea
+                  class="textarea inputHeritageCode nanum-coding use-custom-scrollbar"
+                  rows="1"
+                  spellcheck="false"
+                  maxlength="4990"
+                ></textarea>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+    </div>
+
+    <div class="tile is-vertical box mt-3">
+
+      <div class="tile is-child">
+        <button id="addFeatButton" class="button is-link">Add Ancestry Feat</button>
+      </div>
+
+      <div id="featContent" class="tile is-child">
+
+        <div id="featLayout" class="card mb-2 ancestryFeat is-hidden">
+          <div class="card-header cursor-clickable">
+            <p
+              class="card-header-title is-paddingless has-txt-value-number is-size-5"
+            >Ancestry Feat</p>
+            <a
+              class="card-header-icon is-paddingless mt-1 delete is-medium"
+            ></a>
+          </div>
+          <div class="card-content">
+            <div class="field">
+              <label class="label">Name</label>
+              <div class="control">
+                <input
+                  class="input inputFeatName"
+                  type="text"
+                  placeholder="e.g. Grim Insight"
+                />
+              </div>
+            </div>
+
+            <div class="columns">
+              <div class="column field">
+                <label class="label">Level</label>
+                <div class="control">
+                  <div class="select">
+                    <select class="inputFeatLevel">
+                      <option value="-1">Unselectable</option>
+                      <option value="1" selected>1</option>
+                      <option value="5">5</option>
+                      <option value="9">9</option>
+                      <option value="13">13</option>
+                      <option value="17">17</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+
+              <div class="column field">
+                <label class="label">Actions</label>
+                <div class="control">
+                  <div class="select">
+                    <select class="inputFeatActions pf-icon">
+                      <option value="NONE">None</option>
+                      <option value="ACTION">[one-action]</option>
+                      <option value="TWO_ACTIONS">[two-actions]</option>
+                      <option value="THREE_ACTIONS">[three-actions]</option>
+                      <option value="FREE_ACTION">[free-action]</option>
+                      <option value="REACTION">[reaction]</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+
+              <div class="column field">
+                <label class="label">Rarity</label>
+                <div class="control">
+                  <div class="select">
+                    <select class="inputFeatRarity">
+                      <option value="COMMON">Common</option>
+                      <option value="UNCOMMON">Uncommon</option>
+                      <option value="RARE">Rare</option>
+                      <option value="UNIQUE">Unique</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="">
+              <label class="label">Other Traits</label>
+              <select
+                class="inputFeatTags"
+                data-placeholder="Select Traits"
+                multiple
+              >
+                {{#each tags}}
+                  <option value="{{id}}">{{name}}</option>
+                {{/each}}
+              </select>
+            </div>
+
+            <div class="field">
+              <label class="label">Prerequisites</label>
+              <div class="control">
+                <input
+                  class="input inputFeatPrereq"
+                  type="text"
+                  maxlength="290"
+                  placeholder="e.g. umbral gnome heritage"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">Requirements</label>
+              <div class="control">
+                <input class="input inputFeatReq" type="text" maxlength="590" />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">Frequency</label>
+              <div class="control">
+                <input
+                  class="input inputFeatFreq"
+                  type="text"
+                  maxlength="290"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">Cost</label>
+              <div class="control">
+                <input
+                  class="input inputFeatCost"
+                  type="text"
+                  maxlength="290"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">Trigger</label>
+              <div class="control">
+                <input
+                  class="input inputFeatTrigger"
+                  type="text"
+                  maxlength="290"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">
+                Description
+                <a href="/wsc_docs/#description_fields" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+              </label>
+              <div class="control">
+                <textarea
+                  class="textarea inputFeatDesc"
+                  placeholder="Others’ attempts to scare you often grant you insights..."
+                ></textarea>
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">
+                Special
+                <a href="/wsc_docs/#description_fields" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+              </label>
+              <div class="control">
+                <input
+                  class="input inputFeatSpecial"
+                  type="text"
+                  maxlength="590"
+                />
+              </div>
+            </div>
+
+            <div class="field pt-1">
+              <label class="checkbox">
+                <input
+                  type="checkbox"
+                  class="inputFeatSelectMultiple"
+                  value="1"
+                />
+                <strong>Can Choose Multiple Times</strong>
+              </label>
+            </div>
+
+            <div class="field pos-relative">
+              <label class="label">
+                Code
+                <a href="/wsc_docs/#code_basics" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+                <span class="code-block-statement-display">Builder & Sheet
+                  Statements</span>
+              </label>
+              <div class="control">
+                <textarea
+                  class="textarea inputFeatCode nanum-coding use-custom-scrollbar"
+                  rows="1"
+                  spellcheck="false"
+                  maxlength="4990"
+                ></textarea>
+              </div>
+            </div>
+
+          </div>
+        </div>
+
+      </div>
+
+    </div>
+
+  </div>
 </div>
 
 <div class="field is-grouped is-grouped-centered pb-2">
-    <div class="control">
-        <!--<a class="button is-info is-rounded is-small has-text-white">
+  <div class="control">
+    <!--<a class="button is-info is-rounded is-small has-text-white">
           <span class="icon is-small">
             <i class="fas fa-arrow-left"></i>
           </span>
           <span>Back</span>
         </a>-->
-        {{#if ancestryID}}
-            <button id="updateButton" onClick="canLeavePage()" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{else}}
-            <button id="createButton" onClick="canLeavePage()" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{/if}}
-    </div>
+    {{#if ancestryID}}
+      <button
+        id="updateButton"
+        onClick="canLeavePage()"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{else}}
+      <button
+        id="createButton"
+        onClick="canLeavePage()"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{/if}}
+  </div>
 </div>

--- a/views/homebrew/builder_animal-companion.handlebars
+++ b/views/homebrew/builder_animal-companion.handlebars
@@ -1,365 +1,452 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/homebrew-builders.css">
-    <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
-    <script type="text/javascript" src="/js/homebrew/builder/spell/builder-spell.js"></script>
-    {{#if spellID}}
-        <script type="text/javascript" src="/js/homebrew/builder/spell/editor-spell.js"></script>
-    {{/if}}
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/homebrew-builders.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
+  <script
+    type="text/javascript"
+    src="/js/homebrew/builder/spell/builder-spell.js"
+  ></script>
+  {{#if spellID}}
+    <script
+      type="text/javascript"
+      src="/js/homebrew/builder/spell/editor-spell.js"
+    ></script>
+  {{/if}}
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew" class="active">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/homebrew"
+      class="active"
+    >Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
+
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="pageloader">
-    <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+  <div class="lds-roller"><div></div><div></div><div></div><div></div><div
+    ></div><div></div><div></div><div></div></div>
 </div>
 
 <div class="pt-3">
-    <h1 class="title is-2 has-txt-value-number has-text-centered">Animal Companion Builder</h1>
+  <h1 class="title is-2 has-txt-value-number has-text-centered">Animal Companion
+    Builder</h1>
 </div>
 
-<div id="builder-container" data-user-id="{{user.id}}" data-bundle-id="{{bundleID}}" data-animal-comp-id="{{animalCompID}}" class="columns is-mobile is-centered mt-2 mb-3">
-    <div class="column is-8 tile is-ancestor is-vertical">
+<div
+  id="builder-container"
+  data-user-id="{{user.id}}"
+  data-bundle-id="{{bundleID}}"
+  data-animal-comp-id="{{animalCompID}}"
+  class="columns is-mobile is-centered mt-2 mb-3"
+>
+  <div class="column is-8 tile is-ancestor is-vertical">
 
-        <div class="tile">
+    <div class="tile">
 
-            <div class="tile is-parent is-vertical box is-marginless">
+      <div class="tile is-parent is-vertical box is-marginless">
 
-                <div class="tile is-child field">
-                    <label class="label">Name</label>
-                    <div class="control">
-                        <input class="input" id="inputName" type="text" placeholder="e.g. Crocodile" autocomplete="off">
-                    </div>
-                </div>
-
-                <div class="tile is-child columns">
-
-                    <div class="column field">
-                        <label class="label">Rarity</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputRarity">
-                                    <option value="COMMON">Common</option>
-                                    <option value="UNCOMMON">Uncommon</option>
-                                    <option value="RARE">Rare</option>
-                                    <option value="UNIQUE">Unique</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Starting Size</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputSize">
-                                    <option value="TINY">Tiny</option>
-                                    <option value="SMALL" selected>Small</option>
-                                    <option value="SMALL-MED">Small or Medium</option>
-                                    <option value="MEDIUM">Medium</option>
-                                    <option value="MED-LARGE">Medium or Large</option>
-                                    <option value="LARGE">Large</option>
-                                    <option value="HUGE">Huge</option>
-                                    <option value="GARGANTUAN">Gargantuan</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                </div>
-
-                <div class="tile is-child columns">
-                    
-                    <div class="column field">
-                        <label class="label">Attack Name</label>
-                        <div class="control">
-                            <input class="input" id="inputA1Name" type="text" maxlength="40" placeholder="">
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Type</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputA1Type">
-                                    <option value="MELEE" selected>Melee</option>
-                                    <option value="RANGED">Ranged</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="column is-2 field">
-                        <label class="label">Damage Die</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputDieType">
-                                    <option value="">1</option>
-                                    <option value="d2">d2</option>
-                                    <option value="d4">d4</option>
-                                    <option value="d6" selected>d6</option>
-                                    <option value="d8">d8</option>
-                                    <option value="d10">d10</option>
-                                    <option value="d12">d12</option>
-                                    <option value="d20">d20</option>
-                                    <option value="NONE">-</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Damage Type (most likely just: P, S, or B)</label>
-                        <div class="control">
-                            <input class="input" id="inputDamageType" type="text" maxlength="40" placeholder="">
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Weapon Category</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputWeaponCategory">
-                                    <option value="SIMPLE" selected>Simple</option>
-                                    <option value="MARTIAL">Martial</option>
-                                    <option value="ADVANCED">Advanced</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                </div>
-
-                <div class="tile is-child">
-                    <label class="label">Traits</label>
-                    <select id="inputTags" data-placeholder="Select Traits" multiple>
-                        {{#each tags}}
-                            <option value="{{id}}">{{name}}</option>
-                        {{/each}}
-                    </select>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Range</label>
-                    <div class="control">
-                        <input class="input" id="inputRange" type="text" maxlength="290" placeholder="">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Area</label>
-                    <div class="control">
-                        <input class="input" id="inputArea" type="text" maxlength="290" placeholder="">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Targets</label>
-                    <div class="control">
-                        <input class="input" id="inputTargets" type="text" maxlength="290" placeholder="">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Saving Throw</label>
-                    <div class="control">
-                        <div class="select">
-                            <select id="inputSavingThrow">
-                                <option value="">N/A</option>
-                                <option value="FORT">Fortitude</option>
-                                <option value="REFLEX">Reflex</option>
-                                <option value="WILL">Will</option>
-                                <option value="BASIC_FORT">Basic Fortitude</option>
-                                <option value="BASIC_REFLEX">Basic Reflex</option>
-                                <option value="BASIC_WILL">Basic Will</option>
-                            </select>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Duration</label>
-                    <div class="control">
-                        <input class="input" id="inputDuration" type="text" maxlength="290" placeholder="">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">
-                        Description
-                        <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                    </label>
-                    <div class="control">
-                        <textarea class="textarea" id="inputDesc" placeholder="The target’s form appears blurry..."></textarea>
-                    </div>
-                </div>
-
-                <div class="tile is-child columns">
-                    <div class="column is-2 field">
-                        <div class="control is-pulled-right">
-                            <div class="select">
-                                <select id="inputHeightenedOneVal">
-                                    <option value="">N/A</option>
-                                    <option value="PLUS_ONE">+1</option>
-                                    <option value="PLUS_TWO">+2</option>
-                                    <option value="PLUS_THREE">+3</option>
-                                    <option value="PLUS_FOUR">+4</option>
-                                    <option value="LEVEL_2">2nd</option>
-                                    <option value="LEVEL_3">3rd</option>
-                                    <option value="LEVEL_4">4th</option>
-                                    <option value="LEVEL_5">5th</option>
-                                    <option value="LEVEL_6">6th</option>
-                                    <option value="LEVEL_7">7th</option>
-                                    <option value="LEVEL_8">8th</option>
-                                    <option value="LEVEL_9">9th</option>
-                                    <option value="LEVEL_10">10th</option>
-                                    <option value="CUSTOM">Custom</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="column field">
-                        <label class="label">Heightened</label>
-                        <div class="control">
-                            <textarea id="inputHeightenedOneText" class="textarea"></textarea>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child columns">
-                    <div class="column is-2 field">
-                        <div class="control is-pulled-right">
-                            <div class="select">
-                                <select id="inputHeightenedTwoVal">
-                                    <option value="">N/A</option>
-                                    <option value="PLUS_ONE">+1</option>
-                                    <option value="PLUS_TWO">+2</option>
-                                    <option value="PLUS_THREE">+3</option>
-                                    <option value="PLUS_FOUR">+4</option>
-                                    <option value="LEVEL_2">2nd</option>
-                                    <option value="LEVEL_3">3rd</option>
-                                    <option value="LEVEL_4">4th</option>
-                                    <option value="LEVEL_5">5th</option>
-                                    <option value="LEVEL_6">6th</option>
-                                    <option value="LEVEL_7">7th</option>
-                                    <option value="LEVEL_8">8th</option>
-                                    <option value="LEVEL_9">9th</option>
-                                    <option value="LEVEL_10">10th</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="column field">
-                        <label class="label">Heightened</label>
-                        <div class="control">
-                            <textarea id="inputHeightenedTwoText" class="textarea"></textarea>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child columns">
-                    <div class="column is-2 field">
-                        <div class="control is-pulled-right">
-                            <div class="select">
-                                <select id="inputHeightenedThreeVal">
-                                    <option value="">N/A</option>
-                                    <option value="PLUS_ONE">+1</option>
-                                    <option value="PLUS_TWO">+2</option>
-                                    <option value="PLUS_THREE">+3</option>
-                                    <option value="PLUS_FOUR">+4</option>
-                                    <option value="LEVEL_2">2nd</option>
-                                    <option value="LEVEL_3">3rd</option>
-                                    <option value="LEVEL_4">4th</option>
-                                    <option value="LEVEL_5">5th</option>
-                                    <option value="LEVEL_6">6th</option>
-                                    <option value="LEVEL_7">7th</option>
-                                    <option value="LEVEL_8">8th</option>
-                                    <option value="LEVEL_9">9th</option>
-                                    <option value="LEVEL_10">10th</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="column field">
-                        <label class="label">Heightened</label>
-                        <div class="control">
-                            <textarea id="inputHeightenedThreeText" class="textarea"></textarea>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child columns">
-                    <div class="column is-2 field">
-                        <div class="control is-pulled-right">
-                            <div class="select">
-                                <select id="inputHeightenedFourVal">
-                                    <option value="">N/A</option>
-                                    <option value="PLUS_ONE">+1</option>
-                                    <option value="PLUS_TWO">+2</option>
-                                    <option value="PLUS_THREE">+3</option>
-                                    <option value="PLUS_FOUR">+4</option>
-                                    <option value="LEVEL_2">2nd</option>
-                                    <option value="LEVEL_3">3rd</option>
-                                    <option value="LEVEL_4">4th</option>
-                                    <option value="LEVEL_5">5th</option>
-                                    <option value="LEVEL_6">6th</option>
-                                    <option value="LEVEL_7">7th</option>
-                                    <option value="LEVEL_8">8th</option>
-                                    <option value="LEVEL_9">9th</option>
-                                    <option value="LEVEL_10">10th</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="column field">
-                        <label class="label">Heightened</label>
-                        <div class="control">
-                            <textarea id="inputHeightenedFourText" class="textarea"></textarea>
-                        </div>
-                    </div>
-                </div>
-
-            </div>
+        <div class="tile is-child field">
+          <label class="label">Name</label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputName"
+              type="text"
+              placeholder="e.g. Crocodile"
+              autocomplete="off"
+            />
+          </div>
         </div>
+
+        <div class="tile is-child columns">
+
+          <div class="column field">
+            <label class="label">Rarity</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputRarity">
+                  <option value="COMMON">Common</option>
+                  <option value="UNCOMMON">Uncommon</option>
+                  <option value="RARE">Rare</option>
+                  <option value="UNIQUE">Unique</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Starting Size</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputSize">
+                  <option value="TINY">Tiny</option>
+                  <option value="SMALL" selected>Small</option>
+                  <option value="SMALL-MED">Small or Medium</option>
+                  <option value="MEDIUM">Medium</option>
+                  <option value="MED-LARGE">Medium or Large</option>
+                  <option value="LARGE">Large</option>
+                  <option value="HUGE">Huge</option>
+                  <option value="GARGANTUAN">Gargantuan</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        <div class="tile is-child columns">
+
+          <div class="column field">
+            <label class="label">Attack Name</label>
+            <div class="control">
+              <input
+                class="input"
+                id="inputA1Name"
+                type="text"
+                maxlength="40"
+                placeholder=""
+              />
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Type</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputA1Type">
+                  <option value="MELEE" selected>Melee</option>
+                  <option value="RANGED">Ranged</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div class="column is-2 field">
+            <label class="label">Damage Die</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputDieType">
+                  <option value="">1</option>
+                  <option value="d2">d2</option>
+                  <option value="d4">d4</option>
+                  <option value="d6" selected>d6</option>
+                  <option value="d8">d8</option>
+                  <option value="d10">d10</option>
+                  <option value="d12">d12</option>
+                  <option value="d20">d20</option>
+                  <option value="NONE">-</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Damage Type (most likely just: P, S, or B)</label>
+            <div class="control">
+              <input
+                class="input"
+                id="inputDamageType"
+                type="text"
+                maxlength="40"
+                placeholder=""
+              />
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Weapon Category</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputWeaponCategory">
+                  <option value="SIMPLE" selected>Simple</option>
+                  <option value="MARTIAL">Martial</option>
+                  <option value="ADVANCED">Advanced</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        <div class="tile is-child">
+          <label class="label">Traits</label>
+          <select id="inputTags" data-placeholder="Select Traits" multiple>
+            {{#each tags}}
+              <option value="{{id}}">{{name}}</option>
+            {{/each}}
+          </select>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Range</label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputRange"
+              type="text"
+              maxlength="290"
+              placeholder=""
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Area</label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputArea"
+              type="text"
+              maxlength="290"
+              placeholder=""
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Targets</label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputTargets"
+              type="text"
+              maxlength="290"
+              placeholder=""
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Saving Throw</label>
+          <div class="control">
+            <div class="select">
+              <select id="inputSavingThrow">
+                <option value="">N/A</option>
+                <option value="FORT">Fortitude</option>
+                <option value="REFLEX">Reflex</option>
+                <option value="WILL">Will</option>
+                <option value="BASIC_FORT">Basic Fortitude</option>
+                <option value="BASIC_REFLEX">Basic Reflex</option>
+                <option value="BASIC_WILL">Basic Will</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Duration</label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputDuration"
+              type="text"
+              maxlength="290"
+              placeholder=""
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">
+            Description
+            <a href="/wsc_docs/#description_fields" target="_blank"><span
+                class="icon is-small has-text-info has-tooltip-top"
+                data-tooltip="WSC Docs"
+              ><i class="fas fa-book"></i></span></a>
+          </label>
+          <div class="control">
+            <textarea
+              class="textarea"
+              id="inputDesc"
+              placeholder="The target’s form appears blurry..."
+            ></textarea>
+          </div>
+        </div>
+
+        <div class="tile is-child columns">
+          <div class="column is-2 field">
+            <div class="control is-pulled-right">
+              <div class="select">
+                <select id="inputHeightenedOneVal">
+                  <option value="">N/A</option>
+                  <option value="PLUS_ONE">+1</option>
+                  <option value="PLUS_TWO">+2</option>
+                  <option value="PLUS_THREE">+3</option>
+                  <option value="PLUS_FOUR">+4</option>
+                  <option value="LEVEL_2">2nd</option>
+                  <option value="LEVEL_3">3rd</option>
+                  <option value="LEVEL_4">4th</option>
+                  <option value="LEVEL_5">5th</option>
+                  <option value="LEVEL_6">6th</option>
+                  <option value="LEVEL_7">7th</option>
+                  <option value="LEVEL_8">8th</option>
+                  <option value="LEVEL_9">9th</option>
+                  <option value="LEVEL_10">10th</option>
+                  <option value="CUSTOM">Custom</option>
+                </select>
+              </div>
+            </div>
+          </div>
+          <div class="column field">
+            <label class="label">Heightened</label>
+            <div class="control">
+              <textarea id="inputHeightenedOneText" class="textarea"></textarea>
+            </div>
+          </div>
+        </div>
+
+        <div class="tile is-child columns">
+          <div class="column is-2 field">
+            <div class="control is-pulled-right">
+              <div class="select">
+                <select id="inputHeightenedTwoVal">
+                  <option value="">N/A</option>
+                  <option value="PLUS_ONE">+1</option>
+                  <option value="PLUS_TWO">+2</option>
+                  <option value="PLUS_THREE">+3</option>
+                  <option value="PLUS_FOUR">+4</option>
+                  <option value="LEVEL_2">2nd</option>
+                  <option value="LEVEL_3">3rd</option>
+                  <option value="LEVEL_4">4th</option>
+                  <option value="LEVEL_5">5th</option>
+                  <option value="LEVEL_6">6th</option>
+                  <option value="LEVEL_7">7th</option>
+                  <option value="LEVEL_8">8th</option>
+                  <option value="LEVEL_9">9th</option>
+                  <option value="LEVEL_10">10th</option>
+                </select>
+              </div>
+            </div>
+          </div>
+          <div class="column field">
+            <label class="label">Heightened</label>
+            <div class="control">
+              <textarea id="inputHeightenedTwoText" class="textarea"></textarea>
+            </div>
+          </div>
+        </div>
+
+        <div class="tile is-child columns">
+          <div class="column is-2 field">
+            <div class="control is-pulled-right">
+              <div class="select">
+                <select id="inputHeightenedThreeVal">
+                  <option value="">N/A</option>
+                  <option value="PLUS_ONE">+1</option>
+                  <option value="PLUS_TWO">+2</option>
+                  <option value="PLUS_THREE">+3</option>
+                  <option value="PLUS_FOUR">+4</option>
+                  <option value="LEVEL_2">2nd</option>
+                  <option value="LEVEL_3">3rd</option>
+                  <option value="LEVEL_4">4th</option>
+                  <option value="LEVEL_5">5th</option>
+                  <option value="LEVEL_6">6th</option>
+                  <option value="LEVEL_7">7th</option>
+                  <option value="LEVEL_8">8th</option>
+                  <option value="LEVEL_9">9th</option>
+                  <option value="LEVEL_10">10th</option>
+                </select>
+              </div>
+            </div>
+          </div>
+          <div class="column field">
+            <label class="label">Heightened</label>
+            <div class="control">
+              <textarea
+                id="inputHeightenedThreeText"
+                class="textarea"
+              ></textarea>
+            </div>
+          </div>
+        </div>
+
+        <div class="tile is-child columns">
+          <div class="column is-2 field">
+            <div class="control is-pulled-right">
+              <div class="select">
+                <select id="inputHeightenedFourVal">
+                  <option value="">N/A</option>
+                  <option value="PLUS_ONE">+1</option>
+                  <option value="PLUS_TWO">+2</option>
+                  <option value="PLUS_THREE">+3</option>
+                  <option value="PLUS_FOUR">+4</option>
+                  <option value="LEVEL_2">2nd</option>
+                  <option value="LEVEL_3">3rd</option>
+                  <option value="LEVEL_4">4th</option>
+                  <option value="LEVEL_5">5th</option>
+                  <option value="LEVEL_6">6th</option>
+                  <option value="LEVEL_7">7th</option>
+                  <option value="LEVEL_8">8th</option>
+                  <option value="LEVEL_9">9th</option>
+                  <option value="LEVEL_10">10th</option>
+                </select>
+              </div>
+            </div>
+          </div>
+          <div class="column field">
+            <label class="label">Heightened</label>
+            <div class="control">
+              <textarea
+                id="inputHeightenedFourText"
+                class="textarea"
+              ></textarea>
+            </div>
+          </div>
+        </div>
+
+      </div>
     </div>
+  </div>
 </div>
 
 <div class="field is-grouped is-grouped-centered pb-2">
-    <div class="control">
-        {{#if spellID}}
-            <button id="updateButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{else}}
-            <button id="createButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{/if}}
-    </div>
+  <div class="control">
+    {{#if spellID}}
+      <button
+        id="updateButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{else}}
+      <button
+        id="createButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{/if}}
+  </div>
 </div>

--- a/views/homebrew/builder_archetype.handlebars
+++ b/views/homebrew/builder_archetype.handlebars
@@ -1,422 +1,571 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/homebrew-builders.css">
-    <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
-    <script type="text/javascript" src="/js/homebrew/builder/archetype/builder-archetype.js"></script>
-    {{#if archetypeID}}
-        <script type="text/javascript" src="/js/homebrew/builder/archetype/editor-archetype.js"></script>
-    {{/if}}
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/homebrew-builders.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
+  <script
+    type="text/javascript"
+    src="/js/homebrew/builder/archetype/builder-archetype.js"
+  ></script>
+  {{#if archetypeID}}
+    <script
+      type="text/javascript"
+      src="/js/homebrew/builder/archetype/editor-archetype.js"
+    ></script>
+  {{/if}}
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew" class="active">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/homebrew"
+      class="active"
+    >Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
+
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="pageloader">
-    <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+  <div class="lds-roller"><div></div><div></div><div></div><div></div><div
+    ></div><div></div><div></div><div></div></div>
 </div>
 
 <div class="pt-3">
-    <h1 class="title is-2 has-txt-value-number has-text-centered">Archetype Builder</h1>
+  <h1 class="title is-2 has-txt-value-number has-text-centered">Archetype
+    Builder</h1>
 </div>
 
-<div id="builder-container" data-user-id="{{user.id}}" data-bundle-id="{{bundleID}}" data-archetype-id="{{archetypeID}}" class="columns is-mobile is-centered mt-2 mb-3">
-    <div class="column is-8 tile is-ancestor is-vertical">
+<div
+  id="builder-container"
+  data-user-id="{{user.id}}"
+  data-bundle-id="{{bundleID}}"
+  data-archetype-id="{{archetypeID}}"
+  class="columns is-mobile is-centered mt-2 mb-3"
+>
+  <div class="column is-8 tile is-ancestor is-vertical">
 
-        <div class="tile">
+    <div class="tile">
 
-            <div class="tile is-parent is-vertical box is-marginless mr-2">
+      <div class="tile is-parent is-vertical box is-marginless mr-2">
 
-                <div class="tile is-child field">
-                    <label class="label">Name</label>
-                    <div class="control">
-                        <input id="inputName" class="input" type="text" placeholder="e.g. Wizard" autocomplete="off">
-                    </div>
-                </div>
-
-                <div class="tile is-child field pl-2">
-                    <label class="checkbox">
-                        <input type="checkbox" id="inputIsMulticlass" value="1">
-                        <strong>Is Multiclass</strong>
-                    </label>
-                </div>
-            
-                <div class="tile is-child field">
-                    <label class="label">
-                        Description
-                        <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                    </label>
-                    <div class="control">
-                        <textarea id="inputDescription" class="textarea" placeholder="You enjoy tinkering with alchemical formulas..."></textarea>
-                    </div>
-                </div>
-                
-            </div>
-
+        <div class="tile is-child field">
+          <label class="label">Name</label>
+          <div class="control">
+            <input
+              id="inputName"
+              class="input"
+              type="text"
+              placeholder="e.g. Wizard"
+              autocomplete="off"
+            />
+          </div>
         </div>
 
-        <div class="tile is-vertical box mt-3">
-            <div class="tile is-child">
-                
-                    <div id="dedicationFeat" class="card mb-2">
-                        <div class="card-header cursor-clickable">
-                            <p class="card-header-title is-paddingless has-txt-value-number is-size-5">Dedication Feat</p>
-                        </div>
-                        <div class="card-content">
-
-                            <div class="columns">
-                                <div class="column field">
-                                    <label class="label">Level</label>
-                                    <div class="control">
-                                        <div class="select">
-                                            <select class="inputFeatLevel">
-                                                <option value="1">1</option>
-                                                <option value="2" selected>2</option>
-                                                <option value="4">4</option>
-                                                <option value="6">6</option>
-                                                <option value="8">8</option>
-                                                <option value="10">10</option>
-                                                <option value="12">12</option>
-                                                <option value="14">14</option>
-                                                <option value="16">16</option>
-                                                <option value="18">18</option>
-                                                <option value="20">20</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div class="column field is-hidden">
-                                    <label class="label">Actions</label>
-                                    <div class="control">
-                                        <div class="select">
-                                            <select class="inputFeatActions pf-icon">
-                                                <option value="NONE">None</option>
-                                                <option value="ACTION">[one-action]</option>
-                                                <option value="TWO_ACTIONS">[two-actions]</option>
-                                                <option value="THREE_ACTIONS">[three-actions]</option>
-                                                <option value="FREE_ACTION">[free-action]</option>
-                                                <option value="REACTION">[reaction]</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div class="column field">
-                                    <label class="label">Rarity</label>
-                                    <div class="control">
-                                        <div class="select">
-                                            <select class="inputFeatRarity">
-                                                <option value="COMMON">Common</option>
-                                                <option value="UNCOMMON">Uncommon</option>
-                                                <option value="RARE">Rare</option>
-                                                <option value="UNIQUE">Unique</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="">
-                                <label class="label">Other Traits</label>
-                                <select class="inputFeatTags" data-placeholder="Select Traits" multiple>
-                                  {{#each tags}}
-                                    <option value="{{id}}">{{name}}</option>
-                                  {{/each}}
-                                </select>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Prerequisites</label>
-                                <div class="control">
-                                    <input class="input inputFeatPrereq" type="text" maxlength="290" placeholder="">
-                                </div>
-                            </div>
-
-                            <div class="field is-hidden">
-                                <label class="label">Requirements</label>
-                                <div class="control">
-                                    <input class="input inputFeatReq" type="text" maxlength="590">
-                                </div>
-                            </div>
-
-                            <div class="field is-hidden">
-                                <label class="label">Frequency</label>
-                                <div class="control">
-                                    <input class="input inputFeatFreq" type="text" maxlength="290">
-                                </div>
-                            </div>
-
-                            <div class="field is-hidden">
-                                <label class="label">Cost</label>
-                                <div class="control">
-                                    <input class="input inputFeatCost" type="text" maxlength="290">
-                                </div>
-                            </div>
-
-                            <div class="field is-hidden">
-                                <label class="label">Trigger</label>
-                                <div class="control">
-                                    <input class="input inputFeatTrigger" type="text" maxlength="290">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">
-                                    Description
-                                    <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                </label>
-                                <div class="control">
-                                    <textarea class="textarea inputFeatDesc" placeholder="Others’ attempts to scare you often grant you insights..."></textarea>
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">
-                                  Special
-                                  <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                </label>
-                                <div class="control">
-                                    <input class="input inputFeatSpecial" type="text" maxlength="590">
-                                </div>
-                            </div>
-
-                            <div class="field pt-1 is-hidden">
-                                <label class="checkbox">
-                                    <input type="checkbox" class="inputFeatSelectMultiple" value="1">
-                                    <strong>Can Choose Multiple Times</strong>
-                                </label>
-                            </div>
-
-                            <div class="field pos-relative">
-                                <label class="label">
-                                    Code
-                                    <a href="/wsc_docs/#code_basics" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                    <span class="code-block-statement-display">Builder & Sheet Statements</span>
-                                </label>
-                                <div class="control">
-                                    <textarea class="textarea inputFeatCode nanum-coding use-custom-scrollbar" rows="1" spellcheck="false" maxlength="990"></textarea>
-                                </div>
-                            </div>
-
-                        </div>
-                    </div>
-
-            </div>
+        <div class="tile is-child field pl-2">
+          <label class="checkbox">
+            <input type="checkbox" id="inputIsMulticlass" value="1" />
+            <strong>Is Multiclass</strong>
+          </label>
         </div>
 
-        <div class="tile is-vertical box mt-3">
-
-                <div class="tile is-child">
-                    <button id="addFeatButton" class="button is-link">Add Archetype Feat</button>
-                </div>
-
-                <div id="featContent" class="tile is-child">
-
-                    <div id="featLayout" class="card mb-2 archetypeFeat is-hidden">
-                        <div class="card-header cursor-clickable">
-                            <p class="card-header-title is-paddingless has-txt-value-number is-size-5">Archetype Feat</p>
-                            <a class="card-header-icon is-paddingless mt-1 delete is-medium"></a>
-                        </div>
-                        <div class="card-content">
-                            <div class="field">
-                                <label class="label">Name</label>
-                                <div class="control">
-                                    <input class="input inputFeatName" type="text" placeholder="e.g. Basic Arcana">
-                                </div>
-                            </div>
-
-                            <div class="columns">
-                                <div class="column field">
-                                    <label class="label">Level</label>
-                                    <div class="control">
-                                        <div class="select">
-                                            <select class="inputFeatLevel">
-                                                <option value="-1">Unselectable</option>
-                                                <option value="1" selected>1</option>
-                                                <option value="2">2</option>
-                                                <option value="3">3</option>
-                                                <option value="4">4</option>
-                                                <option value="5">5</option>
-                                                <option value="6">6</option>
-                                                <option value="7">7</option>
-                                                <option value="8">8</option>
-                                                <option value="9">9</option>
-                                                <option value="10">10</option>
-                                                <option value="11">11</option>
-                                                <option value="12">12</option>
-                                                <option value="13">13</option>
-                                                <option value="14">14</option>
-                                                <option value="15">15</option>
-                                                <option value="16">16</option>
-                                                <option value="17">17</option>
-                                                <option value="18">18</option>
-                                                <option value="19">19</option>
-                                                <option value="20">20</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div class="column field">
-                                    <label class="label">Actions</label>
-                                    <div class="control">
-                                        <div class="select">
-                                            <select class="inputFeatActions pf-icon">
-                                                <option value="NONE">None</option>
-                                                <option value="ACTION">[one-action]</option>
-                                                <option value="TWO_ACTIONS">[two-actions]</option>
-                                                <option value="THREE_ACTIONS">[three-actions]</option>
-                                                <option value="FREE_ACTION">[free-action]</option>
-                                                <option value="REACTION">[reaction]</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div class="column field">
-                                    <label class="label">Rarity</label>
-                                    <div class="control">
-                                        <div class="select">
-                                            <select class="inputFeatRarity">
-                                                <option value="COMMON">Common</option>
-                                                <option value="UNCOMMON">Uncommon</option>
-                                                <option value="RARE">Rare</option>
-                                                <option value="UNIQUE">Unique</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="">
-                                <label class="label">Other Traits</label>
-                                <select class="inputFeatTags" data-placeholder="Select Traits" multiple>
-                                  {{#each tags}}
-                                    <option value="{{id}}">{{name}}</option>
-                                  {{/each}}
-                                  <option value="9">Skill</option> <!-- Hardcoded Skill Tag ID -->
-                                </select>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Prerequisites</label>
-                                <div class="control">
-                                    <input class="input inputFeatPrereq" type="text" maxlength="290" placeholder="">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Requirements</label>
-                                <div class="control">
-                                    <input class="input inputFeatReq" type="text" maxlength="590">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Frequency</label>
-                                <div class="control">
-                                    <input class="input inputFeatFreq" type="text" maxlength="290">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Cost</label>
-                                <div class="control">
-                                    <input class="input inputFeatCost" type="text" maxlength="290">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Trigger</label>
-                                <div class="control">
-                                    <input class="input inputFeatTrigger" type="text" maxlength="290">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">
-                                    Description
-                                    <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                </label>
-                                <div class="control">
-                                    <textarea class="textarea inputFeatDesc" placeholder="Others’ attempts to scare you often grant you insights..."></textarea>
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">
-                                  Special
-                                  <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                </label>
-                                <div class="control">
-                                    <input class="input inputFeatSpecial" type="text" maxlength="590">
-                                </div>
-                            </div>
-
-                            <div class="field pt-1">
-                                <label class="checkbox">
-                                    <input type="checkbox" class="inputFeatSelectMultiple" value="1">
-                                    <strong>Can Choose Multiple Times</strong>
-                                </label>
-                            </div>
-
-                            <div class="field pos-relative">
-                                <label class="label">
-                                    Code
-                                    <a href="/wsc_docs/#code_basics" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                    <span class="code-block-statement-display">Builder & Sheet Statements</span>
-                                </label>
-                                <div class="control">
-                                    <textarea class="textarea inputFeatCode nanum-coding use-custom-scrollbar" rows="1" spellcheck="false" maxlength="4990"></textarea>
-                                </div>
-                            </div>
-
-                        </div>
-                    </div>
-                    
-
-                </div>
-
+        <div class="tile is-child field">
+          <label class="label">
+            Description
+            <a href="/wsc_docs/#description_fields" target="_blank"><span
+                class="icon is-small has-text-info has-tooltip-top"
+                data-tooltip="WSC Docs"
+              ><i class="fas fa-book"></i></span></a>
+          </label>
+          <div class="control">
+            <textarea
+              id="inputDescription"
+              class="textarea"
+              placeholder="You enjoy tinkering with alchemical formulas..."
+            ></textarea>
+          </div>
         </div>
+
+      </div>
 
     </div>
+
+    <div class="tile is-vertical box mt-3">
+      <div class="tile is-child">
+
+        <div id="dedicationFeat" class="card mb-2">
+          <div class="card-header cursor-clickable">
+            <p
+              class="card-header-title is-paddingless has-txt-value-number is-size-5"
+            >Dedication Feat</p>
+          </div>
+          <div class="card-content">
+
+            <div class="columns">
+              <div class="column field">
+                <label class="label">Level</label>
+                <div class="control">
+                  <div class="select">
+                    <select class="inputFeatLevel">
+                      <option value="1">1</option>
+                      <option value="2" selected>2</option>
+                      <option value="4">4</option>
+                      <option value="6">6</option>
+                      <option value="8">8</option>
+                      <option value="10">10</option>
+                      <option value="12">12</option>
+                      <option value="14">14</option>
+                      <option value="16">16</option>
+                      <option value="18">18</option>
+                      <option value="20">20</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+
+              <div class="column field is-hidden">
+                <label class="label">Actions</label>
+                <div class="control">
+                  <div class="select">
+                    <select class="inputFeatActions pf-icon">
+                      <option value="NONE">None</option>
+                      <option value="ACTION">[one-action]</option>
+                      <option value="TWO_ACTIONS">[two-actions]</option>
+                      <option value="THREE_ACTIONS">[three-actions]</option>
+                      <option value="FREE_ACTION">[free-action]</option>
+                      <option value="REACTION">[reaction]</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+
+              <div class="column field">
+                <label class="label">Rarity</label>
+                <div class="control">
+                  <div class="select">
+                    <select class="inputFeatRarity">
+                      <option value="COMMON">Common</option>
+                      <option value="UNCOMMON">Uncommon</option>
+                      <option value="RARE">Rare</option>
+                      <option value="UNIQUE">Unique</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="">
+              <label class="label">Other Traits</label>
+              <select
+                class="inputFeatTags"
+                data-placeholder="Select Traits"
+                multiple
+              >
+                {{#each tags}}
+                  <option value="{{id}}">{{name}}</option>
+                {{/each}}
+              </select>
+            </div>
+
+            <div class="field">
+              <label class="label">Prerequisites</label>
+              <div class="control">
+                <input
+                  class="input inputFeatPrereq"
+                  type="text"
+                  maxlength="290"
+                  placeholder=""
+                />
+              </div>
+            </div>
+
+            <div class="field is-hidden">
+              <label class="label">Requirements</label>
+              <div class="control">
+                <input class="input inputFeatReq" type="text" maxlength="590" />
+              </div>
+            </div>
+
+            <div class="field is-hidden">
+              <label class="label">Frequency</label>
+              <div class="control">
+                <input
+                  class="input inputFeatFreq"
+                  type="text"
+                  maxlength="290"
+                />
+              </div>
+            </div>
+
+            <div class="field is-hidden">
+              <label class="label">Cost</label>
+              <div class="control">
+                <input
+                  class="input inputFeatCost"
+                  type="text"
+                  maxlength="290"
+                />
+              </div>
+            </div>
+
+            <div class="field is-hidden">
+              <label class="label">Trigger</label>
+              <div class="control">
+                <input
+                  class="input inputFeatTrigger"
+                  type="text"
+                  maxlength="290"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">
+                Description
+                <a href="/wsc_docs/#description_fields" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+              </label>
+              <div class="control">
+                <textarea
+                  class="textarea inputFeatDesc"
+                  placeholder="Others’ attempts to scare you often grant you insights..."
+                ></textarea>
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">
+                Special
+                <a href="/wsc_docs/#description_fields" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+              </label>
+              <div class="control">
+                <input
+                  class="input inputFeatSpecial"
+                  type="text"
+                  maxlength="590"
+                />
+              </div>
+            </div>
+
+            <div class="field pt-1 is-hidden">
+              <label class="checkbox">
+                <input
+                  type="checkbox"
+                  class="inputFeatSelectMultiple"
+                  value="1"
+                />
+                <strong>Can Choose Multiple Times</strong>
+              </label>
+            </div>
+
+            <div class="field pos-relative">
+              <label class="label">
+                Code
+                <a href="/wsc_docs/#code_basics" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+                <span class="code-block-statement-display">Builder & Sheet
+                  Statements</span>
+              </label>
+              <div class="control">
+                <textarea
+                  class="textarea inputFeatCode nanum-coding use-custom-scrollbar"
+                  rows="1"
+                  spellcheck="false"
+                  maxlength="990"
+                ></textarea>
+              </div>
+            </div>
+
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+    <div class="tile is-vertical box mt-3">
+
+      <div class="tile is-child">
+        <button id="addFeatButton" class="button is-link">Add Archetype Feat</button>
+      </div>
+
+      <div id="featContent" class="tile is-child">
+
+        <div id="featLayout" class="card mb-2 archetypeFeat is-hidden">
+          <div class="card-header cursor-clickable">
+            <p
+              class="card-header-title is-paddingless has-txt-value-number is-size-5"
+            >Archetype Feat</p>
+            <a
+              class="card-header-icon is-paddingless mt-1 delete is-medium"
+            ></a>
+          </div>
+          <div class="card-content">
+            <div class="field">
+              <label class="label">Name</label>
+              <div class="control">
+                <input
+                  class="input inputFeatName"
+                  type="text"
+                  placeholder="e.g. Basic Arcana"
+                />
+              </div>
+            </div>
+
+            <div class="columns">
+              <div class="column field">
+                <label class="label">Level</label>
+                <div class="control">
+                  <div class="select">
+                    <select class="inputFeatLevel">
+                      <option value="-1">Unselectable</option>
+                      <option value="1" selected>1</option>
+                      <option value="2">2</option>
+                      <option value="3">3</option>
+                      <option value="4">4</option>
+                      <option value="5">5</option>
+                      <option value="6">6</option>
+                      <option value="7">7</option>
+                      <option value="8">8</option>
+                      <option value="9">9</option>
+                      <option value="10">10</option>
+                      <option value="11">11</option>
+                      <option value="12">12</option>
+                      <option value="13">13</option>
+                      <option value="14">14</option>
+                      <option value="15">15</option>
+                      <option value="16">16</option>
+                      <option value="17">17</option>
+                      <option value="18">18</option>
+                      <option value="19">19</option>
+                      <option value="20">20</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+
+              <div class="column field">
+                <label class="label">Actions</label>
+                <div class="control">
+                  <div class="select">
+                    <select class="inputFeatActions pf-icon">
+                      <option value="NONE">None</option>
+                      <option value="ACTION">[one-action]</option>
+                      <option value="TWO_ACTIONS">[two-actions]</option>
+                      <option value="THREE_ACTIONS">[three-actions]</option>
+                      <option value="FREE_ACTION">[free-action]</option>
+                      <option value="REACTION">[reaction]</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+
+              <div class="column field">
+                <label class="label">Rarity</label>
+                <div class="control">
+                  <div class="select">
+                    <select class="inputFeatRarity">
+                      <option value="COMMON">Common</option>
+                      <option value="UNCOMMON">Uncommon</option>
+                      <option value="RARE">Rare</option>
+                      <option value="UNIQUE">Unique</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="">
+              <label class="label">Other Traits</label>
+              <select
+                class="inputFeatTags"
+                data-placeholder="Select Traits"
+                multiple
+              >
+                {{#each tags}}
+                  <option value="{{id}}">{{name}}</option>
+                {{/each}}
+                <option value="9">Skill</option>
+                <!-- Hardcoded Skill Tag ID -->
+              </select>
+            </div>
+
+            <div class="field">
+              <label class="label">Prerequisites</label>
+              <div class="control">
+                <input
+                  class="input inputFeatPrereq"
+                  type="text"
+                  maxlength="290"
+                  placeholder=""
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">Requirements</label>
+              <div class="control">
+                <input class="input inputFeatReq" type="text" maxlength="590" />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">Frequency</label>
+              <div class="control">
+                <input
+                  class="input inputFeatFreq"
+                  type="text"
+                  maxlength="290"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">Cost</label>
+              <div class="control">
+                <input
+                  class="input inputFeatCost"
+                  type="text"
+                  maxlength="290"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">Trigger</label>
+              <div class="control">
+                <input
+                  class="input inputFeatTrigger"
+                  type="text"
+                  maxlength="290"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">
+                Description
+                <a href="/wsc_docs/#description_fields" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+              </label>
+              <div class="control">
+                <textarea
+                  class="textarea inputFeatDesc"
+                  placeholder="Others’ attempts to scare you often grant you insights..."
+                ></textarea>
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">
+                Special
+                <a href="/wsc_docs/#description_fields" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+              </label>
+              <div class="control">
+                <input
+                  class="input inputFeatSpecial"
+                  type="text"
+                  maxlength="590"
+                />
+              </div>
+            </div>
+
+            <div class="field pt-1">
+              <label class="checkbox">
+                <input
+                  type="checkbox"
+                  class="inputFeatSelectMultiple"
+                  value="1"
+                />
+                <strong>Can Choose Multiple Times</strong>
+              </label>
+            </div>
+
+            <div class="field pos-relative">
+              <label class="label">
+                Code
+                <a href="/wsc_docs/#code_basics" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+                <span class="code-block-statement-display">Builder & Sheet
+                  Statements</span>
+              </label>
+              <div class="control">
+                <textarea
+                  class="textarea inputFeatCode nanum-coding use-custom-scrollbar"
+                  rows="1"
+                  spellcheck="false"
+                  maxlength="4990"
+                ></textarea>
+              </div>
+            </div>
+
+          </div>
+        </div>
+
+      </div>
+
+    </div>
+
+  </div>
 </div>
 
 <div class="field is-grouped is-grouped-centered pb-2">
-    <div class="control">
-        {{#if archetypeID}}
-            <button id="updateButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{else}}
-            <button id="createButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{/if}}
-    </div>
+  <div class="control">
+    {{#if archetypeID}}
+      <button
+        id="updateButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{else}}
+      <button
+        id="createButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{/if}}
+  </div>
 </div>

--- a/views/homebrew/builder_background.handlebars
+++ b/views/homebrew/builder_background.handlebars
@@ -1,142 +1,203 @@
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/homebrew-builders.css" />
 
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/homebrew-builders.css">
-    <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
-    <script type="text/javascript" src="/js/homebrew/builder/background/builder-background.js"></script>
-    {{#if backgroundID}}
-        <script type="text/javascript" src="/js/homebrew/builder/background/editor-background.js"></script>
-    {{/if}}
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
+  <script
+    type="text/javascript"
+    src="/js/homebrew/builder/background/builder-background.js"
+  ></script>
+  {{#if backgroundID}}
+    <script
+      type="text/javascript"
+      src="/js/homebrew/builder/background/editor-background.js"
+    ></script>
+  {{/if}}
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew" class="active">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/homebrew"
+      class="active"
+    >Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
+
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="pageloader">
-    <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+  <div class="lds-roller"><div></div><div></div><div></div><div></div><div
+    ></div><div></div><div></div><div></div></div>
 </div>
 
 <div class="pt-3">
-    <h1 class="title is-2 has-txt-value-number has-text-centered">Background Builder</h1>
+  <h1 class="title is-2 has-txt-value-number has-text-centered">Background
+    Builder</h1>
 </div>
 
-<div id="builder-container" data-user-id="{{user.id}}" data-bundle-id="{{bundleID}}" data-background-id="{{backgroundID}}" class="columns is-mobile is-centered mt-2 mb-3">
-    <div class="column is-8 tile is-ancestor is-vertical">
+<div
+  id="builder-container"
+  data-user-id="{{user.id}}"
+  data-bundle-id="{{bundleID}}"
+  data-background-id="{{backgroundID}}"
+  class="columns is-mobile is-centered mt-2 mb-3"
+>
+  <div class="column is-8 tile is-ancestor is-vertical">
+
+    <div class="tile">
+
+      <div class="tile is-parent is-vertical box is-6 is-marginless mr-2">
+
+        <div class="tile is-child field">
+          <label class="label">Name</label>
+          <div class="control">
+            <input
+              id="inputName"
+              class="input"
+              type="text"
+              placeholder="e.g. Warrior"
+              autocomplete="off"
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Rarity</label>
+          <div class="control">
+            <div class="select">
+              <select id="inputRarity">
+                <option value="COMMON">Common</option>
+                <option value="UNCOMMON">Uncommon</option>
+                <option value="RARE">Rare</option>
+                <option value="UNIQUE">Unique</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <div class="tile is-parent is-vertical box is-6 is-marginless ml-2">
 
         <div class="tile">
-
-            <div class="tile is-parent is-vertical box is-6 is-marginless mr-2">
-
-                <div class="tile is-child field">
-                    <label class="label">Name</label>
-                    <div class="control">
-                        <input id="inputName" class="input" type="text" placeholder="e.g. Warrior" autocomplete="off">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Rarity</label>
-                    <div class="control">
-                        <div class="select">
-                            <select id="inputRarity">
-                                <option value="COMMON">Common</option>
-                                <option value="UNCOMMON">Uncommon</option>
-                                <option value="RARE">Rare</option>
-                                <option value="UNIQUE">Unique</option>
-                            </select>
-                        </div>
-                    </div>
-                </div>
-
+          <div class="tile is-child field">
+            <label class="label">First Boost Options</label>
+            <div class="control">
+              <div class="select is-multiple">
+                <select
+                  id="inputBoosts"
+                  multiple
+                  size="6"
+                  class="use-invisible-scrollbar"
+                >
+                  <option value="STR">Strength</option>
+                  <option value="DEX">Dexterity</option>
+                  <option value="CON">Constitution</option>
+                  <option value="INT">Intelligence</option>
+                  <option value="WIS">Wisdom</option>
+                  <option value="CHA">Charisma</option>
+                </select>
+              </div>
             </div>
-
-            <div class="tile is-parent is-vertical box is-6 is-marginless ml-2">
-
-                <div class="tile">
-                    <div class="tile is-child field">
-                        <label class="label">First Boost Options</label>
-                        <div class="control">
-                            <div class="select is-multiple">
-                                <select id="inputBoosts" multiple size="6" class="use-invisible-scrollbar">
-                                    <option value="STR">Strength</option>
-                                    <option value="DEX">Dexterity</option>
-                                    <option value="CON">Constitution</option>
-                                    <option value="INT">Intelligence</option>
-                                    <option value="WIS">Wisdom</option>
-                                    <option value="CHA">Charisma</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                </div>
-
-            </div>
+          </div>
 
         </div>
 
-        <div class="tile">
-            <div class="tile is-parent is-vertical box mt-3 ml-3">
-                <div class="tile is-child field">
-                    <label class="label">
-                        Description
-                        <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                    </label>
-                    <div class="control">
-                        <textarea id="inputDescription" class="textarea" placeholder="In your younger days, you waded into battle..."></textarea>
-                    </div>
-                </div>
-
-                <div class="tile is-child field pos-relative">
-                    <label class="label">
-                        Code
-                        <a href="/wsc_docs/#code_basics" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                        <span class="code-block-statement-display">Builder & Sheet Statements</span>
-                    </label>
-                    <div class="control">
-                        <textarea id="inputCode" class="textarea nanum-coding use-custom-scrollbar" rows="4" spellcheck="false" maxlength="990"></textarea>
-                    </div>
-                </div>
-            </div>
-        </div>
+      </div>
 
     </div>
+
+    <div class="tile">
+      <div class="tile is-parent is-vertical box mt-3 ml-3">
+        <div class="tile is-child field">
+          <label class="label">
+            Description
+            <a href="/wsc_docs/#description_fields" target="_blank"><span
+                class="icon is-small has-text-info has-tooltip-top"
+                data-tooltip="WSC Docs"
+              ><i class="fas fa-book"></i></span></a>
+          </label>
+          <div class="control">
+            <textarea
+              id="inputDescription"
+              class="textarea"
+              placeholder="In your younger days, you waded into battle..."
+            ></textarea>
+          </div>
+        </div>
+
+        <div class="tile is-child field pos-relative">
+          <label class="label">
+            Code
+            <a href="/wsc_docs/#code_basics" target="_blank"><span
+                class="icon is-small has-text-info has-tooltip-top"
+                data-tooltip="WSC Docs"
+              ><i class="fas fa-book"></i></span></a>
+            <span class="code-block-statement-display">Builder & Sheet
+              Statements</span>
+          </label>
+          <div class="control">
+            <textarea
+              id="inputCode"
+              class="textarea nanum-coding use-custom-scrollbar"
+              rows="4"
+              spellcheck="false"
+              maxlength="990"
+            ></textarea>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
 </div>
 
 <div class="field is-grouped is-grouped-centered pb-2">
-    <div class="control">
-        {{#if backgroundID}}
-            <button id="updateButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{else}}
-            <button id="createButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{/if}}
-    </div>
+  <div class="control">
+    {{#if backgroundID}}
+      <button
+        id="updateButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{else}}
+      <button
+        id="createButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{/if}}
+  </div>
 </div>

--- a/views/homebrew/builder_class-feature.handlebars
+++ b/views/homebrew/builder_class-feature.handlebars
@@ -1,191 +1,260 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/homebrew-builders.css">
-    <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
-    <script type="text/javascript" src="/js/homebrew/builder/class-feature/builder-class-feature.js"></script>
-    {{#if classFeatureID}}
-        <script type="text/javascript" src="/js/homebrew/builder/class-feature/editor-class-feature.js"></script>
-    {{/if}}
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/homebrew-builders.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
+  <script
+    type="text/javascript"
+    src="/js/homebrew/builder/class-feature/builder-class-feature.js"
+  ></script>
+  {{#if classFeatureID}}
+    <script
+      type="text/javascript"
+      src="/js/homebrew/builder/class-feature/editor-class-feature.js"
+    ></script>
+  {{/if}}
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew" class="active">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/homebrew"
+      class="active"
+    >Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
+
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="pageloader">
-    <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+  <div class="lds-roller"><div></div><div></div><div></div><div></div><div
+    ></div><div></div><div></div><div></div></div>
 </div>
 
 <div class="pt-3">
-    <h1 class="title is-2 has-txt-value-number has-text-centered">Class Feature Builder</h1>
+  <h1 class="title is-2 has-txt-value-number has-text-centered">Class Feature
+    Builder</h1>
 </div>
 
-<div id="builder-container" data-user-id="{{user.id}}" data-bundle-id="{{bundleID}}" data-class-feature-id="{{classFeatureID}}" class="columns is-mobile is-centered mt-2 mb-3">
-    <div class="column is-8 tile is-ancestor is-vertical">
+<div
+  id="builder-container"
+  data-user-id="{{user.id}}"
+  data-bundle-id="{{bundleID}}"
+  data-class-feature-id="{{classFeatureID}}"
+  class="columns is-mobile is-centered mt-2 mb-3"
+>
+  <div class="column is-8 tile is-ancestor is-vertical">
 
-        <div class="tile">
+    <div class="tile">
 
-            <div class="tile is-parent is-vertical box is-marginless mr-2">
+      <div class="tile is-parent is-vertical box is-marginless mr-2">
 
-                <div class="tile is-child">
-                    <div class="field is-grouped is-grouped-centered">
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputBuilderType">
-                                    <option value="FEATURE">Class Feature</option>
-                                    <option value="FEATURE-OPTION">Class Feature Option</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div id="sectionClassFor" class="control">
-                            <div class="select">
-                                <select id="inputClassFor">
-                                </select>
-                            </div>
-                        </div>
-                        <div id="sectionClassFeatureFor" class="control">
-                            <div class="select">
-                                <select id="inputClassFeatureFor">
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                
+        <div class="tile is-child">
+          <div class="field is-grouped is-grouped-centered">
+            <div class="control">
+              <div class="select">
+                <select id="inputBuilderType">
+                  <option value="FEATURE">Class Feature</option>
+                  <option value="FEATURE-OPTION">Class Feature Option</option>
+                </select>
+              </div>
             </div>
-
+            <div id="sectionClassFor" class="control">
+              <div class="select">
+                <select id="inputClassFor">
+                </select>
+              </div>
+            </div>
+            <div id="sectionClassFeatureFor" class="control">
+              <div class="select">
+                <select id="inputClassFeatureFor">
+                </select>
+              </div>
+            </div>
+          </div>
         </div>
 
-        <div class="tile is-vertical box ml-3 mt-3">
-
-            <div id="classFeatureContent" class="tile is-child">
-
-                    <div id="classFeatureLayout" class="card mb-2 classFeature isLayout is-hidden">
-                        <div class="card-header cursor-clickable">
-                            <p class="card-header-title is-paddingless has-txt-value-number is-size-5">Ability</p>
-                            <a class="card-header-icon is-paddingless mt-1 delete is-medium"></a>
-                        </div>
-                        <div class="card-content">
-                            <div class="columns">
-                                <div class="column field">
-                                    <label class="label">Name</label>
-                                    <div class="control">
-                                        <input class="input inputClassFeatureName" type="text" placeholder="e.g. Spirit Instinct" autocomplete="off">
-                                    </div>
-                                </div>
-                                <div class="column field classFeatureLevelSection">
-                                    <label class="label">Level</label>
-                                    <div class="control">
-                                        <div class="select">
-                                            <select class="inputClassFeatureLevel">
-                                                <option value="-1">Unacquirable</option>
-                                                <option value="1" selected>1</option>
-                                                <option value="2">2</option>
-                                                <option value="3">3</option>
-                                                <option value="4">4</option>
-                                                <option value="5">5</option>
-                                                <option value="6">6</option>
-                                                <option value="7">7</option>
-                                                <option value="8">8</option>
-                                                <option value="9">9</option>
-                                                <option value="10">10</option>
-                                                <option value="11">11</option>
-                                                <option value="12">12</option>
-                                                <option value="13">13</option>
-                                                <option value="14">14</option>
-                                                <option value="15">15</option>
-                                                <option value="16">16</option>
-                                                <option value="17">17</option>
-                                                <option value="18">18</option>
-                                                <option value="19">19</option>
-                                                <option value="20">20</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="field">
-                                <label class="label">
-                                    Description
-                                    <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                </label>
-                                <div class="control">
-                                    <textarea class="textarea inputClassFeatureDesc" placeholder=""></textarea>
-                                </div>
-                            </div>
-                            <div class="field pos-relative">
-                                <label class="label">
-                                    Code
-                                    <a href="/wsc_docs/#code_basics" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                    <span class="code-block-statement-display">Builder & Sheet Statements</span>
-                                </label>
-                                <div class="control">
-                                    <textarea class="textarea inputClassFeatureCode nanum-coding use-custom-scrollbar" rows="1" spellcheck="false" maxlength="4990"></textarea>
-                                </div>
-                            </div>
-                            <div class="field pt-1 classFeatureDisplayInSheetSection">
-                                <label class="checkbox">
-                                    <input type="checkbox" class="inputClassFeatureDisplayInSheet" value="1" checked>
-                                    <strong>Display In Sheet</strong>
-                                </label>
-                            </div>
-                            <div class="field pt-1 classFeatureIsSelectorSection">
-                                <label class="checkbox">
-                                    <input type="checkbox" class="inputClassFeatureIsSelector" value="1">
-                                    <strong>is Selector</strong>
-                                </label>
-                            </div>
-                            <div class="classFeatureSelectionOptions is-hidden">
-                                <div class="">
-                                    <button class="button is-link classFeatureAddOptionButton">Add Option</button>
-                                </div>
-                                <div class="classFeatureOptionsContent pt-2">
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-            </div>
-
-        </div>
+      </div>
 
     </div>
+
+    <div class="tile is-vertical box ml-3 mt-3">
+
+      <div id="classFeatureContent" class="tile is-child">
+
+        <div
+          id="classFeatureLayout"
+          class="card mb-2 classFeature isLayout is-hidden"
+        >
+          <div class="card-header cursor-clickable">
+            <p
+              class="card-header-title is-paddingless has-txt-value-number is-size-5"
+            >Ability</p>
+            <a
+              class="card-header-icon is-paddingless mt-1 delete is-medium"
+            ></a>
+          </div>
+          <div class="card-content">
+            <div class="columns">
+              <div class="column field">
+                <label class="label">Name</label>
+                <div class="control">
+                  <input
+                    class="input inputClassFeatureName"
+                    type="text"
+                    placeholder="e.g. Spirit Instinct"
+                    autocomplete="off"
+                  />
+                </div>
+              </div>
+              <div class="column field classFeatureLevelSection">
+                <label class="label">Level</label>
+                <div class="control">
+                  <div class="select">
+                    <select class="inputClassFeatureLevel">
+                      <option value="-1">Unacquirable</option>
+                      <option value="1" selected>1</option>
+                      <option value="2">2</option>
+                      <option value="3">3</option>
+                      <option value="4">4</option>
+                      <option value="5">5</option>
+                      <option value="6">6</option>
+                      <option value="7">7</option>
+                      <option value="8">8</option>
+                      <option value="9">9</option>
+                      <option value="10">10</option>
+                      <option value="11">11</option>
+                      <option value="12">12</option>
+                      <option value="13">13</option>
+                      <option value="14">14</option>
+                      <option value="15">15</option>
+                      <option value="16">16</option>
+                      <option value="17">17</option>
+                      <option value="18">18</option>
+                      <option value="19">19</option>
+                      <option value="20">20</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="field">
+              <label class="label">
+                Description
+                <a href="/wsc_docs/#description_fields" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+              </label>
+              <div class="control">
+                <textarea
+                  class="textarea inputClassFeatureDesc"
+                  placeholder=""
+                ></textarea>
+              </div>
+            </div>
+            <div class="field pos-relative">
+              <label class="label">
+                Code
+                <a href="/wsc_docs/#code_basics" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+                <span class="code-block-statement-display">Builder & Sheet
+                  Statements</span>
+              </label>
+              <div class="control">
+                <textarea
+                  class="textarea inputClassFeatureCode nanum-coding use-custom-scrollbar"
+                  rows="1"
+                  spellcheck="false"
+                  maxlength="4990"
+                ></textarea>
+              </div>
+            </div>
+            <div class="field pt-1 classFeatureDisplayInSheetSection">
+              <label class="checkbox">
+                <input
+                  type="checkbox"
+                  class="inputClassFeatureDisplayInSheet"
+                  value="1"
+                  checked
+                />
+                <strong>Display In Sheet</strong>
+              </label>
+            </div>
+            <div class="field pt-1 classFeatureIsSelectorSection">
+              <label class="checkbox">
+                <input
+                  type="checkbox"
+                  class="inputClassFeatureIsSelector"
+                  value="1"
+                />
+                <strong>is Selector</strong>
+              </label>
+            </div>
+            <div class="classFeatureSelectionOptions is-hidden">
+              <div class="">
+                <button class="button is-link classFeatureAddOptionButton">Add
+                  Option</button>
+              </div>
+              <div class="classFeatureOptionsContent pt-2">
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+    </div>
+
+  </div>
 </div>
 
 <div class="field is-grouped is-grouped-centered pb-2">
-    <div class="control">
-        {{#if classFeatureID}}
-            <button id="updateButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{else}}
-            <button id="createButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{/if}}
-    </div>
+  <div class="control">
+    {{#if classFeatureID}}
+      <button
+        id="updateButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{else}}
+      <button
+        id="createButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{/if}}
+  </div>
 </div>

--- a/views/homebrew/builder_class.handlebars
+++ b/views/homebrew/builder_class.handlebars
@@ -1,632 +1,794 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/homebrew-builders.css">
-    <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
-    <script type="text/javascript" src="/js/homebrew/builder/cClass/builder-class.js"></script>
-    {{#if classID}}
-        <script type="text/javascript" src="/js/homebrew/builder/cClass/editor-class.js"></script>
-    {{/if}}
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/homebrew-builders.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
+  <script
+    type="text/javascript"
+    src="/js/homebrew/builder/cClass/builder-class.js"
+  ></script>
+  {{#if classID}}
+    <script
+      type="text/javascript"
+      src="/js/homebrew/builder/cClass/editor-class.js"
+    ></script>
+  {{/if}}
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew" class="active">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/homebrew"
+      class="active"
+    >Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
+
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="pageloader">
-    <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+  <div class="lds-roller"><div></div><div></div><div></div><div></div><div
+    ></div><div></div><div></div><div></div></div>
 </div>
 
 <div class="pt-3">
-    <h1 class="title is-2 has-txt-value-number has-text-centered">Class Builder</h1>
+  <h1 class="title is-2 has-txt-value-number has-text-centered">Class Builder</h1>
 </div>
 
-<div id="builder-container" data-user-id="{{user.id}}" data-bundle-id="{{bundleID}}" data-class-id="{{classID}}" class="columns is-mobile is-centered mt-2 mb-3">
-    <div class="column is-8 tile is-ancestor is-vertical">
+<div
+  id="builder-container"
+  data-user-id="{{user.id}}"
+  data-bundle-id="{{bundleID}}"
+  data-class-id="{{classID}}"
+  class="columns is-mobile is-centered mt-2 mb-3"
+>
+  <div class="column is-8 tile is-ancestor is-vertical">
 
-        <div class="tile">
+    <div class="tile">
 
-            <div class="tile is-parent is-vertical box is-marginless mr-2">
+      <div class="tile is-parent is-vertical box is-marginless mr-2">
 
-                <div class="tile is-child field">
-                    <label class="label">Name</label>
-                    <div class="control">
-                        <input id="inputName" class="input" type="text" placeholder="e.g. Wizard" autocomplete="off">
-                    </div>
-                </div>
+        <div class="tile is-child field">
+          <label class="label">Name</label>
+          <div class="control">
+            <input
+              id="inputName"
+              class="input"
+              type="text"
+              placeholder="e.g. Wizard"
+              autocomplete="off"
+            />
+          </div>
+        </div>
 
-                <div class="tile is-child field">
-                    <label class="label">Hit Points</label>
-                    <div class="control">
-                        <input id="inputHitPoints" class="input" type="number" value="8">
-                    </div>
-                </div>
+        <div class="tile is-child field">
+          <label class="label">Hit Points</label>
+          <div class="control">
+            <input id="inputHitPoints" class="input" type="number" value="8" />
+          </div>
+        </div>
 
-                <div class="tile is-child columns is-centered">
+        <div class="tile is-child columns is-centered">
 
-                    <div class="column"></div>
+          <div class="column"></div>
 
-                    <div class="column field">
-                        <label class="label">Key Ability</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputKeyAbility">
-                                    <option value="Strength" selected>Strength</option>
-                                    <option value="Dexterity">Dexterity</option>
-                                    <option value="Constitution">Constitution</option>
-                                    <option value="Intelligence">Intelligence</option>
-                                    <option value="Wisdom">Wisdom</option>
-                                    <option value="Charisma">Charisma</option>
-                                    <option value="OTHER">OTHER</option>
-                                    <option value="OR">OR</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
+          <div class="column field">
+            <label class="label">Key Ability</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputKeyAbility">
+                  <option value="Strength" selected>Strength</option>
+                  <option value="Dexterity">Dexterity</option>
+                  <option value="Constitution">Constitution</option>
+                  <option value="Intelligence">Intelligence</option>
+                  <option value="Wisdom">Wisdom</option>
+                  <option value="Charisma">Charisma</option>
+                  <option value="OTHER">OTHER</option>
+                  <option value="OR">OR</option>
+                </select>
+              </div>
+            </div>
+          </div>
 
-                    <div class="column"></div>
+          <div class="column"></div>
 
-                </div>
+        </div>
 
-                <div id="abilityStoreOptionsSection" class="tile is-child columns is-hidden">
+        <div
+          id="abilityStoreOptionsSection"
+          class="tile is-child columns is-hidden"
+        >
 
-                    <div class="column"></div>
+          <div class="column"></div>
 
-                    <div class="column field">
-                        <label class="label">Option 1</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputKeyAbilityOptionOne">
-                                    <option value="Strength" selected>Strength</option>
-                                    <option value="Dexterity">Dexterity</option>
-                                    <option value="Constitution">Constitution</option>
-                                    <option value="Intelligence">Intelligence</option>
-                                    <option value="Wisdom">Wisdom</option>
-                                    <option value="Charisma">Charisma</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
+          <div class="column field">
+            <label class="label">Option 1</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputKeyAbilityOptionOne">
+                  <option value="Strength" selected>Strength</option>
+                  <option value="Dexterity">Dexterity</option>
+                  <option value="Constitution">Constitution</option>
+                  <option value="Intelligence">Intelligence</option>
+                  <option value="Wisdom">Wisdom</option>
+                  <option value="Charisma">Charisma</option>
+                </select>
+              </div>
+            </div>
+          </div>
 
-                    <div class="column field">
-                        <label class="label">Option 2</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputKeyAbilityOptionTwo">
-                                    <option value="Strength">Strength</option>
-                                    <option value="Dexterity" selected>Dexterity</option>
-                                    <option value="Constitution">Constitution</option>
-                                    <option value="Intelligence">Intelligence</option>
-                                    <option value="Wisdom">Wisdom</option>
-                                    <option value="Charisma">Charisma</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
+          <div class="column field">
+            <label class="label">Option 2</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputKeyAbilityOptionTwo">
+                  <option value="Strength">Strength</option>
+                  <option value="Dexterity" selected>Dexterity</option>
+                  <option value="Constitution">Constitution</option>
+                  <option value="Intelligence">Intelligence</option>
+                  <option value="Wisdom">Wisdom</option>
+                  <option value="Charisma">Charisma</option>
+                </select>
+              </div>
+            </div>
+          </div>
 
-                    <div class="column"></div>
+          <div class="column"></div>
 
-                </div>
+        </div>
 
-                <div class="tile is-child columns">
+        <div class="tile is-child columns">
 
-                    <div class="column field">
-                        <label class="label">Perception</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputPerception">
-                                    <option value="U">Untrained</option>
-                                    <option value="T" selected>Trained</option>
-                                    <option value="E">Expert</option>
-                                    <option value="M">Master</option>
-                                    <option value="L">Legendary</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
+          <div class="column field">
+            <label class="label">Perception</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputPerception">
+                  <option value="U">Untrained</option>
+                  <option value="T" selected>Trained</option>
+                  <option value="E">Expert</option>
+                  <option value="M">Master</option>
+                  <option value="L">Legendary</option>
+                </select>
+              </div>
+            </div>
+          </div>
 
-                    <div class="column field">
-                        <label class="label">Class DC</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputClassDC">
-                                    <option value="U">Untrained</option>
-                                    <option value="T" selected>Trained</option>
-                                    <option value="E">Expert</option>
-                                    <option value="M">Master</option>
-                                    <option value="L">Legendary</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
+          <div class="column field">
+            <label class="label">Class DC</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputClassDC">
+                  <option value="U">Untrained</option>
+                  <option value="T" selected>Trained</option>
+                  <option value="E">Expert</option>
+                  <option value="M">Master</option>
+                  <option value="L">Legendary</option>
+                </select>
+              </div>
+            </div>
+          </div>
 
-                    <div class="column field">
-                        <label class="label">Skill - Trained</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputSkills">
-                                    <option value="" selected>None</option>
-                                    <option value="Acrobatics">Acrobatics</option>
-                                    <option value="Arcana">Arcana</option>
-                                    <option value="Athletics">Athletics</option>
-                                    <option value="Crafting">Crafting</option>
-                                    <option value="Deception">Deception</option>
-                                    <option value="Diplomacy">Diplomacy</option>
-                                    <option value="Intimidation">Intimidation</option>
-                                    <option value="Medicine">Medicine</option>
-                                    <option value="Nature">Nature</option>
-                                    <option value="Occultism">Occultism</option>
-                                    <option value="Performance">Performance</option>
-                                    <option value="Religion">Religion</option>
-                                    <option value="Society">Society</option>
-                                    <option value="Stealth">Stealth</option>
-                                    <option value="Survival">Survival</option>
-                                    <option value="Thievery">Thievery</option>
-                                    <option value="Acrobatics or Athletics">Acrobatics or Athletics</option>
-                                    <option value="Arcana or Crafting">Arcana or Crafting</option>
-                                    <option value="Deception or Diplomacy">Deception or Diplomacy</option>
-                                    <option value="Medicine or Religion">Medicine or Religion</option>
-                                    <option value="Nature or Survival">Nature or Survival</option>
-                                    <option value="Stealth or Thievery">Stealth or Thievery</option>
-                                    <option value="Nature, Survival">Nature and Survival</option>
-                                    <option value="Occultism, Performance">Occultism and Performance</option>
-                                    <option value="Stealth, Thievery">Stealth and Thievery</option>
-                                    <option value="Arcana, Nature, Occultism, Religion">Arcana, Nature, Occultism, and Religion</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
+          <div class="column field">
+            <label class="label">Skill - Trained</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputSkills">
+                  <option value="" selected>None</option>
+                  <option value="Acrobatics">Acrobatics</option>
+                  <option value="Arcana">Arcana</option>
+                  <option value="Athletics">Athletics</option>
+                  <option value="Crafting">Crafting</option>
+                  <option value="Deception">Deception</option>
+                  <option value="Diplomacy">Diplomacy</option>
+                  <option value="Intimidation">Intimidation</option>
+                  <option value="Medicine">Medicine</option>
+                  <option value="Nature">Nature</option>
+                  <option value="Occultism">Occultism</option>
+                  <option value="Performance">Performance</option>
+                  <option value="Religion">Religion</option>
+                  <option value="Society">Society</option>
+                  <option value="Stealth">Stealth</option>
+                  <option value="Survival">Survival</option>
+                  <option value="Thievery">Thievery</option>
+                  <option value="Acrobatics or Athletics">Acrobatics or
+                    Athletics</option>
+                  <option value="Arcana or Crafting">Arcana or Crafting</option>
+                  <option value="Deception or Diplomacy">Deception or Diplomacy</option>
+                  <option value="Medicine or Religion">Medicine or Religion</option>
+                  <option value="Nature or Survival">Nature or Survival</option>
+                  <option value="Stealth or Thievery">Stealth or Thievery</option>
+                  <option value="Nature, Survival">Nature and Survival</option>
+                  <option value="Occultism, Performance">Occultism and
+                    Performance</option>
+                  <option value="Stealth, Thievery">Stealth and Thievery</option>
+                  <option value="Arcana, Nature, Occultism, Religion">Arcana,
+                    Nature, Occultism, and Religion</option>
+                </select>
+              </div>
+            </div>
+          </div>
 
-                    <div class="column field">
-                        <label class="label">Additional Skills - Trained</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputSkillsMore">
-                                    <option value="0">0</option>
-                                    <option value="1">1</option>
-                                    <option value="2">2</option>
-                                    <option value="3" selected>3</option>
-                                    <option value="4">4</option>
-                                    <option value="5">5</option>
-                                    <option value="6">6</option>
-                                    <option value="7">7</option>
-                                    <option value="8">8</option>
-                                    <option value="9">9</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
+          <div class="column field">
+            <label class="label">Additional Skills - Trained</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputSkillsMore">
+                  <option value="0">0</option>
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                  <option value="3" selected>3</option>
+                  <option value="4">4</option>
+                  <option value="5">5</option>
+                  <option value="6">6</option>
+                  <option value="7">7</option>
+                  <option value="8">8</option>
+                  <option value="9">9</option>
+                </select>
+              </div>
+            </div>
+          </div>
 
+        </div>
 
-                </div>
+        <div class="tile is-child columns">
 
-                <div class="tile is-child columns">
+          <div class="column field">
+            <label class="label">Fortitude</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputFortitude">
+                  <option value="U">Untrained</option>
+                  <option value="T" selected>Trained</option>
+                  <option value="E">Expert</option>
+                  <option value="M">Master</option>
+                  <option value="L">Legendary</option>
+                </select>
+              </div>
+            </div>
+          </div>
 
-                    <div class="column field">
-                        <label class="label">Fortitude</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputFortitude">
-                                    <option value="U">Untrained</option>
-                                    <option value="T" selected>Trained</option>
-                                    <option value="E">Expert</option>
-                                    <option value="M">Master</option>
-                                    <option value="L">Legendary</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
+          <div class="column field">
+            <label class="label">Reflex</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputReflex">
+                  <option value="U">Untrained</option>
+                  <option value="T" selected>Trained</option>
+                  <option value="E">Expert</option>
+                  <option value="M">Master</option>
+                  <option value="L">Legendary</option>
+                </select>
+              </div>
+            </div>
+          </div>
 
-                    <div class="column field">
-                        <label class="label">Reflex</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputReflex">
-                                    <option value="U">Untrained</option>
-                                    <option value="T" selected>Trained</option>
-                                    <option value="E">Expert</option>
-                                    <option value="M">Master</option>
-                                    <option value="L">Legendary</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
+          <div class="column field">
+            <label class="label">Will</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputWill">
+                  <option value="U">Untrained</option>
+                  <option value="T" selected>Trained</option>
+                  <option value="E">Expert</option>
+                  <option value="M">Master</option>
+                  <option value="L">Legendary</option>
+                </select>
+              </div>
+            </div>
+          </div>
 
-                    <div class="column field">
-                        <label class="label">Will</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputWill">
-                                    <option value="U">Untrained</option>
-                                    <option value="T" selected>Trained</option>
-                                    <option value="E">Expert</option>
-                                    <option value="M">Master</option>
-                                    <option value="L">Legendary</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
+        </div>
 
-                </div>
+        <div class="tile is-child columns">
 
-                <div class="tile is-child columns">
+          <div class="column">
 
-                    <div class="column">
-
-                        <div class="">
-                            <label class="label">Attacks - Trained</label>
-                            <select id="inputWeaponsTrained" data-placeholder="Select Weapons" multiple>
-                                <option value="Unarmed Attacks">Unarmed Attacks</option>
-                                <option value="Simple Weapons">Simple Weapons</option>
-                                <option value="Martial Weapons">Martial Weapons</option>
-                                <option value="Advanced Weapons">Advanced Weapons</option>
-                                {{#each weaponItems}}
-                                    <option value="{{name}}">{{name}}</option>
-                                {{/each}}
-                            </select>
-                        </div>
-
-
-                        <div class="">
-                            <label class="label">Attacks - Expert</label>
-                            <select id="inputWeaponsExpert" data-placeholder="Select Weapons" multiple>
-                                <option value="Unarmed Attacks">Unarmed Attacks</option>
-                                <option value="Simple Weapons">Simple Weapons</option>
-                                <option value="Martial Weapons">Martial Weapons</option>
-                                <option value="Advanced Weapons">Advanced Weapons</option>
-                                {{#each weaponItems}}
-                                    <option value="{{name}}">{{name}}</option>
-                                {{/each}}
-                            </select>
-                        </div>
-
-                    </div>
-
-                    <div class="column">
-
-                        <div class="">
-                            <label class="label">Defenses - Trained</label>
-                            <select id="inputArmorTrained" data-placeholder="Select Armor" multiple>
-                                <option value="Unarmored Defense">Unarmored Defense</option>
-                                <option value="Light Armor">Light Armor</option>
-                                <option value="Medium Armor">Medium Armor</option>
-                                <option value="Heavy Armor">Heavy Armor</option>
-                            </select>
-                        </div>
-
-                        <div class="">
-                            <label class="label">Defenses - Expert</label>
-                            <select id="inputArmorExpert" data-placeholder="Select Armor" multiple>
-                                <option value="Unarmored Defense">Unarmored Defense</option>
-                                <option value="Light Armor">Light Armor</option>
-                                <option value="Medium Armor">Medium Armor</option>
-                                <option value="Heavy Armor">Heavy Armor</option>
-                            </select>
-                        </div>
-
-                    </div>
-
-                </div>
-
-            
-                <div class="tile is-child field">
-                    <label class="label">
-                        Description
-                        <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                    </label>
-                    <div class="control">
-                        <textarea id="inputDescription" class="textarea" placeholder="Always hungry for new experiences..."></textarea>
-                    </div>
-                </div>
-
-                <div class="tile is-child field is-marginless">
-                    <div class="control">
-                        <input id="inputImageURL" class="input isURL" type="text" maxlength="200" placeholder="Image URL" spellcheck="false" autocomplete="off">
-                    </div>
-                </div>
-                
+            <div class="">
+              <label class="label">Attacks - Trained</label>
+              <select
+                id="inputWeaponsTrained"
+                data-placeholder="Select Weapons"
+                multiple
+              >
+                <option value="Unarmed Attacks">Unarmed Attacks</option>
+                <option value="Simple Weapons">Simple Weapons</option>
+                <option value="Martial Weapons">Martial Weapons</option>
+                <option value="Advanced Weapons">Advanced Weapons</option>
+                {{#each weaponItems}}
+                  <option value="{{name}}">{{name}}</option>
+                {{/each}}
+              </select>
             </div>
 
-        </div>
+            <div class="">
+              <label class="label">Attacks - Expert</label>
+              <select
+                id="inputWeaponsExpert"
+                data-placeholder="Select Weapons"
+                multiple
+              >
+                <option value="Unarmed Attacks">Unarmed Attacks</option>
+                <option value="Simple Weapons">Simple Weapons</option>
+                <option value="Martial Weapons">Martial Weapons</option>
+                <option value="Advanced Weapons">Advanced Weapons</option>
+                {{#each weaponItems}}
+                  <option value="{{name}}">{{name}}</option>
+                {{/each}}
+              </select>
+            </div>
 
-        <div class="tile is-vertical box mt-3">
+          </div>
 
-                <div class="tile is-child">
-                    <button id="addClassFeatureButton" class="button is-link">Add Class Feature</button>
-                </div>
+          <div class="column">
 
-                <div id="classFeatureContent" class="tile is-child">
+            <div class="">
+              <label class="label">Defenses - Trained</label>
+              <select
+                id="inputArmorTrained"
+                data-placeholder="Select Armor"
+                multiple
+              >
+                <option value="Unarmored Defense">Unarmored Defense</option>
+                <option value="Light Armor">Light Armor</option>
+                <option value="Medium Armor">Medium Armor</option>
+                <option value="Heavy Armor">Heavy Armor</option>
+              </select>
+            </div>
 
-                    <div id="classFeatureLayout" class="card mb-2 classFeature isLayout is-hidden">
-                        <div class="card-header cursor-clickable">
-                            <p class="card-header-title is-paddingless has-txt-value-number is-size-5">Feature</p>
-                            <a class="card-header-icon is-paddingless mt-1 delete is-medium"></a>
-                        </div>
-                        <div class="card-content">
-                            <div class="columns">
-                                <div class="column field">
-                                    <label class="label">Name</label>
-                                    <div class="control">
-                                        <input class="input inputClassFeatureName" type="text" placeholder="e.g. Skill Increase">
-                                    </div>
-                                </div>
-                                <div class="column field classFeatureLevelSection">
-                                    <label class="label">Level</label>
-                                    <div class="control">
-                                        <div class="select">
-                                            <select class="inputClassFeatureLevel">
-                                                <option value="-1">Unacquirable</option>
-                                                <option value="1" selected>1</option>
-                                                <option value="2">2</option>
-                                                <option value="3">3</option>
-                                                <option value="4">4</option>
-                                                <option value="5">5</option>
-                                                <option value="6">6</option>
-                                                <option value="7">7</option>
-                                                <option value="8">8</option>
-                                                <option value="9">9</option>
-                                                <option value="10">10</option>
-                                                <option value="11">11</option>
-                                                <option value="12">12</option>
-                                                <option value="13">13</option>
-                                                <option value="14">14</option>
-                                                <option value="15">15</option>
-                                                <option value="16">16</option>
-                                                <option value="17">17</option>
-                                                <option value="18">18</option>
-                                                <option value="19">19</option>
-                                                <option value="20">20</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="field">
-                                <label class="label">
-                                    Description
-                                    <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                </label>
-                                <div class="control">
-                                    <textarea class="textarea inputClassFeatureDesc" placeholder=""></textarea>
-                                </div>
-                            </div>
-                            <div class="field pos-relative">
-                                <label class="label">
-                                    Code
-                                    <a href="/wsc_docs/#code_basics" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                    <span class="code-block-statement-display">Builder & Sheet Statements</span>
-                                </label>
-                                <div class="control">
-                                    <textarea class="textarea inputClassFeatureCode nanum-coding use-custom-scrollbar" rows="1" spellcheck="false" maxlength="4990"></textarea>
-                                </div>
-                            </div>
-                            <div class="field pt-1 classFeatureDisplayInSheetSection">
-                                <label class="checkbox">
-                                    <input type="checkbox" class="inputClassFeatureDisplayInSheet" value="1" checked>
-                                    <strong>Display In Sheet</strong>
-                                </label>
-                            </div>
-                            <div class="field pt-1 classFeatureIsSelectorSection">
-                                <label class="checkbox">
-                                    <input type="checkbox" class="inputClassFeatureIsSelector" value="1">
-                                    <strong>is Selector</strong>
-                                </label>
-                            </div>
-                            <div class="classFeatureSelectionOptions is-hidden">
-                                <div class="">
-                                    <button class="button is-link classFeatureAddOptionButton">Add Option</button>
-                                </div>
-                                <div class="classFeatureOptionsContent pt-2">
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+            <div class="">
+              <label class="label">Defenses - Expert</label>
+              <select
+                id="inputArmorExpert"
+                data-placeholder="Select Armor"
+                multiple
+              >
+                <option value="Unarmored Defense">Unarmored Defense</option>
+                <option value="Light Armor">Light Armor</option>
+                <option value="Medium Armor">Medium Armor</option>
+                <option value="Heavy Armor">Heavy Armor</option>
+              </select>
+            </div>
 
-                </div>
+          </div>
 
         </div>
 
-        <div class="tile is-vertical box mt-3">
-
-                <div class="tile is-child">
-                    <button id="addFeatButton" class="button is-link">Add Class Feat</button>
-                </div>
-
-                <div id="featContent" class="tile is-child">
-
-                    <div id="featLayout" class="card mb-2 classFeat is-hidden">
-                        <div class="card-header cursor-clickable">
-                            <p class="card-header-title is-paddingless has-txt-value-number is-size-5">Class Feat</p>
-                            <a class="card-header-icon is-paddingless mt-1 delete is-medium"></a>
-                        </div>
-                        <div class="card-content">
-                            <div class="field">
-                                <label class="label">Name</label>
-                                <div class="control">
-                                    <input class="input inputFeatName" type="text" placeholder="e.g. Grim Insight">
-                                </div>
-                            </div>
-
-                            <div class="columns">
-                                <div class="column field">
-                                    <label class="label">Level</label>
-                                    <div class="control">
-                                        <div class="select">
-                                            <select class="inputFeatLevel">
-                                                <option value="-1">Unselectable</option>
-                                                <option value="1" selected>1</option>
-                                                <option value="2">2</option>
-                                                <option value="4">4</option>
-                                                <option value="6">6</option>
-                                                <option value="8">8</option>
-                                                <option value="10">10</option>
-                                                <option value="12">12</option>
-                                                <option value="14">14</option>
-                                                <option value="16">16</option>
-                                                <option value="18">18</option>
-                                                <option value="20">20</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div class="column field">
-                                    <label class="label">Actions</label>
-                                    <div class="control">
-                                        <div class="select">
-                                            <select class="inputFeatActions pf-icon">
-                                                <option value="NONE">None</option>
-                                                <option value="ACTION">[one-action]</option>
-                                                <option value="TWO_ACTIONS">[two-actions]</option>
-                                                <option value="THREE_ACTIONS">[three-actions]</option>
-                                                <option value="FREE_ACTION">[free-action]</option>
-                                                <option value="REACTION">[reaction]</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div class="column field">
-                                    <label class="label">Rarity</label>
-                                    <div class="control">
-                                        <div class="select">
-                                            <select class="inputFeatRarity">
-                                                <option value="COMMON">Common</option>
-                                                <option value="UNCOMMON">Uncommon</option>
-                                                <option value="RARE">Rare</option>
-                                                <option value="UNIQUE">Unique</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="">
-                                <label class="label">Other Traits</label>
-                                <select class="inputFeatTags" data-placeholder="Select Traits" multiple>
-                                  {{#each tags}}
-                                    <option value="{{id}}">{{name}}</option>
-                                  {{/each}}
-                                </select>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Prerequisites</label>
-                                <div class="control">
-                                    <input class="input inputFeatPrereq" type="text" maxlength="290" placeholder="">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Requirements</label>
-                                <div class="control">
-                                    <input class="input inputFeatReq" type="text" maxlength="590">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Frequency</label>
-                                <div class="control">
-                                    <input class="input inputFeatFreq" type="text" maxlength="290">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Cost</label>
-                                <div class="control">
-                                    <input class="input inputFeatCost" type="text" maxlength="290">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Trigger</label>
-                                <div class="control">
-                                    <input class="input inputFeatTrigger" type="text" maxlength="290">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">
-                                    Description
-                                    <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                </label>
-                                <div class="control">
-                                    <textarea class="textarea inputFeatDesc" placeholder="Others’ attempts to scare you often grant you insights..."></textarea>
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">
-                                  Special
-                                  <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                </label>
-                                <div class="control">
-                                    <input class="input inputFeatSpecial" type="text" maxlength="590">
-                                </div>
-                            </div>
-
-                            <div class="field pt-1">
-                                <label class="checkbox">
-                                    <input type="checkbox" class="inputFeatSelectMultiple" value="1">
-                                    <strong>Can Choose Multiple Times</strong>
-                                </label>
-                            </div>
-
-                            <div class="field pos-relative">
-                                <label class="label">
-                                    Code
-                                    <a href="/wsc_docs/#code_basics" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                    <span class="code-block-statement-display">Builder & Sheet Statements</span>
-                                </label>
-                                <div class="control">
-                                    <textarea class="textarea inputFeatCode nanum-coding use-custom-scrollbar" rows="1" spellcheck="false" maxlength="4990"></textarea>
-                                </div>
-                            </div>
-
-                        </div>
-                    </div>
-                    
-
-                </div>
-
+        <div class="tile is-child field">
+          <label class="label">
+            Description
+            <a href="/wsc_docs/#description_fields" target="_blank"><span
+                class="icon is-small has-text-info has-tooltip-top"
+                data-tooltip="WSC Docs"
+              ><i class="fas fa-book"></i></span></a>
+          </label>
+          <div class="control">
+            <textarea
+              id="inputDescription"
+              class="textarea"
+              placeholder="Always hungry for new experiences..."
+            ></textarea>
+          </div>
         </div>
+
+        <div class="tile is-child field is-marginless">
+          <div class="control">
+            <input
+              id="inputImageURL"
+              class="input isURL"
+              type="text"
+              maxlength="200"
+              placeholder="Image URL"
+              spellcheck="false"
+              autocomplete="off"
+            />
+          </div>
+        </div>
+
+      </div>
 
     </div>
+
+    <div class="tile is-vertical box mt-3">
+
+      <div class="tile is-child">
+        <button id="addClassFeatureButton" class="button is-link">Add Class
+          Feature</button>
+      </div>
+
+      <div id="classFeatureContent" class="tile is-child">
+
+        <div
+          id="classFeatureLayout"
+          class="card mb-2 classFeature isLayout is-hidden"
+        >
+          <div class="card-header cursor-clickable">
+            <p
+              class="card-header-title is-paddingless has-txt-value-number is-size-5"
+            >Feature</p>
+            <a
+              class="card-header-icon is-paddingless mt-1 delete is-medium"
+            ></a>
+          </div>
+          <div class="card-content">
+            <div class="columns">
+              <div class="column field">
+                <label class="label">Name</label>
+                <div class="control">
+                  <input
+                    class="input inputClassFeatureName"
+                    type="text"
+                    placeholder="e.g. Skill Increase"
+                  />
+                </div>
+              </div>
+              <div class="column field classFeatureLevelSection">
+                <label class="label">Level</label>
+                <div class="control">
+                  <div class="select">
+                    <select class="inputClassFeatureLevel">
+                      <option value="-1">Unacquirable</option>
+                      <option value="1" selected>1</option>
+                      <option value="2">2</option>
+                      <option value="3">3</option>
+                      <option value="4">4</option>
+                      <option value="5">5</option>
+                      <option value="6">6</option>
+                      <option value="7">7</option>
+                      <option value="8">8</option>
+                      <option value="9">9</option>
+                      <option value="10">10</option>
+                      <option value="11">11</option>
+                      <option value="12">12</option>
+                      <option value="13">13</option>
+                      <option value="14">14</option>
+                      <option value="15">15</option>
+                      <option value="16">16</option>
+                      <option value="17">17</option>
+                      <option value="18">18</option>
+                      <option value="19">19</option>
+                      <option value="20">20</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="field">
+              <label class="label">
+                Description
+                <a href="/wsc_docs/#description_fields" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+              </label>
+              <div class="control">
+                <textarea
+                  class="textarea inputClassFeatureDesc"
+                  placeholder=""
+                ></textarea>
+              </div>
+            </div>
+            <div class="field pos-relative">
+              <label class="label">
+                Code
+                <a href="/wsc_docs/#code_basics" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+                <span class="code-block-statement-display">Builder & Sheet
+                  Statements</span>
+              </label>
+              <div class="control">
+                <textarea
+                  class="textarea inputClassFeatureCode nanum-coding use-custom-scrollbar"
+                  rows="1"
+                  spellcheck="false"
+                  maxlength="4990"
+                ></textarea>
+              </div>
+            </div>
+            <div class="field pt-1 classFeatureDisplayInSheetSection">
+              <label class="checkbox">
+                <input
+                  type="checkbox"
+                  class="inputClassFeatureDisplayInSheet"
+                  value="1"
+                  checked
+                />
+                <strong>Display In Sheet</strong>
+              </label>
+            </div>
+            <div class="field pt-1 classFeatureIsSelectorSection">
+              <label class="checkbox">
+                <input
+                  type="checkbox"
+                  class="inputClassFeatureIsSelector"
+                  value="1"
+                />
+                <strong>is Selector</strong>
+              </label>
+            </div>
+            <div class="classFeatureSelectionOptions is-hidden">
+              <div class="">
+                <button class="button is-link classFeatureAddOptionButton">Add
+                  Option</button>
+              </div>
+              <div class="classFeatureOptionsContent pt-2">
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+    </div>
+
+    <div class="tile is-vertical box mt-3">
+
+      <div class="tile is-child">
+        <button id="addFeatButton" class="button is-link">Add Class Feat</button>
+      </div>
+
+      <div id="featContent" class="tile is-child">
+
+        <div id="featLayout" class="card mb-2 classFeat is-hidden">
+          <div class="card-header cursor-clickable">
+            <p
+              class="card-header-title is-paddingless has-txt-value-number is-size-5"
+            >Class Feat</p>
+            <a
+              class="card-header-icon is-paddingless mt-1 delete is-medium"
+            ></a>
+          </div>
+          <div class="card-content">
+            <div class="field">
+              <label class="label">Name</label>
+              <div class="control">
+                <input
+                  class="input inputFeatName"
+                  type="text"
+                  placeholder="e.g. Grim Insight"
+                />
+              </div>
+            </div>
+
+            <div class="columns">
+              <div class="column field">
+                <label class="label">Level</label>
+                <div class="control">
+                  <div class="select">
+                    <select class="inputFeatLevel">
+                      <option value="-1">Unselectable</option>
+                      <option value="1" selected>1</option>
+                      <option value="2">2</option>
+                      <option value="4">4</option>
+                      <option value="6">6</option>
+                      <option value="8">8</option>
+                      <option value="10">10</option>
+                      <option value="12">12</option>
+                      <option value="14">14</option>
+                      <option value="16">16</option>
+                      <option value="18">18</option>
+                      <option value="20">20</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+
+              <div class="column field">
+                <label class="label">Actions</label>
+                <div class="control">
+                  <div class="select">
+                    <select class="inputFeatActions pf-icon">
+                      <option value="NONE">None</option>
+                      <option value="ACTION">[one-action]</option>
+                      <option value="TWO_ACTIONS">[two-actions]</option>
+                      <option value="THREE_ACTIONS">[three-actions]</option>
+                      <option value="FREE_ACTION">[free-action]</option>
+                      <option value="REACTION">[reaction]</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+
+              <div class="column field">
+                <label class="label">Rarity</label>
+                <div class="control">
+                  <div class="select">
+                    <select class="inputFeatRarity">
+                      <option value="COMMON">Common</option>
+                      <option value="UNCOMMON">Uncommon</option>
+                      <option value="RARE">Rare</option>
+                      <option value="UNIQUE">Unique</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="">
+              <label class="label">Other Traits</label>
+              <select
+                class="inputFeatTags"
+                data-placeholder="Select Traits"
+                multiple
+              >
+                {{#each tags}}
+                  <option value="{{id}}">{{name}}</option>
+                {{/each}}
+              </select>
+            </div>
+
+            <div class="field">
+              <label class="label">Prerequisites</label>
+              <div class="control">
+                <input
+                  class="input inputFeatPrereq"
+                  type="text"
+                  maxlength="290"
+                  placeholder=""
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">Requirements</label>
+              <div class="control">
+                <input class="input inputFeatReq" type="text" maxlength="590" />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">Frequency</label>
+              <div class="control">
+                <input
+                  class="input inputFeatFreq"
+                  type="text"
+                  maxlength="290"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">Cost</label>
+              <div class="control">
+                <input
+                  class="input inputFeatCost"
+                  type="text"
+                  maxlength="290"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">Trigger</label>
+              <div class="control">
+                <input
+                  class="input inputFeatTrigger"
+                  type="text"
+                  maxlength="290"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">
+                Description
+                <a href="/wsc_docs/#description_fields" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+              </label>
+              <div class="control">
+                <textarea
+                  class="textarea inputFeatDesc"
+                  placeholder="Others’ attempts to scare you often grant you insights..."
+                ></textarea>
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">
+                Special
+                <a href="/wsc_docs/#description_fields" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+              </label>
+              <div class="control">
+                <input
+                  class="input inputFeatSpecial"
+                  type="text"
+                  maxlength="590"
+                />
+              </div>
+            </div>
+
+            <div class="field pt-1">
+              <label class="checkbox">
+                <input
+                  type="checkbox"
+                  class="inputFeatSelectMultiple"
+                  value="1"
+                />
+                <strong>Can Choose Multiple Times</strong>
+              </label>
+            </div>
+
+            <div class="field pos-relative">
+              <label class="label">
+                Code
+                <a href="/wsc_docs/#code_basics" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+                <span class="code-block-statement-display">Builder & Sheet
+                  Statements</span>
+              </label>
+              <div class="control">
+                <textarea
+                  class="textarea inputFeatCode nanum-coding use-custom-scrollbar"
+                  rows="1"
+                  spellcheck="false"
+                  maxlength="4990"
+                ></textarea>
+              </div>
+            </div>
+
+          </div>
+        </div>
+
+      </div>
+
+    </div>
+
+  </div>
 </div>
 
 <div class="field is-grouped is-grouped-centered pb-2">
-    <div class="control">
-        {{#if classID}}
-            <button id="updateButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{else}}
-            <button id="createButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{/if}}
-    </div>
+  <div class="control">
+    {{#if classID}}
+      <button
+        id="updateButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{else}}
+      <button
+        id="createButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{/if}}
+  </div>
 </div>

--- a/views/homebrew/builder_creature.handlebars
+++ b/views/homebrew/builder_creature.handlebars
@@ -1,42 +1,59 @@
-{{#section 'header'}}
-<link rel="stylesheet" href="/css/homebrew-builders.css">
-<script type="text/javascript" src="/js/confirm-page-leave.js"></script>
-<script type="text/javascript" src="/js/homebrew/builder/creature/builder-creature.js"></script>
-{{#if creatureID}}
-<script type="text/javascript" src="/js/homebrew/builder/creature/editor-creature.js"></script>
-{{/if}}
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/homebrew-builders.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-<li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
+  <script
+    type="text/javascript"
+    src="/js/homebrew/builder/creature/builder-creature.js"
+  ></script>
+  {{#if creatureID}}
+    <script
+      type="text/javascript"
+      src="/js/homebrew/builder/creature/editor-creature.js"
+    ></script>
+  {{/if}}
 {{/section}}
 
-{{#section 'nav_characters'}}
-<li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-<li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-<li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew" class="active">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-<li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/homebrew"
+      class="active"
+    >Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-<li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-<li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'banner_nav'}}
-<div class="banner_w3lspvt-2"></div>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
+
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="pageloader">
@@ -56,8 +73,13 @@
   <h1 class="title is-2 has-txt-value-number has-text-centered">Creature Builder</h1>
 </div>
 
-<div id="builder-container" data-user-id="{{user.id}}" data-bundle-id="{{bundleID}}" data-creature-id="{{creatureID}}"
-  class="columns is-mobile is-centered mt-2 mb-3">
+<div
+  id="builder-container"
+  data-user-id="{{user.id}}"
+  data-bundle-id="{{bundleID}}"
+  data-creature-id="{{creatureID}}"
+  class="columns is-mobile is-centered mt-2 mb-3"
+>
   <div class="column is-10 is-vertical">
 
     <div class="">
@@ -67,10 +89,14 @@
         <div class="field">
           <label class="label">Name</label>
           <div class="control">
-            <input id="inputName" class="input" type="text" autocomplete="off">
+            <input
+              id="inputName"
+              class="input"
+              type="text"
+              autocomplete="off"
+            />
           </div>
         </div>
-
 
         <div class="columns">
 
@@ -167,11 +193,11 @@
 
         </div>
 
-        <div class="  ">
+        <div class="">
           <label class="label">Traits</label>
           <select id="inputTags" data-placeholder="Select Traits" multiple>
             {{#each tags}}
-            <option value="{{id}}">{{name}}</option>
+              <option value="{{id}}">{{name}}</option>
             {{/each}}
           </select>
         </div>
@@ -179,31 +205,52 @@
         <div class="field">
           <label class="label">Family Group</label>
           <div class="control">
-            <input class="input" id="inputFamilyType" type="text" maxlength="120" placeholder="eg. Humanoid">
+            <input
+              class="input"
+              id="inputFamilyType"
+              type="text"
+              maxlength="120"
+              placeholder="eg. Humanoid"
+            />
           </div>
         </div>
 
-        <hr class="m-2">
+        <hr class="m-2" />
 
         <div class="field">
           <label class="label">Perception Bonus</label>
           <div class="control">
-            <input id="inputPerceptionBonus" class="input" type="number" value="5">
+            <input
+              id="inputPerceptionBonus"
+              class="input"
+              type="number"
+              value="5"
+            />
           </div>
         </div>
 
         <div class="field">
           <label class="label">Senses</label>
           <div class="control">
-            <input class="input" id="inputSenses" type="text" maxlength="450" placeholder="eg. darkvision">
+            <input
+              class="input"
+              id="inputSenses"
+              type="text"
+              maxlength="450"
+              placeholder="eg. darkvision"
+            />
           </div>
         </div>
 
-        <div class="  ">
+        <div class="">
           <label class="label">Languages</label>
-          <select id="inputLanguages" data-placeholder="Select Languages" multiple>
+          <select
+            id="inputLanguages"
+            data-placeholder="Select Languages"
+            multiple
+          >
             {{#each languages}}
-            <option value="{{id}}">{{name}}</option>
+              <option value="{{id}}">{{name}}</option>
             {{/each}}
           </select>
         </div>
@@ -211,11 +258,17 @@
         <div class="field">
           <label class="label">Extra Languages</label>
           <div class="control">
-            <input class="input" id="inputLanguagesCustom" type="text" maxlength="600" placeholder="eg. Tongues">
+            <input
+              class="input"
+              id="inputLanguagesCustom"
+              type="text"
+              maxlength="600"
+              placeholder="eg. Tongues"
+            />
           </div>
         </div>
 
-        <hr class="m-2">
+        <hr class="m-2" />
 
         <!-- Skills entry -->
 
@@ -227,20 +280,32 @@
 
           <div id="skillLayout" class="card mb-2 creatureSkill is-hidden">
             <div class="card-header cursor-clickable">
-              <p class="card-header-title is-paddingless has-txt-value-number is-size-5">Skill</p>
-              <a class="card-header-icon is-paddingless mt-1 delete is-medium"></a>
+              <p
+                class="card-header-title is-paddingless has-txt-value-number is-size-5"
+              >Skill</p>
+              <a
+                class="card-header-icon is-paddingless mt-1 delete is-medium"
+              ></a>
             </div>
             <div class="card-content columns is-marginless">
               <div class="field column is-paddingless">
                 <label class="label">Name</label>
                 <div class="control">
-                  <input class="input inputSkillName" type="text" placeholder="e.g. Arcana">
+                  <input
+                    class="input inputSkillName"
+                    type="text"
+                    placeholder="e.g. Arcana"
+                  />
                 </div>
               </div>
               <div class="field column is-paddingless pl-2">
                 <label class="label">Bonus</label>
                 <div class="control">
-                  <input class="input inputSkillBonus" type="number" value="0">
+                  <input
+                    class="input inputSkillBonus"
+                    type="number"
+                    value="0"
+                  />
                 </div>
               </div>
             </div>
@@ -248,7 +313,7 @@
 
         </div>
 
-        <hr class="m-2">
+        <hr class="m-2" />
 
         <!-- Items entry -->
 
@@ -260,20 +325,32 @@
 
           <div id="itemLayout" class="card mb-2 creatureItem is-hidden">
             <div class="card-header cursor-clickable">
-              <p class="card-header-title is-paddingless has-txt-value-number is-size-5">Item</p>
-              <a class="card-header-icon is-paddingless mt-1 delete is-medium"></a>
+              <p
+                class="card-header-title is-paddingless has-txt-value-number is-size-5"
+              >Item</p>
+              <a
+                class="card-header-icon is-paddingless mt-1 delete is-medium"
+              ></a>
             </div>
             <div class="card-content columns is-marginless">
               <div class="field column is-paddingless">
                 <label class="label">Name</label>
                 <div class="control">
-                  <input class="input inputItemDisplayName" type="text" placeholder="e.g. Greatsword">
+                  <input
+                    class="input inputItemDisplayName"
+                    type="text"
+                    placeholder="e.g. Greatsword"
+                  />
                 </div>
               </div>
               <div class="field column is-paddingless pl-2">
                 <label class="label">Quantity</label>
                 <div class="control">
-                  <input class="input inputItemQuantity" type="number" value="1">
+                  <input
+                    class="input inputItemQuantity"
+                    type="number"
+                    value="1"
+                  />
                 </div>
               </div>
               <!-- TODO: Add name, doIndex, and shieldStats -->
@@ -282,76 +359,91 @@
 
         </div>
 
-        <hr class="m-2">
+        <hr class="m-2" />
 
         <div class="columns">
           <div class="column field">
             <label class="label">Str</label>
             <div class="control">
-              <input id="inputStrMod" class="input" type="number" value="2">
+              <input id="inputStrMod" class="input" type="number" value="2" />
             </div>
           </div>
           <div class="column field">
             <label class="label">Dex</label>
             <div class="control">
-              <input id="inputDexMod" class="input" type="number" value="2">
+              <input id="inputDexMod" class="input" type="number" value="2" />
             </div>
           </div>
           <div class="column field">
             <label class="label">Con</label>
             <div class="control">
-              <input id="inputConMod" class="input" type="number" value="2">
+              <input id="inputConMod" class="input" type="number" value="2" />
             </div>
           </div>
           <div class="column field">
             <label class="label">Int</label>
             <div class="control">
-              <input id="inputIntMod" class="input" type="number" value="2">
+              <input id="inputIntMod" class="input" type="number" value="2" />
             </div>
           </div>
           <div class="column field">
             <label class="label">Wis</label>
             <div class="control">
-              <input id="inputWisMod" class="input" type="number" value="2">
+              <input id="inputWisMod" class="input" type="number" value="2" />
             </div>
           </div>
           <div class="column field">
             <label class="label">Cha</label>
             <div class="control">
-              <input id="inputChaMod" class="input" type="number" value="2">
+              <input id="inputChaMod" class="input" type="number" value="2" />
             </div>
           </div>
         </div>
 
-        <hr class="m-2">
+        <hr class="m-2" />
 
         <!-- interactionAbilitiesJSON entries -->
 
-        <hr class="m-2">
+        <hr class="m-2" />
 
         <div class="columns is-marginless">
           <div class="column field">
             <label class="label">AC</label>
             <div class="control">
-              <input id="inputACValue" class="input" type="number" value="15">
+              <input id="inputACValue" class="input" type="number" value="15" />
             </div>
           </div>
           <div class="column field">
             <label class="label">Fort</label>
             <div class="control">
-              <input id="inputFortValue" class="input" type="number" value="5">
+              <input
+                id="inputFortValue"
+                class="input"
+                type="number"
+                value="5"
+              />
             </div>
           </div>
           <div class="column field">
             <label class="label">Reflex</label>
             <div class="control">
-              <input id="inputReflexValue" class="input" type="number" value="5">
+              <input
+                id="inputReflexValue"
+                class="input"
+                type="number"
+                value="5"
+              />
             </div>
           </div>
           <div class="column field">
             <label class="label">Will</label>
             <div class="control">
-              <input id="inputWillValue" class="input" type="number" value="5">
+              <input
+                id="inputWillValue"
+                class="input"
+                type="number"
+                value="5"
+              />
             </div>
           </div>
         </div>
@@ -359,29 +451,40 @@
         <div class="field">
           <label class="label">Extra Saves Bonus</label>
           <div class="control">
-            <input class="input" id="inputAllSavesCustom" type="text" maxlength="600"
-              placeholder="eg. +1 status to all saves vs. magic">
+            <input
+              class="input"
+              id="inputAllSavesCustom"
+              type="text"
+              maxlength="600"
+              placeholder="eg. +1 status to all saves vs. magic"
+            />
           </div>
         </div>
 
-        <hr class="m-2">
+        <hr class="m-2" />
 
         <div class="columns">
           <div class="column field">
             <label class="label">HP</label>
             <div class="control">
-              <input id="inputHPMax" class="input" type="number" value="30">
+              <input id="inputHPMax" class="input" type="number" value="30" />
             </div>
           </div>
           <div class="column field">
             <label class="label">Extra HP Details</label>
             <div class="control">
-              <input class="input" id="inputHPDetails" type="text" maxlength="450" placeholder="eg. negative healing">
+              <input
+                class="input"
+                id="inputHPDetails"
+                type="text"
+                maxlength="450"
+                placeholder="eg. negative healing"
+              />
             </div>
           </div>
         </div>
 
-        <hr class="m-2">
+        <hr class="m-2" />
 
         <!-- immunitiesJSON entries -->
 
@@ -389,22 +492,22 @@
 
         <!-- resistancesJSON entries -->
 
-        <hr class="m-2">
+        <hr class="m-2" />
 
         <!-- defensiveAbilitiesJSON entries -->
 
-        <hr class="m-2">
+        <hr class="m-2" />
 
         <div class="field">
           <label class="label">Speed</label>
           <div class="control">
-            <input class="input" id="inputSpeed" type="number" value="25">
+            <input class="input" id="inputSpeed" type="number" value="25" />
           </div>
         </div>
 
         <!-- otherSpeedsJSON entries -->
 
-        <hr class="m-2">
+        <hr class="m-2" />
 
         <!-- attacksJSON entries -->
 
@@ -412,20 +515,23 @@
 
         <!-- offensiveAbilitiesJSON entries -->
 
-        <hr class="m-2">
+        <hr class="m-2" />
 
         <div class="field">
           <label class="label">
             Flavor Text
             <a href="/wsc_docs/#description_fields" target="_blank"><span
-                class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i
-                  class="fas fa-book"></i></span></a>
+                class="icon is-small has-text-info has-tooltip-top"
+                data-tooltip="WSC Docs"
+              ><i class="fas fa-book"></i></span></a>
           </label>
           <div class="control">
-            <textarea id="inputDescription" class="textarea use-custom-scrollbar"></textarea>
+            <textarea
+              id="inputDescription"
+              class="textarea use-custom-scrollbar"
+            ></textarea>
           </div>
         </div>
-
 
       </div>
 
@@ -443,11 +549,19 @@
     <span>Back</span>
   </a>-->
     {{#if creatureID}}
-    <button id="updateButton" onClick="canLeavePage()" onClick="canLeavePage()"
-      class="button is-rounded is-success">Save</button>
+      <button
+        id="updateButton"
+        onClick="canLeavePage()"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
     {{else}}
-    <button id="createButton" onClick="canLeavePage()" onClick="canLeavePage()"
-      class="button is-rounded is-success">Save</button>
+      <button
+        id="createButton"
+        onClick="canLeavePage()"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
     {{/if}}
   </div>
 </div>

--- a/views/homebrew/builder_feat-action.handlebars
+++ b/views/homebrew/builder_feat-action.handlebars
@@ -1,296 +1,382 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/homebrew-builders.css">
-    <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
-    <script type="text/javascript" src="/js/homebrew/builder/feat-action/builder-feat-action.js"></script>
-    {{#if featID}}
-        <script type="text/javascript" src="/js/homebrew/builder/feat-action/editor-feat-action.js"></script>
-    {{/if}}
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/homebrew-builders.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
+  <script
+    type="text/javascript"
+    src="/js/homebrew/builder/feat-action/builder-feat-action.js"
+  ></script>
+  {{#if featID}}
+    <script
+      type="text/javascript"
+      src="/js/homebrew/builder/feat-action/editor-feat-action.js"
+    ></script>
+  {{/if}}
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew" class="active">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/homebrew"
+      class="active"
+    >Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
+
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="pageloader">
-    <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+  <div class="lds-roller"><div></div><div></div><div></div><div></div><div
+    ></div><div></div><div></div><div></div></div>
 </div>
 
 <div class="pt-3">
-  <h1 class="title is-2 has-txt-value-number has-text-centered">Feat / Activity Builder</h1>
+  <h1 class="title is-2 has-txt-value-number has-text-centered">Feat / Activity
+    Builder</h1>
 </div>
 
-<div id="builder-container" data-user-id="{{user.id}}" data-bundle-id="{{bundleID}}" data-feat-id="{{featID}}" class="columns is-mobile is-centered mt-2 mb-3">
-    <div class="column is-8 tile is-ancestor is-vertical">
+<div
+  id="builder-container"
+  data-user-id="{{user.id}}"
+  data-bundle-id="{{bundleID}}"
+  data-feat-id="{{featID}}"
+  class="columns is-mobile is-centered mt-2 mb-3"
+>
+  <div class="column is-8 tile is-ancestor is-vertical">
 
-        <div class="tile">
+    <div class="tile">
 
-            <div class="tile is-parent is-vertical box is-marginless">
+      <div class="tile is-parent is-vertical box is-marginless">
 
-                <div class="tile is-child">
-                    <div class="has-text-centered is-marginless">
-                        <p>Use this builder to create any type of feat or basic activity.</p>
-                    </div>
-                    <div class="field is-grouped is-grouped-centered">
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputBuilderType">
-                                    <option value="GENERAL-FEAT" selected>General Feat</option>
-                                    <option value="SKILL-FEAT">Skill Feat</option>
-                                    <option value="CLASS-FEAT">Class Feat</option>
-                                    <option value="ANCESTRY-FEAT">Ancestry Feat</option>
-                                    <option value="ARCHETYPE-FEAT">Archetype Feat</option>
-                                    <option value="BASIC-ACTION">Basic Action</option>
-                                    <option value="SKILL-ACTION">Skill Action</option>
-                                    <option value="COMPANION-ACTION">Companion Action</option>
-                                    <option value="CREATURE-ACTION">Creature Action</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div id="sectionClassOptions" class="control is-hidden">
-                            <div class="select">
-                                <select id="inputClassOptions">
-                                </select>
-                            </div>
-                        </div>
-                        <div id="sectionAncestryOptions" class="control is-hidden">
-                            <div class="select">
-                                <select id="inputAncestryOptions">
-                                </select>
-                            </div>
-                        </div>
-                        <div id="sectionArchetypeOptions" class="control is-hidden">
-                            <div class="select">
-                                <select id="inputArchetypeOptions">
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-
-
-                <div class="tile is-child field">
-                    <label class="label">Name</label>
-                    <div class="control">
-                        <input class="input" id="inputFeatName" type="text" placeholder="e.g. Grim Insight" autocomplete="off">
-                    </div>
-                </div>
-
-                <div class="tile is-child columns">
-
-                    <div id="sectionSkill" class="column field">
-                        <label class="label">Skill</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputFeatSkill">
-                                    <option value="">Any</option>
-                                    {{#each skills}}
-                                        <option value="{{id}}">{{name}}</option>
-                                    {{/each}}
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div id="sectionMinProf" class="column field">
-                        <label class="label">Min. Proficiency</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputFeatMinProf">
-                                    <option value="U" selected>Untrained</option>
-                                    <option value="T">Trained</option>
-                                    <option value="E">Expert</option>
-                                    <option value="M">Master</option>
-                                    <option value="L">Legendary</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div id="sectionLevel" class="column field">
-                        <label class="label">Level</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputFeatLevel">
-                                    <option value="-1">Unselectable</option>
-                                    <option value="1" selected>1</option>
-                                    <option value="2">2</option>
-                                    <option value="3">3</option>
-                                    <option value="4">4</option>
-                                    <option value="5">5</option>
-                                    <option value="6">6</option>
-                                    <option value="7">7</option>
-                                    <option value="8">8</option>
-                                    <option value="9">9</option>
-                                    <option value="10">10</option>
-                                    <option value="11">11</option>
-                                    <option value="12">12</option>
-                                    <option value="13">13</option>
-                                    <option value="14">14</option>
-                                    <option value="15">15</option>
-                                    <option value="16">16</option>
-                                    <option value="17">17</option>
-                                    <option value="18">18</option>
-                                    <option value="19">19</option>
-                                    <option value="20">20</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Actions</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputFeatActions" class="pf-icon">
-                                    <option value="NONE">None</option>
-                                    <option value="ACTION">[one-action]</option>
-                                    <option value="TWO_ACTIONS">[two-actions]</option>
-                                    <option value="THREE_ACTIONS">[three-actions]</option>
-                                    <option value="FREE_ACTION">[free-action]</option>
-                                    <option value="REACTION">[reaction]</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Rarity</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputFeatRarity">
-                                    <option value="COMMON">Common</option>
-                                    <option value="UNCOMMON">Uncommon</option>
-                                    <option value="RARE">Rare</option>
-                                    <option value="UNIQUE">Unique</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child">
-                    <label class="label">Other Traits</label>
-                    <select id="inputFeatTags" data-placeholder="Select Traits" multiple>
-                        {{#each tags}}
-                            <option value="{{id}}">{{name}}</option>
-                        {{/each}}
-                    </select>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Prerequisites</label>
-                    <div class="control">
-                        <input class="input" id="inputFeatPrereq" type="text" maxlength="290">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Requirements</label>
-                    <div class="control">
-                        <input class="input" id="inputFeatReq" type="text" maxlength="590">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Frequency</label>
-                    <div class="control">
-                        <input class="input" id="inputFeatFreq" type="text" maxlength="290">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Cost</label>
-                    <div class="control">
-                        <input class="input" id="inputFeatCost" type="text" maxlength="290">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Trigger</label>
-                    <div class="control">
-                        <input class="input" id="inputFeatTrigger" type="text" maxlength="290">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">
-                        Description
-                        <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                    </label>
-                    <div class="control">
-                        <textarea class="textarea" id="inputFeatDesc" placeholder=""></textarea>
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">
-                      Special
-                      <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                    </label>
-                    <div class="control">
-                        <input class="input" id="inputFeatSpecial" type="text" maxlength="590">
-                    </div>
-                </div>
-
-                <div id="sectionSelectMultiple" class="tile is-child field pt-1">
-                     <label class="checkbox">
-                        <input type="checkbox" id="inputFeatSelectMultiple" value="1">
-                        <strong>Can Choose Multiple Times</strong>
-                    </label>
-                </div>
-
-                <div class="tile is-child field pos-relative">
-                    <label class="label">
-                        Code
-                        <a href="/wsc_docs/#code_basics" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                        <span class="code-block-statement-display">Builder & Sheet Statements</span>
-                    </label>
-                    <div class="control">
-                        <textarea id="inputFeatCode" class="textarea nanum-coding use-custom-scrollbar" rows="1" spellcheck="false" maxlength="4990"></textarea>
-                    </div>
-                </div>
-
+        <div class="tile is-child">
+          <div class="has-text-centered is-marginless">
+            <p>Use this builder to create any type of feat or basic activity.</p>
+          </div>
+          <div class="field is-grouped is-grouped-centered">
+            <div class="control">
+              <div class="select">
+                <select id="inputBuilderType">
+                  <option value="GENERAL-FEAT" selected>General Feat</option>
+                  <option value="SKILL-FEAT">Skill Feat</option>
+                  <option value="CLASS-FEAT">Class Feat</option>
+                  <option value="ANCESTRY-FEAT">Ancestry Feat</option>
+                  <option value="ARCHETYPE-FEAT">Archetype Feat</option>
+                  <option value="BASIC-ACTION">Basic Action</option>
+                  <option value="SKILL-ACTION">Skill Action</option>
+                  <option value="COMPANION-ACTION">Companion Action</option>
+                  <option value="CREATURE-ACTION">Creature Action</option>
+                </select>
+              </div>
             </div>
+            <div id="sectionClassOptions" class="control is-hidden">
+              <div class="select">
+                <select id="inputClassOptions">
+                </select>
+              </div>
+            </div>
+            <div id="sectionAncestryOptions" class="control is-hidden">
+              <div class="select">
+                <select id="inputAncestryOptions">
+                </select>
+              </div>
+            </div>
+            <div id="sectionArchetypeOptions" class="control is-hidden">
+              <div class="select">
+                <select id="inputArchetypeOptions">
+                </select>
+              </div>
+            </div>
+          </div>
         </div>
+
+        <div class="tile is-child field">
+          <label class="label">Name</label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputFeatName"
+              type="text"
+              placeholder="e.g. Grim Insight"
+              autocomplete="off"
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child columns">
+
+          <div id="sectionSkill" class="column field">
+            <label class="label">Skill</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputFeatSkill">
+                  <option value="">Any</option>
+                  {{#each skills}}
+                    <option value="{{id}}">{{name}}</option>
+                  {{/each}}
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div id="sectionMinProf" class="column field">
+            <label class="label">Min. Proficiency</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputFeatMinProf">
+                  <option value="U" selected>Untrained</option>
+                  <option value="T">Trained</option>
+                  <option value="E">Expert</option>
+                  <option value="M">Master</option>
+                  <option value="L">Legendary</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div id="sectionLevel" class="column field">
+            <label class="label">Level</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputFeatLevel">
+                  <option value="-1">Unselectable</option>
+                  <option value="1" selected>1</option>
+                  <option value="2">2</option>
+                  <option value="3">3</option>
+                  <option value="4">4</option>
+                  <option value="5">5</option>
+                  <option value="6">6</option>
+                  <option value="7">7</option>
+                  <option value="8">8</option>
+                  <option value="9">9</option>
+                  <option value="10">10</option>
+                  <option value="11">11</option>
+                  <option value="12">12</option>
+                  <option value="13">13</option>
+                  <option value="14">14</option>
+                  <option value="15">15</option>
+                  <option value="16">16</option>
+                  <option value="17">17</option>
+                  <option value="18">18</option>
+                  <option value="19">19</option>
+                  <option value="20">20</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Actions</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputFeatActions" class="pf-icon">
+                  <option value="NONE">None</option>
+                  <option value="ACTION">[one-action]</option>
+                  <option value="TWO_ACTIONS">[two-actions]</option>
+                  <option value="THREE_ACTIONS">[three-actions]</option>
+                  <option value="FREE_ACTION">[free-action]</option>
+                  <option value="REACTION">[reaction]</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Rarity</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputFeatRarity">
+                  <option value="COMMON">Common</option>
+                  <option value="UNCOMMON">Uncommon</option>
+                  <option value="RARE">Rare</option>
+                  <option value="UNIQUE">Unique</option>
+                </select>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="tile is-child">
+          <label class="label">Other Traits</label>
+          <select id="inputFeatTags" data-placeholder="Select Traits" multiple>
+            {{#each tags}}
+              <option value="{{id}}">{{name}}</option>
+            {{/each}}
+          </select>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Prerequisites</label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputFeatPrereq"
+              type="text"
+              maxlength="290"
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Requirements</label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputFeatReq"
+              type="text"
+              maxlength="590"
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Frequency</label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputFeatFreq"
+              type="text"
+              maxlength="290"
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Cost</label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputFeatCost"
+              type="text"
+              maxlength="290"
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Trigger</label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputFeatTrigger"
+              type="text"
+              maxlength="290"
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">
+            Description
+            <a href="/wsc_docs/#description_fields" target="_blank"><span
+                class="icon is-small has-text-info has-tooltip-top"
+                data-tooltip="WSC Docs"
+              ><i class="fas fa-book"></i></span></a>
+          </label>
+          <div class="control">
+            <textarea
+              class="textarea"
+              id="inputFeatDesc"
+              placeholder=""
+            ></textarea>
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">
+            Special
+            <a href="/wsc_docs/#description_fields" target="_blank"><span
+                class="icon is-small has-text-info has-tooltip-top"
+                data-tooltip="WSC Docs"
+              ><i class="fas fa-book"></i></span></a>
+          </label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputFeatSpecial"
+              type="text"
+              maxlength="590"
+            />
+          </div>
+        </div>
+
+        <div id="sectionSelectMultiple" class="tile is-child field pt-1">
+          <label class="checkbox">
+            <input type="checkbox" id="inputFeatSelectMultiple" value="1" />
+            <strong>Can Choose Multiple Times</strong>
+          </label>
+        </div>
+
+        <div class="tile is-child field pos-relative">
+          <label class="label">
+            Code
+            <a href="/wsc_docs/#code_basics" target="_blank"><span
+                class="icon is-small has-text-info has-tooltip-top"
+                data-tooltip="WSC Docs"
+              ><i class="fas fa-book"></i></span></a>
+            <span class="code-block-statement-display">Builder & Sheet
+              Statements</span>
+          </label>
+          <div class="control">
+            <textarea
+              id="inputFeatCode"
+              class="textarea nanum-coding use-custom-scrollbar"
+              rows="1"
+              spellcheck="false"
+              maxlength="4990"
+            ></textarea>
+          </div>
+        </div>
+
+      </div>
     </div>
+  </div>
 </div>
 
 <div class="field is-grouped is-grouped-centered pb-2">
-    <div class="control">
-        {{#if featID}}
-            <button id="updateButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{else}}
-            <button id="createButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{/if}}
-    </div>
+  <div class="control">
+    {{#if featID}}
+      <button
+        id="updateButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{else}}
+      <button
+        id="createButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{/if}}
+  </div>
 </div>

--- a/views/homebrew/builder_heritage.handlebars
+++ b/views/homebrew/builder_heritage.handlebars
@@ -1,123 +1,177 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/homebrew-builders.css">
-    <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
-    <script type="text/javascript" src="/js/homebrew/builder/heritage/builder-heritage.js"></script>
-    {{#if heritageID}}
-        <script type="text/javascript" src="/js/homebrew/builder/heritage/editor-heritage.js"></script>
-    {{/if}}
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/homebrew-builders.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
+  <script
+    type="text/javascript"
+    src="/js/homebrew/builder/heritage/builder-heritage.js"
+  ></script>
+  {{#if heritageID}}
+    <script
+      type="text/javascript"
+      src="/js/homebrew/builder/heritage/editor-heritage.js"
+    ></script>
+  {{/if}}
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew" class="active">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/homebrew"
+      class="active"
+    >Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
+
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="pageloader">
-    <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+  <div class="lds-roller"><div></div><div></div><div></div><div></div><div
+    ></div><div></div><div></div><div></div></div>
 </div>
 
 <div class="pt-3">
-    <h1 class="title is-2 has-txt-value-number has-text-centered">Heritage Builder</h1>
+  <h1 class="title is-2 has-txt-value-number has-text-centered">Heritage Builder</h1>
 </div>
 
-<div id="builder-container" data-user-id="{{user.id}}" data-bundle-id="{{bundleID}}" data-heritage-id="{{heritageID}}" class="columns is-mobile is-centered mt-2 mb-3">
-    <div class="column is-6 tile is-ancestor is-vertical">
+<div
+  id="builder-container"
+  data-user-id="{{user.id}}"
+  data-bundle-id="{{bundleID}}"
+  data-heritage-id="{{heritageID}}"
+  class="columns is-mobile is-centered mt-2 mb-3"
+>
+  <div class="column is-6 tile is-ancestor is-vertical">
 
-        <div class="tile">
+    <div class="tile">
 
-            <div class="tile is-parent is-vertical box is-marginless mr-2">
+      <div class="tile is-parent is-vertical box is-marginless mr-2">
 
-                <div class="tile is-child">
-                    <div class="field is-grouped is-grouped-centered">
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputHeritageFor">
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Name</label>
-                    <div class="control">
-                        <input id="inputName" class="input" type="text" placeholder="e.g. Umbral" autocomplete="off">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Rarity</label>
-                    <div class="control">
-                        <div class="select">
-                            <select id="inputRarity">
-                                <option value="COMMON">Common</option>
-                                <option value="UNCOMMON">Uncommon</option>
-                                <option value="RARE">Rare</option>
-                                <option value="UNIQUE">Unique</option>
-                            </select>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">
-                        Description
-                        <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                    </label>
-                    <div class="control">
-                        <textarea id="inputDesc" class="textarea" placeholder="Whether from a connection to dark or shadowy fey..."></textarea>
-                    </div>
-                </div>
-                <div class="tile is-child field pos-relative">
-                    <label class="label">
-                        Code
-                        <a href="/wsc_docs/#code_basics" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                        <span class="code-block-statement-display">Builder & Sheet Statements</span>
-                    </label>
-                    <div class="control">
-                        <textarea id="inputCode" class="textarea nanum-coding use-custom-scrollbar" rows="1" spellcheck="false" maxlength="4990"></textarea>
-                    </div>
-                </div>   
-
+        <div class="tile is-child">
+          <div class="field is-grouped is-grouped-centered">
+            <div class="control">
+              <div class="select">
+                <select id="inputHeritageFor">
+                </select>
+              </div>
             </div>
+          </div>
         </div>
+
+        <div class="tile is-child field">
+          <label class="label">Name</label>
+          <div class="control">
+            <input
+              id="inputName"
+              class="input"
+              type="text"
+              placeholder="e.g. Umbral"
+              autocomplete="off"
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Rarity</label>
+          <div class="control">
+            <div class="select">
+              <select id="inputRarity">
+                <option value="COMMON">Common</option>
+                <option value="UNCOMMON">Uncommon</option>
+                <option value="RARE">Rare</option>
+                <option value="UNIQUE">Unique</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">
+            Description
+            <a href="/wsc_docs/#description_fields" target="_blank"><span
+                class="icon is-small has-text-info has-tooltip-top"
+                data-tooltip="WSC Docs"
+              ><i class="fas fa-book"></i></span></a>
+          </label>
+          <div class="control">
+            <textarea
+              id="inputDesc"
+              class="textarea"
+              placeholder="Whether from a connection to dark or shadowy fey..."
+            ></textarea>
+          </div>
+        </div>
+        <div class="tile is-child field pos-relative">
+          <label class="label">
+            Code
+            <a href="/wsc_docs/#code_basics" target="_blank"><span
+                class="icon is-small has-text-info has-tooltip-top"
+                data-tooltip="WSC Docs"
+              ><i class="fas fa-book"></i></span></a>
+            <span class="code-block-statement-display">Builder & Sheet
+              Statements</span>
+          </label>
+          <div class="control">
+            <textarea
+              id="inputCode"
+              class="textarea nanum-coding use-custom-scrollbar"
+              rows="1"
+              spellcheck="false"
+              maxlength="4990"
+            ></textarea>
+          </div>
+        </div>
+
+      </div>
     </div>
+  </div>
 </div>
 
 <div class="field is-grouped is-grouped-centered pb-2">
-    <div class="control">
-        {{#if heritageID}}
-            <button id="updateButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{else}}
-            <button id="createButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{/if}}
-    </div>
+  <div class="control">
+    {{#if heritageID}}
+      <button
+        id="updateButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{else}}
+      <button
+        id="createButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{/if}}
+  </div>
 </div>

--- a/views/homebrew/builder_item.handlebars
+++ b/views/homebrew/builder_item.handlebars
@@ -1,644 +1,846 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/homebrew-builders.css">
-    <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
-    <script type="text/javascript" src="/js/homebrew/builder/item/builder-item.js"></script>
-    {{#if itemID}}
-        <script type="text/javascript" src="/js/homebrew/builder/item/editor-item.js"></script>
-    {{/if}}
-    <script src="/js/sheet/utils/material-utils.js"></script>
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/homebrew-builders.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
+  <script
+    type="text/javascript"
+    src="/js/homebrew/builder/item/builder-item.js"
+  ></script>
+  {{#if itemID}}
+    <script
+      type="text/javascript"
+      src="/js/homebrew/builder/item/editor-item.js"
+    ></script>
+  {{/if}}
+  <script src="/js/sheet/utils/material-utils.js"></script>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew" class="active">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/homebrew"
+      class="active"
+    >Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
+
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="pageloader">
-    <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+  <div class="lds-roller"><div></div><div></div><div></div><div></div><div
+    ></div><div></div><div></div><div></div></div>
 </div>
 
 <div class="pt-3">
-    <h1 class="title is-2 has-txt-value-number has-text-centered">Item Builder</h1>
+  <h1 class="title is-2 has-txt-value-number has-text-centered">Item Builder</h1>
 </div>
 
-<div id="builder-container" data-user-id="{{user.id}}" data-bundle-id="{{bundleID}}" data-item-id="{{itemID}}" class="columns is-mobile is-centered mt-2 mb-3">
-    <div class="column is-8 tile is-ancestor is-vertical">
-
-        <div class="tile">
-
-            <div class="tile is-parent is-vertical box is-marginless">
-
-                <div class="tile is-child">
-                    <div class="has-text-centered is-marginless">
-                        <p>Use this builder to create general items, storage, weapons, armor, shields, or runes.</p>
-                    </div>
-                    <div class="field is-grouped is-grouped-centered">
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputBuilderType">
-                                    <option value="GENERAL" selected>General Item</option>
-                                    <option value="STORAGE">Storage Item</option>
-                                    <option value="WEAPON">Weapon</option>
-                                    <option value="ARMOR">Armor</option>
-                                    <option value="SHIELD">Shield</option>
-                                    <option value="RUNE">Runestone</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div id="sectionItemCopyOfOther" class="control is-hidden">
-                            <div class="select">
-                                <select id="inputItemCopyOfOther">
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Name</label>
-                    <div class="control">
-                        <input class="input" id="inputName" type="text" placeholder="e.g. Adventurer's Pack" autocomplete="off">
-                    </div>
-                </div>
-
-                <div class="tile is-child columns">
-
-                    <div class="column field">
-                        <label class="label">Price (in cp)</label>
-                        <div class="control">
-                            <input id="inputPrice" class="input" type="number" value="100" min="0">
-                        </div>
-                    </div>
-
-                    <div id="sectionBulk" class="column field">
-                        <label class="label">Bulk</label>
-                        <div class="control">
-                            <input id="inputBulk" class="input" type="number" value="0.0" step="0.1" min="0">
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Level</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputLevel">
-                                    <option value="0" selected>0</option>
-                                    <option value="1">1</option>
-                                    <option value="2">2</option>
-                                    <option value="3">3</option>
-                                    <option value="4">4</option>
-                                    <option value="5">5</option>
-                                    <option value="6">6</option>
-                                    <option value="7">7</option>
-                                    <option value="8">8</option>
-                                    <option value="9">9</option>
-                                    <option value="10">10</option>
-                                    <option value="11">11</option>
-                                    <option value="12">12</option>
-                                    <option value="13">13</option>
-                                    <option value="14">14</option>
-                                    <option value="15">15</option>
-                                    <option value="16">16</option>
-                                    <option value="17">17</option>
-                                    <option value="18">18</option>
-                                    <option value="19">19</option>
-                                    <option value="20">20</option>
-                                    <option value="21">21</option>
-                                    <option value="22">22</option>
-                                    <option value="23">23</option>
-                                    <option value="24">24</option>
-                                    <option value="25">25</option>
-                                    <option value="26">26</option>
-                                    <option value="27">27</option>
-                                    <option value="28">28</option>
-                                    <option value="29">29</option>
-                                    <option value="30">30</option>
-                                    <option value="999">N/A</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                </div>
-
-                <div class="tile is-child columns">
-
-                    <div class="column field">
-                        <label class="label has-text-weight-normal"><strong class="has-tooltip-top" data-tooltip="Used to categorize the item in the item list">Category</strong></label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputCategory">
-                                    <option value="ADJUSTMENT">Adjustment</option>
-                                    <option value="ARTIFACT">Artifact</option>
-                                    <option value="AMMUNITION">Ammunition</option>
-                                    <option value="ARMOR">Armor</option>
-                                    <option value="BELT">Belt</option>
-                                    <option value="BOMB">Bomb</option>
-                                    <option value="BOOK">Book</option>
-                                    <option value="BOOTS">Boots</option>
-                                    <option value="BRACERS">Bracers</option>
-                                    <option value="CATALYST">Catalyst</option>
-                                    <option value="CIRCLET">Circlet</option>
-                                    <option value="CLOAK">Cloak</option>
-                                    <option value="COMPANION">Companion</option>
-                                    <option value="CURRENCY">Currency</option>
-                                    <option value="DRUG">Drug</option>
-                                    <option value="ELIXIR">Elixir</option>
-                                    <option value="EYEPIECE">Eyepiece</option>
-                                    <option value="FULU">Fulu</option>
-                                    <option value="GADGET">Gadget</option>
-                                    <option value="GIFT">Gift</option>
-                                    <option value="GLOVES">Gloves</option>
-                                    <option value="GRIMOIRE">Grimoire</option>
-                                    <option value="HAT">Hat</option>
-                                    <option value="INGREDIENT">Ingredient</option>
-                                    <option value="INSTRUMENT">Instrument</option>
-                                    <option value="KIT">Kit</option>
-                                    <option value="MASK">Mask</option>
-                                    <option value="NECKLACE">Necklace</option>
-                                    <option value="OIL">Oil</option>
-                                    <option value="POISON">Poison</option>
-                                    <option value="POTION">Potion</option>
-                                    <option value="RING">Ring</option>
-                                    <option value="ROD">Rod</option>
-                                    <option value="RUNE">Runestone</option>
-                                    <option value="SCROLL">Scroll</option>
-                                    <option value="SHIELD">Shield</option>
-                                    <option value="SIEGE">Siege</option>
-                                    <option value="SPELLHEART">Spellheart</option>
-                                    <option value="STAFF">Staff</option>
-                                    <option value="STORAGE">Storage</option>
-                                    <option value="STRUCTURE">Structure</option>
-                                    <option value="TALISMAN">Talisman</option>
-                                    <option value="TATTOO">Tattoo</option>
-                                    <option value="TOOL">Tool</option>
-                                    <option value="WAND">Wand</option>
-                                    <option value="WEAPON">Weapon</option>
-                                    <option value="OTHER">Other</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Rarity</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputRarity">
-                                    <option value="COMMON">Common</option>
-                                    <option value="UNCOMMON">Uncommon</option>
-                                    <option value="RARE">Rare</option>
-                                    <option value="UNIQUE">Unique</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div id="sectionSize" class="column field">
-                        <label class="label">Size</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputSize">
-                                    <option value="TINY">Tiny</option>
-                                    <option value="SMALL">Small</option>
-                                    <option value="MEDIUM" selected>Medium</option>
-                                    <option value="LARGE">Large</option>
-                                    <option value="HUGE">Huge</option>
-                                    <option value="GARGANTUAN">Gargantuan</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div id="sectionMaterial" class="column field">
-                        <label class="label">Material</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputMaterial">
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div id="sectionHands" class="column field">
-                        <label class="label">Hands</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputHands">
-                                    <option value="NONE" selected>-</option>
-                                    <option value="ONE">1</option>
-                                    <option value="ONE_PLUS">1+</option>
-                                    <option value="TWO">2</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                </div>
-
-                <div id="sectionWeapon" class="tile is-child columns">
-
-                    <div class="column is-2 field">
-                        <label class="label">Damage Die</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputDieType">
-                                    <option value="">1</option>
-                                    <option value="d2">d2</option>
-                                    <option value="d4">d4</option>
-                                    <option value="d6" selected>d6</option>
-                                    <option value="d8">d8</option>
-                                    <option value="d10">d10</option>
-                                    <option value="d12">d12</option>
-                                    <option value="d20">d20</option>
-                                    <option value="NONE">-</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="column is-5 field">
-                        <label class="label">Damage Type (most likely just: P, S, or B)</label>
-                        <div class="control">
-                            <input class="input" id="inputDamageType" type="text" maxlength="40" placeholder="">
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Weapon Category</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputWeaponCategory">
-                                    <option value="SIMPLE" selected>Simple</option>
-                                    <option value="MARTIAL">Martial</option>
-                                    <option value="ADVANCED">Advanced</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                </div>
-
-                <div id="sectionWeaponMelee" class="tile is-child columns">
-
-                    <div class="column field pt-5 pl-5">
-                        <label class="checkbox">
-                            <input type="checkbox" id="inputIsMelee" value="1">
-                            <strong>Is Melee</strong>
-                        </label>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Melee Weapon Group</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputMeleeWeaponType">
-                                    <option value="AXE" selected>Axe</option>
-                                    <option value="BRAWLING">Brawling</option>
-                                    <option value="CLUB">Club</option>
-                                    <option value="FLAIL">Flail</option>
-                                    <option value="HAMMER">Hammer</option>
-                                    <option value="KNIFE">Knife</option>
-                                    <option value="PICK">Pick</option>
-                                    <option value="POLEARM">Polearm</option>
-                                    <option value="SHIELD">Shield</option>
-                                    <option value="SPEAR">Spear</option>
-                                    <option value="SWORD">Sword</option>                                   
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                </div>
-
-                <div id="sectionWeaponRanged" class="tile is-child columns">
-
-                    <div class="column field pt-5 pl-5">
-                        <label class="checkbox">
-                            <input type="checkbox" id="inputIsRanged" value="1">
-                            <strong>Is Ranged</strong>
-                        </label>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Ranged Weapon Group</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputRangedWeaponType">
-                                    <option value="BOW" selected>Bow</option>
-                                    <option value="CROSSBOW">Crossbow</option>
-                                    <option value="DART">Dart</option>
-                                    <option value="FIREARM">Firearm</option>
-                                    <option value="SLING">Sling</option>   
-                                    <option value="BOMB">Bomb</option>                             
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Range (in feet)</label>
-                        <div class="control">
-                            <input id="inputRange" class="input" type="number" value="20" maxlength="4">
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Reload</label>
-                        <div class="control">
-                            <input id="inputReload" class="input" type="number" value="0" maxlength="1">
-                        </div>
-                    </div>
-
-                </div>
-
-                <div id="sectionStorage" class="tile is-child columns">
-
-                    <div class="column field">
-                        <label class="label">Max Bulk Storage</label>
-                        <div class="control">
-                            <input id="inputMaxBulkStorage" class="input" type="number" value="0.0" step="0.1" min="0">
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Bulk Ignored</label>
-                        <div class="control">
-                            <input id="inputBulkIgnored" class="input" type="number" value="0.0" step="0.1" min="0">
-                        </div>
-                    </div>
-
-                    <div class="column field pt-5">
-                        <label class="checkbox">
-                            <input type="checkbox" id="inputIgnoreSelfBulkIfWearing" value="1">
-                            <strong>Ignore Self-Bulk If Wearing</strong>
-                        </label>
-                    </div>
-
-                </div>
-
-                <div id="sectionShield" class="tile is-child columns">
-
-                    <div class="column field">
-                        <label class="label">AC Bonus</label>
-                        <div class="control">
-                            <input id="inputShieldACBonus" class="input" type="number" value="0" maxlength="1">
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Speed Penalty</label>
-                        <div class="control">
-                            <input id="inputShieldSpeedPenalty" class="input" type="number" value="0" step="5" maxlength="2">
-                        </div>
-                    </div>
-
-                </div>
-
-                <div id="sectionRunestone" class="tile is-child columns">
-
-                    <div class="column field">
-                        <label class="label">Rune Type</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputRuneType">
-                                    <option value="FUNDAMENTAL" selected>Fundamental</option>
-                                    <option value="PROPERTY">Property</option>                              
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">For</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputEtchedType">
-                                    <option value="WEAPON" selected>Weapons</option>
-                                    <option value="ARMOR">Armor</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                </div>
-
-                <div id="sectionArmor" class="tile is-child columns">
-
-                    <div class="column field">
-                        <label class="label">AC Bonus</label>
-                        <div class="control">
-                            <input id="inputArmorACBonus" class="input" type="number" value="0" maxlength="1">
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Dex Cap</label>
-                        <div class="control">
-                            <input id="inputArmorDexCap" class="input" type="number" value="0" maxlength="1">
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Armor Type</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputArmorType">
-                                    <option value="CLOTH">Cloth</option>
-                                    <option value="LEATHER" selected>Leather</option>
-                                    <option value="COMPOSITE">Composite</option>
-                                    <option value="CHAIN">Chain</option>
-                                    <option value="PLATE">Plate</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Armor Category</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputArmorCategory">
-                                    <option value="UNARMORED">Unarmored</option>
-                                    <option value="LIGHT" selected>Light</option>
-                                    <option value="MEDIUM">Medium</option>
-                                    <option value="HEAVY">Heavy</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                </div>
-
-                <div id="sectionArmorPenalties" class="tile is-child columns">
-                    <div class="column field">
-                        <label class="label">Check Penalty</label>
-                        <div class="control">
-                            <input id="inputArmorCheckPenalty" class="input" type="number" value="0" maxlength="1">
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Speed Penalty</label>
-                        <div class="control">
-                            <input id="inputArmorSpeedPenalty" class="input" type="number" value="0" step="5" maxlength="2">
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Min Strength</label>
-                        <div class="control">
-                            <input id="inputArmorMinStrength" class="input" type="number" value="10" maxlength="2">
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child">
-                    <label class="label">Traits</label>
-                    <select id="inputTags" data-placeholder="Select Traits" multiple>
-                      {{#each tags}}
-                        <option value="{{id}}">{{name}}</option>
-                      {{/each}}
-                    </select>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Usage</label>
-                    <div class="control">
-                        <input class="input" id="inputUsage" type="text" maxlength="110" placeholder="">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">
-                        Description
-                        <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                    </label>
-                    <div class="control">
-                        <textarea class="textarea" id="inputDesc" placeholder="This item is the starter kit for an adventurer..."></textarea>
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">
-                        Craft Requirements
-                        <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                    </label>
-                    <div class="control">
-                        <input class="input" id="inputCraftReq" type="text" maxlength="350" placeholder="">
-                    </div>
-                </div>
-
-                <div id="sectionIsShoddy" class="tile is-child field pt-1 pl-2">
-                     <label class="checkbox">
-                        <input type="checkbox" id="inputIsShoddy" value="1">
-                        <strong>Is Shoddy</strong>
-                    </label>
-                </div>
-
-                <div id="sectionQuantity" class="tile is-child columns">
-                    <div class="column field pt-5 is-grouped is-grouped-centered">
-                        <label class="checkbox">
-                            <input type="checkbox" id="inputHasQuantity" value="1">
-                            <strong>Has Quantity</strong>
-                        </label>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Quantity</label>
-                        <div class="control">
-                            <input id="inputQuantity" class="input" type="number" value="1">
-                        </div>
-                    </div>
-                </div>
-
-                <div id="sectionHealth" class="tile is-child columns">
-
-                    <div class="column field">
-                        <label class="label">
-                          <a href="/material_stats" class="has-text-bold-color" target="_blank">
-                            <strong class="has-tooltip-top" data-tooltip="Link to Material Stats page">Hardness<sup class="icon is-small"><i class="fas fa-xs fa-external-link-alt"></i></sup></strong>
-                          </a>
-                        </label>
-                        <div class="control">
-                            <input id="inputHardness" class="input" type="number" value="0">
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">
-                          <a href="/material_stats" class="has-text-bold-color" target="_blank">
-                            <strong class="has-tooltip-top" data-tooltip="Link to Material Stats page">Hit Points<sup class="icon is-small"><i class="fas fa-xs fa-external-link-alt"></i></sup></strong>
-                          </a>
-                        </label>
-                        <div class="control">
-                            <input id="inputHitPoints" class="input" type="number" value="0">
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">
-                          <a href="/material_stats" class="has-text-bold-color" target="_blank">
-                            <strong class="has-tooltip-top" data-tooltip="Link to Material Stats page">Broken Threshold<sup class="icon is-small"><i class="fas fa-xs fa-external-link-alt"></i></sup></strong>
-                          </a>
-                        </label>
-                        <div class="control">
-                            <input id="inputBrokenThreshold" class="input" type="number" value="0">
-                        </div>
-                    </div>
-
-                </div>
-
-                <div class="tile is-child field pos-relative">
-                    <label class="label">
-                        Code
-                        <a href="/wsc_docs/#code_basics" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                        <span class="code-block-statement-display">Sheet Statements Only</span>
-                    </label>
-                    <div class="control">
-                        <textarea id="inputCode" class="textarea nanum-coding use-custom-scrollbar" rows="1" spellcheck="false" maxlength="990"></textarea>
-                    </div>
-                </div>
-
+<div
+  id="builder-container"
+  data-user-id="{{user.id}}"
+  data-bundle-id="{{bundleID}}"
+  data-item-id="{{itemID}}"
+  class="columns is-mobile is-centered mt-2 mb-3"
+>
+  <div class="column is-8 tile is-ancestor is-vertical">
+
+    <div class="tile">
+
+      <div class="tile is-parent is-vertical box is-marginless">
+
+        <div class="tile is-child">
+          <div class="has-text-centered is-marginless">
+            <p>Use this builder to create general items, storage, weapons,
+              armor, shields, or runes.</p>
+          </div>
+          <div class="field is-grouped is-grouped-centered">
+            <div class="control">
+              <div class="select">
+                <select id="inputBuilderType">
+                  <option value="GENERAL" selected>General Item</option>
+                  <option value="STORAGE">Storage Item</option>
+                  <option value="WEAPON">Weapon</option>
+                  <option value="ARMOR">Armor</option>
+                  <option value="SHIELD">Shield</option>
+                  <option value="RUNE">Runestone</option>
+                </select>
+              </div>
             </div>
+            <div id="sectionItemCopyOfOther" class="control is-hidden">
+              <div class="select">
+                <select id="inputItemCopyOfOther">
+                </select>
+              </div>
+            </div>
+          </div>
         </div>
+
+        <div class="tile is-child field">
+          <label class="label">Name</label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputName"
+              type="text"
+              placeholder="e.g. Adventurer's Pack"
+              autocomplete="off"
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child columns">
+
+          <div class="column field">
+            <label class="label">Price (in cp)</label>
+            <div class="control">
+              <input
+                id="inputPrice"
+                class="input"
+                type="number"
+                value="100"
+                min="0"
+              />
+            </div>
+          </div>
+
+          <div id="sectionBulk" class="column field">
+            <label class="label">Bulk</label>
+            <div class="control">
+              <input
+                id="inputBulk"
+                class="input"
+                type="number"
+                value="0.0"
+                step="0.1"
+                min="0"
+              />
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Level</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputLevel">
+                  <option value="0" selected>0</option>
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                  <option value="3">3</option>
+                  <option value="4">4</option>
+                  <option value="5">5</option>
+                  <option value="6">6</option>
+                  <option value="7">7</option>
+                  <option value="8">8</option>
+                  <option value="9">9</option>
+                  <option value="10">10</option>
+                  <option value="11">11</option>
+                  <option value="12">12</option>
+                  <option value="13">13</option>
+                  <option value="14">14</option>
+                  <option value="15">15</option>
+                  <option value="16">16</option>
+                  <option value="17">17</option>
+                  <option value="18">18</option>
+                  <option value="19">19</option>
+                  <option value="20">20</option>
+                  <option value="21">21</option>
+                  <option value="22">22</option>
+                  <option value="23">23</option>
+                  <option value="24">24</option>
+                  <option value="25">25</option>
+                  <option value="26">26</option>
+                  <option value="27">27</option>
+                  <option value="28">28</option>
+                  <option value="29">29</option>
+                  <option value="30">30</option>
+                  <option value="999">N/A</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        <div class="tile is-child columns">
+
+          <div class="column field">
+            <label class="label has-text-weight-normal"><strong
+                class="has-tooltip-top"
+                data-tooltip="Used to categorize the item in the item list"
+              >Category</strong></label>
+            <div class="control">
+              <div class="select">
+                <select id="inputCategory">
+                  <option value="ADJUSTMENT">Adjustment</option>
+                  <option value="ARTIFACT">Artifact</option>
+                  <option value="AMMUNITION">Ammunition</option>
+                  <option value="ARMOR">Armor</option>
+                  <option value="BELT">Belt</option>
+                  <option value="BOMB">Bomb</option>
+                  <option value="BOOK">Book</option>
+                  <option value="BOOTS">Boots</option>
+                  <option value="BRACERS">Bracers</option>
+                  <option value="CATALYST">Catalyst</option>
+                  <option value="CIRCLET">Circlet</option>
+                  <option value="CLOAK">Cloak</option>
+                  <option value="COMPANION">Companion</option>
+                  <option value="CURRENCY">Currency</option>
+                  <option value="DRUG">Drug</option>
+                  <option value="ELIXIR">Elixir</option>
+                  <option value="EYEPIECE">Eyepiece</option>
+                  <option value="FULU">Fulu</option>
+                  <option value="GADGET">Gadget</option>
+                  <option value="GIFT">Gift</option>
+                  <option value="GLOVES">Gloves</option>
+                  <option value="GRIMOIRE">Grimoire</option>
+                  <option value="HAT">Hat</option>
+                  <option value="INGREDIENT">Ingredient</option>
+                  <option value="INSTRUMENT">Instrument</option>
+                  <option value="KIT">Kit</option>
+                  <option value="MASK">Mask</option>
+                  <option value="NECKLACE">Necklace</option>
+                  <option value="OIL">Oil</option>
+                  <option value="POISON">Poison</option>
+                  <option value="POTION">Potion</option>
+                  <option value="RING">Ring</option>
+                  <option value="ROD">Rod</option>
+                  <option value="RUNE">Runestone</option>
+                  <option value="SCROLL">Scroll</option>
+                  <option value="SHIELD">Shield</option>
+                  <option value="SIEGE">Siege</option>
+                  <option value="SPELLHEART">Spellheart</option>
+                  <option value="STAFF">Staff</option>
+                  <option value="STORAGE">Storage</option>
+                  <option value="STRUCTURE">Structure</option>
+                  <option value="TALISMAN">Talisman</option>
+                  <option value="TATTOO">Tattoo</option>
+                  <option value="TOOL">Tool</option>
+                  <option value="WAND">Wand</option>
+                  <option value="WEAPON">Weapon</option>
+                  <option value="OTHER">Other</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Rarity</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputRarity">
+                  <option value="COMMON">Common</option>
+                  <option value="UNCOMMON">Uncommon</option>
+                  <option value="RARE">Rare</option>
+                  <option value="UNIQUE">Unique</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div id="sectionSize" class="column field">
+            <label class="label">Size</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputSize">
+                  <option value="TINY">Tiny</option>
+                  <option value="SMALL">Small</option>
+                  <option value="MEDIUM" selected>Medium</option>
+                  <option value="LARGE">Large</option>
+                  <option value="HUGE">Huge</option>
+                  <option value="GARGANTUAN">Gargantuan</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div id="sectionMaterial" class="column field">
+            <label class="label">Material</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputMaterial">
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div id="sectionHands" class="column field">
+            <label class="label">Hands</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputHands">
+                  <option value="NONE" selected>-</option>
+                  <option value="ONE">1</option>
+                  <option value="ONE_PLUS">1+</option>
+                  <option value="TWO">2</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        <div id="sectionWeapon" class="tile is-child columns">
+
+          <div class="column is-2 field">
+            <label class="label">Damage Die</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputDieType">
+                  <option value="">1</option>
+                  <option value="d2">d2</option>
+                  <option value="d4">d4</option>
+                  <option value="d6" selected>d6</option>
+                  <option value="d8">d8</option>
+                  <option value="d10">d10</option>
+                  <option value="d12">d12</option>
+                  <option value="d20">d20</option>
+                  <option value="NONE">-</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div class="column is-5 field">
+            <label class="label">Damage Type (most likely just: P, S, or B)</label>
+            <div class="control">
+              <input
+                class="input"
+                id="inputDamageType"
+                type="text"
+                maxlength="40"
+                placeholder=""
+              />
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Weapon Category</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputWeaponCategory">
+                  <option value="SIMPLE" selected>Simple</option>
+                  <option value="MARTIAL">Martial</option>
+                  <option value="ADVANCED">Advanced</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        <div id="sectionWeaponMelee" class="tile is-child columns">
+
+          <div class="column field pt-5 pl-5">
+            <label class="checkbox">
+              <input type="checkbox" id="inputIsMelee" value="1" />
+              <strong>Is Melee</strong>
+            </label>
+          </div>
+
+          <div class="column field">
+            <label class="label">Melee Weapon Group</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputMeleeWeaponType">
+                  <option value="AXE" selected>Axe</option>
+                  <option value="BRAWLING">Brawling</option>
+                  <option value="CLUB">Club</option>
+                  <option value="FLAIL">Flail</option>
+                  <option value="HAMMER">Hammer</option>
+                  <option value="KNIFE">Knife</option>
+                  <option value="PICK">Pick</option>
+                  <option value="POLEARM">Polearm</option>
+                  <option value="SHIELD">Shield</option>
+                  <option value="SPEAR">Spear</option>
+                  <option value="SWORD">Sword</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        <div id="sectionWeaponRanged" class="tile is-child columns">
+
+          <div class="column field pt-5 pl-5">
+            <label class="checkbox">
+              <input type="checkbox" id="inputIsRanged" value="1" />
+              <strong>Is Ranged</strong>
+            </label>
+          </div>
+
+          <div class="column field">
+            <label class="label">Ranged Weapon Group</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputRangedWeaponType">
+                  <option value="BOW" selected>Bow</option>
+                  <option value="CROSSBOW">Crossbow</option>
+                  <option value="DART">Dart</option>
+                  <option value="FIREARM">Firearm</option>
+                  <option value="SLING">Sling</option>
+                  <option value="BOMB">Bomb</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Range (in feet)</label>
+            <div class="control">
+              <input
+                id="inputRange"
+                class="input"
+                type="number"
+                value="20"
+                maxlength="4"
+              />
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Reload</label>
+            <div class="control">
+              <input
+                id="inputReload"
+                class="input"
+                type="number"
+                value="0"
+                maxlength="1"
+              />
+            </div>
+          </div>
+
+        </div>
+
+        <div id="sectionStorage" class="tile is-child columns">
+
+          <div class="column field">
+            <label class="label">Max Bulk Storage</label>
+            <div class="control">
+              <input
+                id="inputMaxBulkStorage"
+                class="input"
+                type="number"
+                value="0.0"
+                step="0.1"
+                min="0"
+              />
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Bulk Ignored</label>
+            <div class="control">
+              <input
+                id="inputBulkIgnored"
+                class="input"
+                type="number"
+                value="0.0"
+                step="0.1"
+                min="0"
+              />
+            </div>
+          </div>
+
+          <div class="column field pt-5">
+            <label class="checkbox">
+              <input
+                type="checkbox"
+                id="inputIgnoreSelfBulkIfWearing"
+                value="1"
+              />
+              <strong>Ignore Self-Bulk If Wearing</strong>
+            </label>
+          </div>
+
+        </div>
+
+        <div id="sectionShield" class="tile is-child columns">
+
+          <div class="column field">
+            <label class="label">AC Bonus</label>
+            <div class="control">
+              <input
+                id="inputShieldACBonus"
+                class="input"
+                type="number"
+                value="0"
+                maxlength="1"
+              />
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Speed Penalty</label>
+            <div class="control">
+              <input
+                id="inputShieldSpeedPenalty"
+                class="input"
+                type="number"
+                value="0"
+                step="5"
+                maxlength="2"
+              />
+            </div>
+          </div>
+
+        </div>
+
+        <div id="sectionRunestone" class="tile is-child columns">
+
+          <div class="column field">
+            <label class="label">Rune Type</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputRuneType">
+                  <option value="FUNDAMENTAL" selected>Fundamental</option>
+                  <option value="PROPERTY">Property</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">For</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputEtchedType">
+                  <option value="WEAPON" selected>Weapons</option>
+                  <option value="ARMOR">Armor</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        <div id="sectionArmor" class="tile is-child columns">
+
+          <div class="column field">
+            <label class="label">AC Bonus</label>
+            <div class="control">
+              <input
+                id="inputArmorACBonus"
+                class="input"
+                type="number"
+                value="0"
+                maxlength="1"
+              />
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Dex Cap</label>
+            <div class="control">
+              <input
+                id="inputArmorDexCap"
+                class="input"
+                type="number"
+                value="0"
+                maxlength="1"
+              />
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Armor Type</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputArmorType">
+                  <option value="CLOTH">Cloth</option>
+                  <option value="LEATHER" selected>Leather</option>
+                  <option value="COMPOSITE">Composite</option>
+                  <option value="CHAIN">Chain</option>
+                  <option value="PLATE">Plate</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Armor Category</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputArmorCategory">
+                  <option value="UNARMORED">Unarmored</option>
+                  <option value="LIGHT" selected>Light</option>
+                  <option value="MEDIUM">Medium</option>
+                  <option value="HEAVY">Heavy</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        <div id="sectionArmorPenalties" class="tile is-child columns">
+          <div class="column field">
+            <label class="label">Check Penalty</label>
+            <div class="control">
+              <input
+                id="inputArmorCheckPenalty"
+                class="input"
+                type="number"
+                value="0"
+                maxlength="1"
+              />
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Speed Penalty</label>
+            <div class="control">
+              <input
+                id="inputArmorSpeedPenalty"
+                class="input"
+                type="number"
+                value="0"
+                step="5"
+                maxlength="2"
+              />
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Min Strength</label>
+            <div class="control">
+              <input
+                id="inputArmorMinStrength"
+                class="input"
+                type="number"
+                value="10"
+                maxlength="2"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div class="tile is-child">
+          <label class="label">Traits</label>
+          <select id="inputTags" data-placeholder="Select Traits" multiple>
+            {{#each tags}}
+              <option value="{{id}}">{{name}}</option>
+            {{/each}}
+          </select>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Usage</label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputUsage"
+              type="text"
+              maxlength="110"
+              placeholder=""
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">
+            Description
+            <a href="/wsc_docs/#description_fields" target="_blank"><span
+                class="icon is-small has-text-info has-tooltip-top"
+                data-tooltip="WSC Docs"
+              ><i class="fas fa-book"></i></span></a>
+          </label>
+          <div class="control">
+            <textarea
+              class="textarea"
+              id="inputDesc"
+              placeholder="This item is the starter kit for an adventurer..."
+            ></textarea>
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">
+            Craft Requirements
+            <a href="/wsc_docs/#description_fields" target="_blank"><span
+                class="icon is-small has-text-info has-tooltip-top"
+                data-tooltip="WSC Docs"
+              ><i class="fas fa-book"></i></span></a>
+          </label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputCraftReq"
+              type="text"
+              maxlength="350"
+              placeholder=""
+            />
+          </div>
+        </div>
+
+        <div id="sectionIsShoddy" class="tile is-child field pt-1 pl-2">
+          <label class="checkbox">
+            <input type="checkbox" id="inputIsShoddy" value="1" />
+            <strong>Is Shoddy</strong>
+          </label>
+        </div>
+
+        <div id="sectionQuantity" class="tile is-child columns">
+          <div class="column field pt-5 is-grouped is-grouped-centered">
+            <label class="checkbox">
+              <input type="checkbox" id="inputHasQuantity" value="1" />
+              <strong>Has Quantity</strong>
+            </label>
+          </div>
+
+          <div class="column field">
+            <label class="label">Quantity</label>
+            <div class="control">
+              <input id="inputQuantity" class="input" type="number" value="1" />
+            </div>
+          </div>
+        </div>
+
+        <div id="sectionHealth" class="tile is-child columns">
+
+          <div class="column field">
+            <label class="label">
+              <a
+                href="/material_stats"
+                class="has-text-bold-color"
+                target="_blank"
+              >
+                <strong
+                  class="has-tooltip-top"
+                  data-tooltip="Link to Material Stats page"
+                >Hardness<sup class="icon is-small"><i
+                      class="fas fa-xs fa-external-link-alt"
+                    ></i></sup></strong>
+              </a>
+            </label>
+            <div class="control">
+              <input id="inputHardness" class="input" type="number" value="0" />
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">
+              <a
+                href="/material_stats"
+                class="has-text-bold-color"
+                target="_blank"
+              >
+                <strong
+                  class="has-tooltip-top"
+                  data-tooltip="Link to Material Stats page"
+                >Hit Points<sup class="icon is-small"><i
+                      class="fas fa-xs fa-external-link-alt"
+                    ></i></sup></strong>
+              </a>
+            </label>
+            <div class="control">
+              <input
+                id="inputHitPoints"
+                class="input"
+                type="number"
+                value="0"
+              />
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">
+              <a
+                href="/material_stats"
+                class="has-text-bold-color"
+                target="_blank"
+              >
+                <strong
+                  class="has-tooltip-top"
+                  data-tooltip="Link to Material Stats page"
+                >Broken Threshold<sup class="icon is-small"><i
+                      class="fas fa-xs fa-external-link-alt"
+                    ></i></sup></strong>
+              </a>
+            </label>
+            <div class="control">
+              <input
+                id="inputBrokenThreshold"
+                class="input"
+                type="number"
+                value="0"
+              />
+            </div>
+          </div>
+
+        </div>
+
+        <div class="tile is-child field pos-relative">
+          <label class="label">
+            Code
+            <a href="/wsc_docs/#code_basics" target="_blank"><span
+                class="icon is-small has-text-info has-tooltip-top"
+                data-tooltip="WSC Docs"
+              ><i class="fas fa-book"></i></span></a>
+            <span class="code-block-statement-display">Sheet Statements Only</span>
+          </label>
+          <div class="control">
+            <textarea
+              id="inputCode"
+              class="textarea nanum-coding use-custom-scrollbar"
+              rows="1"
+              spellcheck="false"
+              maxlength="990"
+            ></textarea>
+          </div>
+        </div>
+
+      </div>
     </div>
+  </div>
 </div>
 
 <div class="field is-grouped is-grouped-centered pb-2">
-    <div class="control">
-        {{#if itemID}}
-            <button id="updateButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{else}}
-            <button id="createButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{/if}}
-    </div>
+  <div class="control">
+    {{#if itemID}}
+      <button
+        id="updateButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{else}}
+      <button
+        id="createButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{/if}}
+  </div>
 </div>

--- a/views/homebrew/builder_language.handlebars
+++ b/views/homebrew/builder_language.handlebars
@@ -1,108 +1,162 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/homebrew-builders.css">
-    <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
-    <script type="text/javascript" src="/js/homebrew/builder/language/builder-language.js"></script>
-    {{#if languageID}}
-        <script type="text/javascript" src="/js/homebrew/builder/language/editor-language.js"></script>
-    {{/if}}
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/homebrew-builders.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
+  <script
+    type="text/javascript"
+    src="/js/homebrew/builder/language/builder-language.js"
+  ></script>
+  {{#if languageID}}
+    <script
+      type="text/javascript"
+      src="/js/homebrew/builder/language/editor-language.js"
+    ></script>
+  {{/if}}
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew" class="active">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/homebrew"
+      class="active"
+    >Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
+
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="pageloader">
-    <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+  <div class="lds-roller"><div></div><div></div><div></div><div></div><div
+    ></div><div></div><div></div><div></div></div>
 </div>
 
 <div class="pt-3">
-    <h1 class="title is-2 has-txt-value-number has-text-centered">Language Builder</h1>
+  <h1 class="title is-2 has-txt-value-number has-text-centered">Language Builder</h1>
 </div>
 
-<div id="builder-container" data-user-id="{{user.id}}" data-bundle-id="{{bundleID}}" data-language-id="{{languageID}}" class="columns is-mobile is-centered mt-2 mb-3">
-    <div class="column is-8 tile is-ancestor is-vertical">
+<div
+  id="builder-container"
+  data-user-id="{{user.id}}"
+  data-bundle-id="{{bundleID}}"
+  data-language-id="{{languageID}}"
+  class="columns is-mobile is-centered mt-2 mb-3"
+>
+  <div class="column is-8 tile is-ancestor is-vertical">
 
-        <div class="tile">
+    <div class="tile">
 
-            <div class="tile is-parent is-vertical box is-marginless">
+      <div class="tile is-parent is-vertical box is-marginless">
 
-                <div class="tile is-child field">
-                    <label class="label">Name</label>
-                    <div class="control">
-                        <input id="inputName" class="input" type="text" placeholder="e.g. Dwarven" autocomplete="off">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Speakers</label>
-                    <div class="control">
-                        <input id="inputSpeakers" class="input" type="text" autocomplete="off">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Script</label>
-                    <div class="control">
-                        <input id="inputScript" class="input" type="text" autocomplete="off">
-                    </div>
-                </div>
-
-            </div>
-
+        <div class="tile is-child field">
+          <label class="label">Name</label>
+          <div class="control">
+            <input
+              id="inputName"
+              class="input"
+              type="text"
+              placeholder="e.g. Dwarven"
+              autocomplete="off"
+            />
+          </div>
         </div>
 
-        <div class="tile">
-            <div class="tile is-parent is-vertical box mt-3">
-                <div class="tile is-child field">
-                    <label class="label">
-                        Description
-                        <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                    </label>
-                    <div class="control">
-                        <textarea id="inputDescription" class="textarea" placeholder="Dwarven is a clipped language of hard consonants and guttural pronunciation..."></textarea>
-                    </div>
-                </div>
-            </div>
+        <div class="tile is-child field">
+          <label class="label">Speakers</label>
+          <div class="control">
+            <input
+              id="inputSpeakers"
+              class="input"
+              type="text"
+              autocomplete="off"
+            />
+          </div>
         </div>
+
+        <div class="tile is-child field">
+          <label class="label">Script</label>
+          <div class="control">
+            <input
+              id="inputScript"
+              class="input"
+              type="text"
+              autocomplete="off"
+            />
+          </div>
+        </div>
+
+      </div>
 
     </div>
+
+    <div class="tile">
+      <div class="tile is-parent is-vertical box mt-3">
+        <div class="tile is-child field">
+          <label class="label">
+            Description
+            <a href="/wsc_docs/#description_fields" target="_blank"><span
+                class="icon is-small has-text-info has-tooltip-top"
+                data-tooltip="WSC Docs"
+              ><i class="fas fa-book"></i></span></a>
+          </label>
+          <div class="control">
+            <textarea
+              id="inputDescription"
+              class="textarea"
+              placeholder="Dwarven is a clipped language of hard consonants and guttural pronunciation..."
+            ></textarea>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
 </div>
 
 <div class="field is-grouped is-grouped-centered pb-2">
-    <div class="control">
-        {{#if languageID}}
-            <button id="updateButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{else}}
-            <button id="createButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{/if}}
-    </div>
+  <div class="control">
+    {{#if languageID}}
+      <button
+        id="updateButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{else}}
+      <button
+        id="createButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{/if}}
+  </div>
 </div>

--- a/views/homebrew/builder_spell.handlebars
+++ b/views/homebrew/builder_spell.handlebars
@@ -1,393 +1,500 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/homebrew-builders.css">
-    <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
-    <script type="text/javascript" src="/js/homebrew/builder/spell/builder-spell.js"></script>
-    {{#if spellID}}
-        <script type="text/javascript" src="/js/homebrew/builder/spell/editor-spell.js"></script>
-    {{/if}}
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/homebrew-builders.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
+  <script
+    type="text/javascript"
+    src="/js/homebrew/builder/spell/builder-spell.js"
+  ></script>
+  {{#if spellID}}
+    <script
+      type="text/javascript"
+      src="/js/homebrew/builder/spell/editor-spell.js"
+    ></script>
+  {{/if}}
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew" class="active">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/homebrew"
+      class="active"
+    >Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
+
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="pageloader">
-    <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+  <div class="lds-roller"><div></div><div></div><div></div><div></div><div
+    ></div><div></div><div></div><div></div></div>
 </div>
 
 <div class="pt-3">
-    <h1 class="title is-2 has-txt-value-number has-text-centered">Spell Builder</h1>
+  <h1 class="title is-2 has-txt-value-number has-text-centered">Spell Builder</h1>
 </div>
 
-<div id="builder-container" data-user-id="{{user.id}}" data-bundle-id="{{bundleID}}" data-spell-id="{{spellID}}" class="columns is-mobile is-centered mt-2 mb-3">
-    <div class="column is-8 tile is-ancestor is-vertical">
+<div
+  id="builder-container"
+  data-user-id="{{user.id}}"
+  data-bundle-id="{{bundleID}}"
+  data-spell-id="{{spellID}}"
+  class="columns is-mobile is-centered mt-2 mb-3"
+>
+  <div class="column is-8 tile is-ancestor is-vertical">
 
-        <div class="tile">
+    <div class="tile">
 
-            <div class="tile is-parent is-vertical box is-marginless">
+      <div class="tile is-parent is-vertical box is-marginless">
 
-                <div class="tile is-child field">
-                    <label class="label">Name</label>
-                    <div class="control">
-                        <input class="input" id="inputName" type="text" placeholder="e.g. Blur" autocomplete="off">
-                    </div>
-                </div>
-
-                <div class="tile is-child field pt-1 pl-2">
-                     <label class="checkbox">
-                        <input type="checkbox" id="inputIsFocusSpell" value="1">
-                        <strong>Focus Spell</strong>
-                    </label>
-                </div>
-
-                <div class="tile is-child">
-                    <label class="label">Traits</label>
-                    <select id="inputTags" data-placeholder="Select Traits" multiple>
-                        {{#each tags}}
-                            <option value="{{id}}">{{name}}</option>
-                        {{/each}}
-                    </select>
-                </div>
-
-                <div class="tile is-child columns">
-
-                    <div class="column field">
-                        <label class="label">Level</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputLevel">
-                                    <option value="0">Cantrip</option>
-                                    <option value="1">1</option>
-                                    <option value="2">2</option>
-                                    <option value="3">3</option>
-                                    <option value="4">4</option>
-                                    <option value="5">5</option>
-                                    <option value="6">6</option>
-                                    <option value="7">7</option>
-                                    <option value="8">8</option>
-                                    <option value="9">9</option>
-                                    <option value="10">10</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Rarity</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputRarity">
-                                    <option value="COMMON">Common</option>
-                                    <option value="UNCOMMON">Uncommon</option>
-                                    <option value="RARE">Rare</option>
-                                    <option value="UNIQUE">Unique</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Traditions</label>
-                        <div class="control">
-                            <div class="select is-multiple">
-                                <select id="inputTraditions" multiple size="4" class="use-invisible-scrollbar">
-                                    <option value="arcane">Arcane</option>
-                                    <option value="divine">Divine</option>
-                                    <option value="occult">Occult</option>
-                                    <option value="primal">Primal</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Cast</label>
-                        <div class="control">
-                            <div class="select">
-                                <select id="inputCasting" class="pf-icon">
-                                    <option value="ACTION">[one-action]</option>
-                                    <option value="TWO_ACTIONS">[two-actions]</option>
-                                    <option value="THREE_ACTIONS">[three-actions]</option>
-                                    <option value="FREE_ACTION">[free-action]</option>
-                                    <option value="REACTION">[reaction]</option>
-                                    <option value="ONE_TO_THREE_ACTIONS">[one-action] to [three-actions]</option>
-                                    <option value="ONE_TO_TWO_ACTIONS">[one-action] to [two-actions]</option>
-                                    <option value="TWO_TO_THREE_ACTIONS">[two-actions] to [three-actions]</option>
-                                    <option value="TWO_TO_TWO_ROUNDS">[two-actions] to 2 rounds</option>
-                                    <option value="TWO_TO_THREE_ROUNDS">[two-actions] to 3 rounds</option>
-                                    <option value="THREE_TO_TWO_ROUNDS">[three-actions] to 2 rounds</option>
-                                    <option value="THREE_TO_THREE_ROUNDS">[three-actions] to 3 rounds</option>
-                                    <option value="TWO_ROUNDS">2 rounds</option>
-                                    <option value="THREE_ROUNDS">3 rounds</option>
-                                    <option value="ONE_MINUTE">1 minute</option>
-                                    <option value="FIVE_MINUTES">5 minutes</option>
-                                    <option value="TEN_MINUTES">10 minutes</option>
-                                    <option value="THIRTY_MINUTES">30 minutes</option>
-                                    <option value="ONE_HOUR">1 hour</option>
-                                    <option value="EIGHT_HOURS">8 hours</option>
-                                    <option value="ONE_DAY">24 hours</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="column field">
-                        <label class="label">Components</label>
-                        <div class="control">
-                            <div class="select is-multiple">
-                                <select id="inputCastingComponents" multiple size="4" class="use-invisible-scrollbar">
-                                    <option value="material">Material</option>
-                                    <option value="somatic">Somatic</option>
-                                    <option value="verbal">Verbal</option>
-                                    <option value="focus">Focus</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                </div>
-
-                <div class="tile is-child columns">
-                    <div class="column field">
-                        <label class="label">Cost</label>
-                        <div class="control">
-                            <input class="input" id="inputCost" type="text" maxlength="290" placeholder="">
-                        </div>
-                    </div>
-                    <div class="column field">
-                        <label class="label">Trigger</label>
-                        <div class="control">
-                            <input class="input" id="inputTrigger" type="text" maxlength="290" placeholder="">
-                        </div>
-                    </div>
-                    <div class="column field">
-                        <label class="label">Requirements</label>
-                        <div class="control">
-                            <input class="input" id="inputRequirements" type="text" maxlength="290" placeholder="">
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Range</label>
-                    <div class="control">
-                        <input class="input" id="inputRange" type="text" maxlength="290" placeholder="">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Area</label>
-                    <div class="control">
-                        <input class="input" id="inputArea" type="text" maxlength="290" placeholder="">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Targets</label>
-                    <div class="control">
-                        <input class="input" id="inputTargets" type="text" maxlength="290" placeholder="">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Saving Throw</label>
-                    <div class="control">
-                        <div class="select">
-                            <select id="inputSavingThrow">
-                                <option value="">N/A</option>
-                                <option value="FORT">Fortitude</option>
-                                <option value="REFLEX">Reflex</option>
-                                <option value="WILL">Will</option>
-                                <option value="BASIC_FORT">Basic Fortitude</option>
-                                <option value="BASIC_REFLEX">Basic Reflex</option>
-                                <option value="BASIC_WILL">Basic Will</option>
-                            </select>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">Duration</label>
-                    <div class="control">
-                        <input class="input" id="inputDuration" type="text" maxlength="290" placeholder="">
-                    </div>
-                </div>
-
-                <div class="tile is-child field">
-                    <label class="label">
-                        Description
-                        <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                    </label>
-                    <div class="control">
-                        <textarea class="textarea" id="inputDesc" placeholder="The target’s form appears blurry..."></textarea>
-                    </div>
-                </div>
-
-                <div class="tile is-child columns">
-                    <div class="column is-2 field">
-                        <div class="control is-pulled-right">
-                            <div class="select">
-                                <select id="inputHeightenedOneVal">
-                                    <option value="">N/A</option>
-                                    <option value="PLUS_ONE">+1</option>
-                                    <option value="PLUS_TWO">+2</option>
-                                    <option value="PLUS_THREE">+3</option>
-                                    <option value="PLUS_FOUR">+4</option>
-                                    <option value="LEVEL_2">2nd</option>
-                                    <option value="LEVEL_3">3rd</option>
-                                    <option value="LEVEL_4">4th</option>
-                                    <option value="LEVEL_5">5th</option>
-                                    <option value="LEVEL_6">6th</option>
-                                    <option value="LEVEL_7">7th</option>
-                                    <option value="LEVEL_8">8th</option>
-                                    <option value="LEVEL_9">9th</option>
-                                    <option value="LEVEL_10">10th</option>
-                                    <option value="CUSTOM">Custom</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="column field">
-                        <label class="label">Heightened</label>
-                        <div class="control">
-                            <textarea id="inputHeightenedOneText" class="textarea"></textarea>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child columns">
-                    <div class="column is-2 field">
-                        <div class="control is-pulled-right">
-                            <div class="select">
-                                <select id="inputHeightenedTwoVal">
-                                    <option value="">N/A</option>
-                                    <option value="PLUS_ONE">+1</option>
-                                    <option value="PLUS_TWO">+2</option>
-                                    <option value="PLUS_THREE">+3</option>
-                                    <option value="PLUS_FOUR">+4</option>
-                                    <option value="LEVEL_2">2nd</option>
-                                    <option value="LEVEL_3">3rd</option>
-                                    <option value="LEVEL_4">4th</option>
-                                    <option value="LEVEL_5">5th</option>
-                                    <option value="LEVEL_6">6th</option>
-                                    <option value="LEVEL_7">7th</option>
-                                    <option value="LEVEL_8">8th</option>
-                                    <option value="LEVEL_9">9th</option>
-                                    <option value="LEVEL_10">10th</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="column field">
-                        <label class="label">Heightened</label>
-                        <div class="control">
-                            <textarea id="inputHeightenedTwoText" class="textarea"></textarea>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child columns">
-                    <div class="column is-2 field">
-                        <div class="control is-pulled-right">
-                            <div class="select">
-                                <select id="inputHeightenedThreeVal">
-                                    <option value="">N/A</option>
-                                    <option value="PLUS_ONE">+1</option>
-                                    <option value="PLUS_TWO">+2</option>
-                                    <option value="PLUS_THREE">+3</option>
-                                    <option value="PLUS_FOUR">+4</option>
-                                    <option value="LEVEL_2">2nd</option>
-                                    <option value="LEVEL_3">3rd</option>
-                                    <option value="LEVEL_4">4th</option>
-                                    <option value="LEVEL_5">5th</option>
-                                    <option value="LEVEL_6">6th</option>
-                                    <option value="LEVEL_7">7th</option>
-                                    <option value="LEVEL_8">8th</option>
-                                    <option value="LEVEL_9">9th</option>
-                                    <option value="LEVEL_10">10th</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="column field">
-                        <label class="label">Heightened</label>
-                        <div class="control">
-                            <textarea id="inputHeightenedThreeText" class="textarea"></textarea>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child columns">
-                    <div class="column is-2 field">
-                        <div class="control is-pulled-right">
-                            <div class="select">
-                                <select id="inputHeightenedFourVal">
-                                    <option value="">N/A</option>
-                                    <option value="PLUS_ONE">+1</option>
-                                    <option value="PLUS_TWO">+2</option>
-                                    <option value="PLUS_THREE">+3</option>
-                                    <option value="PLUS_FOUR">+4</option>
-                                    <option value="LEVEL_2">2nd</option>
-                                    <option value="LEVEL_3">3rd</option>
-                                    <option value="LEVEL_4">4th</option>
-                                    <option value="LEVEL_5">5th</option>
-                                    <option value="LEVEL_6">6th</option>
-                                    <option value="LEVEL_7">7th</option>
-                                    <option value="LEVEL_8">8th</option>
-                                    <option value="LEVEL_9">9th</option>
-                                    <option value="LEVEL_10">10th</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="column field">
-                        <label class="label">Heightened</label>
-                        <div class="control">
-                            <textarea id="inputHeightenedFourText" class="textarea"></textarea>
-                        </div>
-                    </div>
-                </div>
-
-            </div>
+        <div class="tile is-child field">
+          <label class="label">Name</label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputName"
+              type="text"
+              placeholder="e.g. Blur"
+              autocomplete="off"
+            />
+          </div>
         </div>
+
+        <div class="tile is-child field pt-1 pl-2">
+          <label class="checkbox">
+            <input type="checkbox" id="inputIsFocusSpell" value="1" />
+            <strong>Focus Spell</strong>
+          </label>
+        </div>
+
+        <div class="tile is-child">
+          <label class="label">Traits</label>
+          <select id="inputTags" data-placeholder="Select Traits" multiple>
+            {{#each tags}}
+              <option value="{{id}}">{{name}}</option>
+            {{/each}}
+          </select>
+        </div>
+
+        <div class="tile is-child columns">
+
+          <div class="column field">
+            <label class="label">Level</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputLevel">
+                  <option value="0">Cantrip</option>
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                  <option value="3">3</option>
+                  <option value="4">4</option>
+                  <option value="5">5</option>
+                  <option value="6">6</option>
+                  <option value="7">7</option>
+                  <option value="8">8</option>
+                  <option value="9">9</option>
+                  <option value="10">10</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Rarity</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputRarity">
+                  <option value="COMMON">Common</option>
+                  <option value="UNCOMMON">Uncommon</option>
+                  <option value="RARE">Rare</option>
+                  <option value="UNIQUE">Unique</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Traditions</label>
+            <div class="control">
+              <div class="select is-multiple">
+                <select
+                  id="inputTraditions"
+                  multiple
+                  size="4"
+                  class="use-invisible-scrollbar"
+                >
+                  <option value="arcane">Arcane</option>
+                  <option value="divine">Divine</option>
+                  <option value="occult">Occult</option>
+                  <option value="primal">Primal</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Cast</label>
+            <div class="control">
+              <div class="select">
+                <select id="inputCasting" class="pf-icon">
+                  <option value="ACTION">[one-action]</option>
+                  <option value="TWO_ACTIONS">[two-actions]</option>
+                  <option value="THREE_ACTIONS">[three-actions]</option>
+                  <option value="FREE_ACTION">[free-action]</option>
+                  <option value="REACTION">[reaction]</option>
+                  <option value="ONE_TO_THREE_ACTIONS">[one-action] to
+                    [three-actions]</option>
+                  <option value="ONE_TO_TWO_ACTIONS">[one-action] to
+                    [two-actions]</option>
+                  <option value="TWO_TO_THREE_ACTIONS">[two-actions] to
+                    [three-actions]</option>
+                  <option value="TWO_TO_TWO_ROUNDS">[two-actions] to 2 rounds</option>
+                  <option value="TWO_TO_THREE_ROUNDS">[two-actions] to 3 rounds</option>
+                  <option value="THREE_TO_TWO_ROUNDS">[three-actions] to 2
+                    rounds</option>
+                  <option value="THREE_TO_THREE_ROUNDS">[three-actions] to 3
+                    rounds</option>
+                  <option value="TWO_ROUNDS">2 rounds</option>
+                  <option value="THREE_ROUNDS">3 rounds</option>
+                  <option value="ONE_MINUTE">1 minute</option>
+                  <option value="FIVE_MINUTES">5 minutes</option>
+                  <option value="TEN_MINUTES">10 minutes</option>
+                  <option value="THIRTY_MINUTES">30 minutes</option>
+                  <option value="ONE_HOUR">1 hour</option>
+                  <option value="EIGHT_HOURS">8 hours</option>
+                  <option value="ONE_DAY">24 hours</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div class="column field">
+            <label class="label">Components</label>
+            <div class="control">
+              <div class="select is-multiple">
+                <select
+                  id="inputCastingComponents"
+                  multiple
+                  size="4"
+                  class="use-invisible-scrollbar"
+                >
+                  <option value="material">Material</option>
+                  <option value="somatic">Somatic</option>
+                  <option value="verbal">Verbal</option>
+                  <option value="focus">Focus</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        <div class="tile is-child columns">
+          <div class="column field">
+            <label class="label">Cost</label>
+            <div class="control">
+              <input
+                class="input"
+                id="inputCost"
+                type="text"
+                maxlength="290"
+                placeholder=""
+              />
+            </div>
+          </div>
+          <div class="column field">
+            <label class="label">Trigger</label>
+            <div class="control">
+              <input
+                class="input"
+                id="inputTrigger"
+                type="text"
+                maxlength="290"
+                placeholder=""
+              />
+            </div>
+          </div>
+          <div class="column field">
+            <label class="label">Requirements</label>
+            <div class="control">
+              <input
+                class="input"
+                id="inputRequirements"
+                type="text"
+                maxlength="290"
+                placeholder=""
+              />
+            </div>
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Range</label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputRange"
+              type="text"
+              maxlength="290"
+              placeholder=""
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Area</label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputArea"
+              type="text"
+              maxlength="290"
+              placeholder=""
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Targets</label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputTargets"
+              type="text"
+              maxlength="290"
+              placeholder=""
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Saving Throw</label>
+          <div class="control">
+            <div class="select">
+              <select id="inputSavingThrow">
+                <option value="">N/A</option>
+                <option value="FORT">Fortitude</option>
+                <option value="REFLEX">Reflex</option>
+                <option value="WILL">Will</option>
+                <option value="BASIC_FORT">Basic Fortitude</option>
+                <option value="BASIC_REFLEX">Basic Reflex</option>
+                <option value="BASIC_WILL">Basic Will</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">Duration</label>
+          <div class="control">
+            <input
+              class="input"
+              id="inputDuration"
+              type="text"
+              maxlength="290"
+              placeholder=""
+            />
+          </div>
+        </div>
+
+        <div class="tile is-child field">
+          <label class="label">
+            Description
+            <a href="/wsc_docs/#description_fields" target="_blank"><span
+                class="icon is-small has-text-info has-tooltip-top"
+                data-tooltip="WSC Docs"
+              ><i class="fas fa-book"></i></span></a>
+          </label>
+          <div class="control">
+            <textarea
+              class="textarea"
+              id="inputDesc"
+              placeholder="The target’s form appears blurry..."
+            ></textarea>
+          </div>
+        </div>
+
+        <div class="tile is-child columns">
+          <div class="column is-2 field">
+            <div class="control is-pulled-right">
+              <div class="select">
+                <select id="inputHeightenedOneVal">
+                  <option value="">N/A</option>
+                  <option value="PLUS_ONE">+1</option>
+                  <option value="PLUS_TWO">+2</option>
+                  <option value="PLUS_THREE">+3</option>
+                  <option value="PLUS_FOUR">+4</option>
+                  <option value="LEVEL_2">2nd</option>
+                  <option value="LEVEL_3">3rd</option>
+                  <option value="LEVEL_4">4th</option>
+                  <option value="LEVEL_5">5th</option>
+                  <option value="LEVEL_6">6th</option>
+                  <option value="LEVEL_7">7th</option>
+                  <option value="LEVEL_8">8th</option>
+                  <option value="LEVEL_9">9th</option>
+                  <option value="LEVEL_10">10th</option>
+                  <option value="CUSTOM">Custom</option>
+                </select>
+              </div>
+            </div>
+          </div>
+          <div class="column field">
+            <label class="label">Heightened</label>
+            <div class="control">
+              <textarea id="inputHeightenedOneText" class="textarea"></textarea>
+            </div>
+          </div>
+        </div>
+
+        <div class="tile is-child columns">
+          <div class="column is-2 field">
+            <div class="control is-pulled-right">
+              <div class="select">
+                <select id="inputHeightenedTwoVal">
+                  <option value="">N/A</option>
+                  <option value="PLUS_ONE">+1</option>
+                  <option value="PLUS_TWO">+2</option>
+                  <option value="PLUS_THREE">+3</option>
+                  <option value="PLUS_FOUR">+4</option>
+                  <option value="LEVEL_2">2nd</option>
+                  <option value="LEVEL_3">3rd</option>
+                  <option value="LEVEL_4">4th</option>
+                  <option value="LEVEL_5">5th</option>
+                  <option value="LEVEL_6">6th</option>
+                  <option value="LEVEL_7">7th</option>
+                  <option value="LEVEL_8">8th</option>
+                  <option value="LEVEL_9">9th</option>
+                  <option value="LEVEL_10">10th</option>
+                </select>
+              </div>
+            </div>
+          </div>
+          <div class="column field">
+            <label class="label">Heightened</label>
+            <div class="control">
+              <textarea id="inputHeightenedTwoText" class="textarea"></textarea>
+            </div>
+          </div>
+        </div>
+
+        <div class="tile is-child columns">
+          <div class="column is-2 field">
+            <div class="control is-pulled-right">
+              <div class="select">
+                <select id="inputHeightenedThreeVal">
+                  <option value="">N/A</option>
+                  <option value="PLUS_ONE">+1</option>
+                  <option value="PLUS_TWO">+2</option>
+                  <option value="PLUS_THREE">+3</option>
+                  <option value="PLUS_FOUR">+4</option>
+                  <option value="LEVEL_2">2nd</option>
+                  <option value="LEVEL_3">3rd</option>
+                  <option value="LEVEL_4">4th</option>
+                  <option value="LEVEL_5">5th</option>
+                  <option value="LEVEL_6">6th</option>
+                  <option value="LEVEL_7">7th</option>
+                  <option value="LEVEL_8">8th</option>
+                  <option value="LEVEL_9">9th</option>
+                  <option value="LEVEL_10">10th</option>
+                </select>
+              </div>
+            </div>
+          </div>
+          <div class="column field">
+            <label class="label">Heightened</label>
+            <div class="control">
+              <textarea
+                id="inputHeightenedThreeText"
+                class="textarea"
+              ></textarea>
+            </div>
+          </div>
+        </div>
+
+        <div class="tile is-child columns">
+          <div class="column is-2 field">
+            <div class="control is-pulled-right">
+              <div class="select">
+                <select id="inputHeightenedFourVal">
+                  <option value="">N/A</option>
+                  <option value="PLUS_ONE">+1</option>
+                  <option value="PLUS_TWO">+2</option>
+                  <option value="PLUS_THREE">+3</option>
+                  <option value="PLUS_FOUR">+4</option>
+                  <option value="LEVEL_2">2nd</option>
+                  <option value="LEVEL_3">3rd</option>
+                  <option value="LEVEL_4">4th</option>
+                  <option value="LEVEL_5">5th</option>
+                  <option value="LEVEL_6">6th</option>
+                  <option value="LEVEL_7">7th</option>
+                  <option value="LEVEL_8">8th</option>
+                  <option value="LEVEL_9">9th</option>
+                  <option value="LEVEL_10">10th</option>
+                </select>
+              </div>
+            </div>
+          </div>
+          <div class="column field">
+            <label class="label">Heightened</label>
+            <div class="control">
+              <textarea
+                id="inputHeightenedFourText"
+                class="textarea"
+              ></textarea>
+            </div>
+          </div>
+        </div>
+
+      </div>
     </div>
+  </div>
 </div>
 
 <div class="field is-grouped is-grouped-centered pb-2">
-    <div class="control">
-        {{#if spellID}}
-            <button id="updateButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{else}}
-            <button id="createButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{/if}}
-    </div>
+  <div class="control">
+    {{#if spellID}}
+      <button
+        id="updateButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{else}}
+      <button
+        id="createButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{/if}}
+  </div>
 </div>

--- a/views/homebrew/builder_toggleable.handlebars
+++ b/views/homebrew/builder_toggleable.handlebars
@@ -1,105 +1,161 @@
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/homebrew-builders.css" />
 
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/homebrew-builders.css">
-    <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
-    <script type="text/javascript" src="/js/homebrew/builder/toggleable/builder-toggleable.js"></script>
-    {{#if toggleableID}}
-        <script type="text/javascript" src="/js/homebrew/builder/toggleable/editor-toggleable.js"></script>
-    {{/if}}
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
+  <script
+    type="text/javascript"
+    src="/js/homebrew/builder/toggleable/builder-toggleable.js"
+  ></script>
+  {{#if toggleableID}}
+    <script
+      type="text/javascript"
+      src="/js/homebrew/builder/toggleable/editor-toggleable.js"
+    ></script>
+  {{/if}}
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew" class="active">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/homebrew"
+      class="active"
+    >Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
+
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="pageloader">
-    <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+  <div class="lds-roller"><div></div><div></div><div></div><div></div><div
+    ></div><div></div><div></div><div></div></div>
 </div>
 
 <div class="pt-3">
-    <h1 class="title is-2 has-txt-value-number has-text-centered">Toggleable Builder</h1>
+  <h1 class="title is-2 has-txt-value-number has-text-centered">Toggleable
+    Builder</h1>
 </div>
 
-<div id="builder-container" data-user-id="{{user.id}}" data-bundle-id="{{bundleID}}" data-toggleable-id="{{toggleableID}}" class="columns is-mobile is-centered mt-2 mb-3">
-    <div class="column is-8 tile is-ancestor is-vertical">
+<div
+  id="builder-container"
+  data-user-id="{{user.id}}"
+  data-bundle-id="{{bundleID}}"
+  data-toggleable-id="{{toggleableID}}"
+  class="columns is-mobile is-centered mt-2 mb-3"
+>
+  <div class="column is-8 tile is-ancestor is-vertical">
 
-        <div class="tile">
+    <div class="tile">
 
-            <div class="tile is-parent is-vertical box is-marginless">
+      <div class="tile is-parent is-vertical box is-marginless">
 
-                <div class="tile is-child field">
-                    <label class="label">Name</label>
-                    <div class="control">
-                        <input id="inputName" class="input" type="text" placeholder="e.g. Panache" autocomplete="off">
-                    </div>
-                </div>
-
-            </div>
-
+        <div class="tile is-child field">
+          <label class="label">Name</label>
+          <div class="control">
+            <input
+              id="inputName"
+              class="input"
+              type="text"
+              placeholder="e.g. Panache"
+              autocomplete="off"
+            />
+          </div>
         </div>
 
-        <div class="tile">
-            <div class="tile is-parent is-vertical box mt-3">
-                <div class="tile is-child field">
-                    <label class="label">
-                        Description
-                        <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                    </label>
-                    <div class="control">
-                        <textarea id="inputDescription" class="textarea use-custom-scrollbar" placeholder="While you have panache..." rows="8"></textarea>
-                    </div>
-                </div>
-
-                <div class="tile is-child field pos-relative">
-                    <label class="label">
-                        Code
-                        <a href="/wsc_docs/#code_basics" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                        <span class="code-block-statement-display">Sheet Statements Only</span>
-                    </label>
-                    <div class="control">
-                        <textarea id="inputCode" class="textarea nanum-coding use-custom-scrollbar" rows="10" spellcheck="false" maxlength="9950"></textarea>
-                    </div>
-                </div>
-            </div>
-        </div>
+      </div>
 
     </div>
+
+    <div class="tile">
+      <div class="tile is-parent is-vertical box mt-3">
+        <div class="tile is-child field">
+          <label class="label">
+            Description
+            <a href="/wsc_docs/#description_fields" target="_blank"><span
+                class="icon is-small has-text-info has-tooltip-top"
+                data-tooltip="WSC Docs"
+              ><i class="fas fa-book"></i></span></a>
+          </label>
+          <div class="control">
+            <textarea
+              id="inputDescription"
+              class="textarea use-custom-scrollbar"
+              placeholder="While you have panache..."
+              rows="8"
+            ></textarea>
+          </div>
+        </div>
+
+        <div class="tile is-child field pos-relative">
+          <label class="label">
+            Code
+            <a href="/wsc_docs/#code_basics" target="_blank"><span
+                class="icon is-small has-text-info has-tooltip-top"
+                data-tooltip="WSC Docs"
+              ><i class="fas fa-book"></i></span></a>
+            <span class="code-block-statement-display">Sheet Statements Only</span>
+          </label>
+          <div class="control">
+            <textarea
+              id="inputCode"
+              class="textarea nanum-coding use-custom-scrollbar"
+              rows="10"
+              spellcheck="false"
+              maxlength="9950"
+            ></textarea>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
 </div>
 
 <div class="field is-grouped is-grouped-centered pb-2">
-    <div class="control">
-        {{#if toggleableID}}
-            <button id="updateButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{else}}
-            <button id="createButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{/if}}
-    </div>
+  <div class="control">
+    {{#if toggleableID}}
+      <button
+        id="updateButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{else}}
+      <button
+        id="createButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{/if}}
+  </div>
 </div>

--- a/views/homebrew/builder_trait.handlebars
+++ b/views/homebrew/builder_trait.handlebars
@@ -1,94 +1,138 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/homebrew-builders.css">
-    <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
-    <script type="text/javascript" src="/js/homebrew/builder/trait/builder-trait.js"></script>
-    {{#if traitID}}
-        <script type="text/javascript" src="/js/homebrew/builder/trait/editor-trait.js"></script>
-    {{/if}}
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/homebrew-builders.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
+  <script
+    type="text/javascript"
+    src="/js/homebrew/builder/trait/builder-trait.js"
+  ></script>
+  {{#if traitID}}
+    <script
+      type="text/javascript"
+      src="/js/homebrew/builder/trait/editor-trait.js"
+    ></script>
+  {{/if}}
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew" class="active">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/homebrew"
+      class="active"
+    >Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
+
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="pageloader">
-    <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+  <div class="lds-roller"><div></div><div></div><div></div><div></div><div
+    ></div><div></div><div></div><div></div></div>
 </div>
 
 <div class="pt-3">
-    <h1 class="title is-2 has-txt-value-number has-text-centered">Trait Builder</h1>
+  <h1 class="title is-2 has-txt-value-number has-text-centered">Trait Builder</h1>
 </div>
 
-<div id="builder-container" data-user-id="{{user.id}}" data-bundle-id="{{bundleID}}" data-trait-id="{{traitID}}" class="columns is-mobile is-centered mt-2 mb-3">
-    <div class="column is-8 tile is-ancestor is-vertical">
+<div
+  id="builder-container"
+  data-user-id="{{user.id}}"
+  data-bundle-id="{{bundleID}}"
+  data-trait-id="{{traitID}}"
+  class="columns is-mobile is-centered mt-2 mb-3"
+>
+  <div class="column is-8 tile is-ancestor is-vertical">
 
-        <div class="tile">
+    <div class="tile">
 
-            <div class="tile is-parent is-vertical box is-marginless">
+      <div class="tile is-parent is-vertical box is-marginless">
 
-                <div class="tile is-child field">
-                    <label class="label">Name</label>
-                    <div class="control">
-                        <input id="inputName" class="input" type="text" placeholder="e.g. Magical" autocomplete="off">
-                    </div>
-                </div>
-
-            </div>
-
+        <div class="tile is-child field">
+          <label class="label">Name</label>
+          <div class="control">
+            <input
+              id="inputName"
+              class="input"
+              type="text"
+              placeholder="e.g. Magical"
+              autocomplete="off"
+            />
+          </div>
         </div>
 
-        <div class="tile">
-            <div class="tile is-parent is-vertical box mt-3">
-                <div class="tile is-child field">
-                    <label class="label">
-                        Description
-                        <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                    </label>
-                    <div class="control">
-                        <textarea id="inputDescription" class="textarea" placeholder="Content with this trait..."></textarea>
-                    </div>
-                </div>
-            </div>
-        </div>
+      </div>
 
     </div>
+
+    <div class="tile">
+      <div class="tile is-parent is-vertical box mt-3">
+        <div class="tile is-child field">
+          <label class="label">
+            Description
+            <a href="/wsc_docs/#description_fields" target="_blank"><span
+                class="icon is-small has-text-info has-tooltip-top"
+                data-tooltip="WSC Docs"
+              ><i class="fas fa-book"></i></span></a>
+          </label>
+          <div class="control">
+            <textarea
+              id="inputDescription"
+              class="textarea"
+              placeholder="Content with this trait..."
+            ></textarea>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
 </div>
 
 <div class="field is-grouped is-grouped-centered pb-2">
-    <div class="control">
-        {{#if traitID}}
-            <button id="updateButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{else}}
-            <button id="createButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{/if}}
-    </div>
+  <div class="control">
+    {{#if traitID}}
+      <button
+        id="updateButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{else}}
+      <button
+        id="createButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{/if}}
+  </div>
 </div>

--- a/views/homebrew/builder_uni-heritage.handlebars
+++ b/views/homebrew/builder_uni-heritage.handlebars
@@ -1,288 +1,405 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/homebrew-builders.css">
-    <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
-    <script type="text/javascript" src="/js/homebrew/builder/uni-heritage/builder-uni-heritage.js"></script>
-    {{#if uniHeritageID}}
-        <script type="text/javascript" src="/js/homebrew/builder/uni-heritage/editor-uni-heritage.js"></script>
-    {{/if}}
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/homebrew-builders.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script type="text/javascript" src="/js/confirm-page-leave.js"></script>
+  <script
+    type="text/javascript"
+    src="/js/homebrew/builder/uni-heritage/builder-uni-heritage.js"
+  ></script>
+  {{#if uniHeritageID}}
+    <script
+      type="text/javascript"
+      src="/js/homebrew/builder/uni-heritage/editor-uni-heritage.js"
+    ></script>
+  {{/if}}
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew" class="active">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/homebrew"
+      class="active"
+    >Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
+
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="pageloader">
-    <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+  <div class="lds-roller"><div></div><div></div><div></div><div></div><div
+    ></div><div></div><div></div><div></div></div>
 </div>
 
 <div class="pt-3">
-    <h1 class="title is-2 has-txt-value-number has-text-centered">Versatile Heritage Builder</h1>
+  <h1 class="title is-2 has-txt-value-number has-text-centered">Versatile
+    Heritage Builder</h1>
 </div>
 
-<div id="builder-container" data-user-id="{{user.id}}" data-bundle-id="{{bundleID}}" data-uni-heritage-id="{{uniHeritageID}}" class="columns is-mobile is-centered mt-2 mb-3">
-    <div class="column is-8 tile is-ancestor is-vertical">
+<div
+  id="builder-container"
+  data-user-id="{{user.id}}"
+  data-bundle-id="{{bundleID}}"
+  data-uni-heritage-id="{{uniHeritageID}}"
+  class="columns is-mobile is-centered mt-2 mb-3"
+>
+  <div class="column is-8 tile is-ancestor is-vertical">
 
-        <div class="tile">
+    <div class="tile">
 
-            <div class="tile is-parent is-vertical box is-6 is-marginless mr-2">
+      <div class="tile is-parent is-vertical box is-6 is-marginless mr-2">
 
-                <div class="tile is-child field">
-                    <label class="label">Name</label>
-                    <div class="control">
-                        <input id="inputName" class="input" type="text" placeholder="e.g. Gnome" autocomplete="off">
-                    </div>
-                </div>
+        <div class="tile is-child field">
+          <label class="label">Name</label>
+          <div class="control">
+            <input
+              id="inputName"
+              class="input"
+              type="text"
+              placeholder="e.g. Gnome"
+              autocomplete="off"
+            />
+          </div>
+        </div>
 
-                <div class="tile is-child field">
-                    <label class="label">Rarity</label>
-                    <div class="control">
-                        <div class="select">
-                            <select id="inputRarity">
-                                <option value="COMMON">Common</option>
-                                <option value="UNCOMMON">Uncommon</option>
-                                <option value="RARE">Rare</option>
-                                <option value="UNIQUE">Unique</option>
-                            </select>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tile is-child field is-marginless">
-                    <div class="control">
-                        <input id="inputImageURL" class="input isURL" type="text" maxlength="200" placeholder="Image URL" spellcheck="false" autocomplete="off">
-                    </div>
-                </div>
-
+        <div class="tile is-child field">
+          <label class="label">Rarity</label>
+          <div class="control">
+            <div class="select">
+              <select id="inputRarity">
+                <option value="COMMON">Common</option>
+                <option value="UNCOMMON">Uncommon</option>
+                <option value="RARE">Rare</option>
+                <option value="UNIQUE">Unique</option>
+              </select>
             </div>
+          </div>
+        </div>
 
-            <div class="tile is-parent is-vertical box is-6 is-marginless ml-2">
+        <div class="tile is-child field is-marginless">
+          <div class="control">
+            <input
+              id="inputImageURL"
+              class="input isURL"
+              type="text"
+              maxlength="200"
+              placeholder="Image URL"
+              spellcheck="false"
+              autocomplete="off"
+            />
+          </div>
+        </div>
 
-                <div class="tile is-vertical">
+      </div>
 
-                    <div class="tile is-child field">
-                        <label class="label">
-                            Description
-                            <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                        </label>
-                        <div class="control">
-                            <textarea id="inputDescription" class="textarea" placeholder="Always hungry for new experiences..."></textarea>
-                        </div>
-                    </div>
+      <div class="tile is-parent is-vertical box is-6 is-marginless ml-2">
 
-                    <div class="tile is-child field pos-relative">
-                        <label class="label">
-                            Code
-                            <a href="/wsc_docs/#code_basics" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                            <span class="code-block-statement-display">Builder & Sheet Statements</span>
-                        </label>
-                        <div class="control">
-                            <textarea id="inputCode" class="textarea nanum-coding use-custom-scrollbar" rows="4" spellcheck="false" maxlength="990"></textarea>
-                        </div>
-                    </div>
-                    
-                </div>
+        <div class="tile is-vertical">
 
+          <div class="tile is-child field">
+            <label class="label">
+              Description
+              <a href="/wsc_docs/#description_fields" target="_blank"><span
+                  class="icon is-small has-text-info has-tooltip-top"
+                  data-tooltip="WSC Docs"
+                ><i class="fas fa-book"></i></span></a>
+            </label>
+            <div class="control">
+              <textarea
+                id="inputDescription"
+                class="textarea"
+                placeholder="Always hungry for new experiences..."
+              ></textarea>
             </div>
+          </div>
+
+          <div class="tile is-child field pos-relative">
+            <label class="label">
+              Code
+              <a href="/wsc_docs/#code_basics" target="_blank"><span
+                  class="icon is-small has-text-info has-tooltip-top"
+                  data-tooltip="WSC Docs"
+                ><i class="fas fa-book"></i></span></a>
+              <span class="code-block-statement-display">Builder & Sheet
+                Statements</span>
+            </label>
+            <div class="control">
+              <textarea
+                id="inputCode"
+                class="textarea nanum-coding use-custom-scrollbar"
+                rows="4"
+                spellcheck="false"
+                maxlength="990"
+              ></textarea>
+            </div>
+          </div>
 
         </div>
 
-        <div class="tile is-vertical box ml-3 mt-3">
-
-                <div class="tile is-child">
-                    <button id="addFeatButton" class="button is-link">Add Heritage Feat</button>
-                </div>
-
-                <div id="featContent" class="tile is-child">
-
-                    <div id="featLayout" class="card mb-2 heritageFeat is-hidden">
-                        <div class="card-header cursor-clickable">
-                            <p class="card-header-title is-paddingless has-txt-value-number is-size-5">Heritage Feat</p>
-                            <a class="card-header-icon is-paddingless mt-1 delete is-medium"></a>
-                        </div>
-                        <div class="card-content">
-                            <div class="field">
-                                <label class="label">Name</label>
-                                <div class="control">
-                                    <input class="input inputFeatName" type="text" placeholder="e.g. Grim Insight">
-                                </div>
-                            </div>
-
-                            <div class="columns">
-                                <div class="column field">
-                                    <label class="label">Level</label>
-                                    <div class="control">
-                                        <div class="select">
-                                            <select class="inputFeatLevel">
-                                                <option value="-1">Unselectable</option>
-                                                <option value="1" selected>1</option>
-                                                <option value="5">5</option>
-                                                <option value="9">9</option>
-                                                <option value="13">13</option>
-                                                <option value="17">17</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div class="column field">
-                                    <label class="label">Actions</label>
-                                    <div class="control">
-                                        <div class="select">
-                                            <select class="inputFeatActions pf-icon">
-                                                <option value="NONE">None</option>
-                                                <option value="ACTION">[one-action]</option>
-                                                <option value="TWO_ACTIONS">[two-actions]</option>
-                                                <option value="THREE_ACTIONS">[three-actions]</option>
-                                                <option value="FREE_ACTION">[free-action]</option>
-                                                <option value="REACTION">[reaction]</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div class="column field">
-                                    <label class="label">Rarity</label>
-                                    <div class="control">
-                                        <div class="select">
-                                            <select class="inputFeatRarity">
-                                                <option value="COMMON">Common</option>
-                                                <option value="UNCOMMON">Uncommon</option>
-                                                <option value="RARE">Rare</option>
-                                                <option value="UNIQUE">Unique</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="">
-                                <label class="label">Other Traits</label>
-                                <select class="inputFeatTags" data-placeholder="Select Traits" multiple>
-                                  {{#each tags}}
-                                    <option value="{{id}}">{{name}}</option>
-                                  {{/each}}
-                                </select>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Prerequisites</label>
-                                <div class="control">
-                                    <input class="input inputFeatPrereq" type="text" maxlength="290" placeholder="e.g. umbral gnome heritage">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Requirements</label>
-                                <div class="control">
-                                    <input class="input inputFeatReq" type="text" maxlength="590">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Frequency</label>
-                                <div class="control">
-                                    <input class="input inputFeatFreq" type="text" maxlength="290">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Cost</label>
-                                <div class="control">
-                                    <input class="input inputFeatCost" type="text" maxlength="290">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">Trigger</label>
-                                <div class="control">
-                                    <input class="input inputFeatTrigger" type="text" maxlength="290">
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">
-                                    Description
-                                    <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                </label>
-                                <div class="control">
-                                    <textarea class="textarea inputFeatDesc" placeholder="Others’ attempts to scare you often grant you insights..."></textarea>
-                                </div>
-                            </div>
-
-                            <div class="field">
-                                <label class="label">
-                                  Special
-                                  <a href="/wsc_docs/#description_fields" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                </label>
-                                <div class="control">
-                                    <input class="input inputFeatSpecial" type="text" maxlength="590">
-                                </div>
-                            </div>
-
-                            <div class="field pt-1">
-                                <label class="checkbox">
-                                    <input type="checkbox" class="inputFeatSelectMultiple" value="1">
-                                    <strong>Can Choose Multiple Times</strong>
-                                </label>
-                            </div>
-
-                            <div class="field pos-relative">
-                                <label class="label">
-                                    Code
-                                    <a href="/wsc_docs/#code_basics" target="_blank"><span class="icon is-small has-text-info has-tooltip-top" data-tooltip="WSC Docs"><i class="fas fa-book"></i></span></a>
-                                    <span class="code-block-statement-display">Builder & Sheet Statements</span>
-                                </label>
-                                <div class="control">
-                                    <textarea class="textarea inputFeatCode nanum-coding use-custom-scrollbar" rows="1" spellcheck="false" maxlength="4990"></textarea>
-                                </div>
-                            </div>
-
-                        </div>
-                    </div>
-                    
-
-                </div>
-
-        </div>
+      </div>
 
     </div>
+
+    <div class="tile is-vertical box ml-3 mt-3">
+
+      <div class="tile is-child">
+        <button id="addFeatButton" class="button is-link">Add Heritage Feat</button>
+      </div>
+
+      <div id="featContent" class="tile is-child">
+
+        <div id="featLayout" class="card mb-2 heritageFeat is-hidden">
+          <div class="card-header cursor-clickable">
+            <p
+              class="card-header-title is-paddingless has-txt-value-number is-size-5"
+            >Heritage Feat</p>
+            <a
+              class="card-header-icon is-paddingless mt-1 delete is-medium"
+            ></a>
+          </div>
+          <div class="card-content">
+            <div class="field">
+              <label class="label">Name</label>
+              <div class="control">
+                <input
+                  class="input inputFeatName"
+                  type="text"
+                  placeholder="e.g. Grim Insight"
+                />
+              </div>
+            </div>
+
+            <div class="columns">
+              <div class="column field">
+                <label class="label">Level</label>
+                <div class="control">
+                  <div class="select">
+                    <select class="inputFeatLevel">
+                      <option value="-1">Unselectable</option>
+                      <option value="1" selected>1</option>
+                      <option value="5">5</option>
+                      <option value="9">9</option>
+                      <option value="13">13</option>
+                      <option value="17">17</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+
+              <div class="column field">
+                <label class="label">Actions</label>
+                <div class="control">
+                  <div class="select">
+                    <select class="inputFeatActions pf-icon">
+                      <option value="NONE">None</option>
+                      <option value="ACTION">[one-action]</option>
+                      <option value="TWO_ACTIONS">[two-actions]</option>
+                      <option value="THREE_ACTIONS">[three-actions]</option>
+                      <option value="FREE_ACTION">[free-action]</option>
+                      <option value="REACTION">[reaction]</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+
+              <div class="column field">
+                <label class="label">Rarity</label>
+                <div class="control">
+                  <div class="select">
+                    <select class="inputFeatRarity">
+                      <option value="COMMON">Common</option>
+                      <option value="UNCOMMON">Uncommon</option>
+                      <option value="RARE">Rare</option>
+                      <option value="UNIQUE">Unique</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="">
+              <label class="label">Other Traits</label>
+              <select
+                class="inputFeatTags"
+                data-placeholder="Select Traits"
+                multiple
+              >
+                {{#each tags}}
+                  <option value="{{id}}">{{name}}</option>
+                {{/each}}
+              </select>
+            </div>
+
+            <div class="field">
+              <label class="label">Prerequisites</label>
+              <div class="control">
+                <input
+                  class="input inputFeatPrereq"
+                  type="text"
+                  maxlength="290"
+                  placeholder="e.g. umbral gnome heritage"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">Requirements</label>
+              <div class="control">
+                <input class="input inputFeatReq" type="text" maxlength="590" />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">Frequency</label>
+              <div class="control">
+                <input
+                  class="input inputFeatFreq"
+                  type="text"
+                  maxlength="290"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">Cost</label>
+              <div class="control">
+                <input
+                  class="input inputFeatCost"
+                  type="text"
+                  maxlength="290"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">Trigger</label>
+              <div class="control">
+                <input
+                  class="input inputFeatTrigger"
+                  type="text"
+                  maxlength="290"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">
+                Description
+                <a href="/wsc_docs/#description_fields" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+              </label>
+              <div class="control">
+                <textarea
+                  class="textarea inputFeatDesc"
+                  placeholder="Others’ attempts to scare you often grant you insights..."
+                ></textarea>
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label">
+                Special
+                <a href="/wsc_docs/#description_fields" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+              </label>
+              <div class="control">
+                <input
+                  class="input inputFeatSpecial"
+                  type="text"
+                  maxlength="590"
+                />
+              </div>
+            </div>
+
+            <div class="field pt-1">
+              <label class="checkbox">
+                <input
+                  type="checkbox"
+                  class="inputFeatSelectMultiple"
+                  value="1"
+                />
+                <strong>Can Choose Multiple Times</strong>
+              </label>
+            </div>
+
+            <div class="field pos-relative">
+              <label class="label">
+                Code
+                <a href="/wsc_docs/#code_basics" target="_blank"><span
+                    class="icon is-small has-text-info has-tooltip-top"
+                    data-tooltip="WSC Docs"
+                  ><i class="fas fa-book"></i></span></a>
+                <span class="code-block-statement-display">Builder & Sheet
+                  Statements</span>
+              </label>
+              <div class="control">
+                <textarea
+                  class="textarea inputFeatCode nanum-coding use-custom-scrollbar"
+                  rows="1"
+                  spellcheck="false"
+                  maxlength="4990"
+                ></textarea>
+              </div>
+            </div>
+
+          </div>
+        </div>
+
+      </div>
+
+    </div>
+
+  </div>
 </div>
 
 <div class="field is-grouped is-grouped-centered pb-2">
-    <div class="control">
-        {{#if uniHeritageID}}
-            <button id="updateButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{else}}
-            <button id="createButton" onClick="canLeavePage()" class="button is-rounded is-success">Save</button>
-        {{/if}}
-    </div>
+  <div class="control">
+    {{#if uniHeritageID}}
+      <button
+        id="updateButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{else}}
+      <button
+        id="createButton"
+        onClick="canLeavePage()"
+        class="button is-rounded is-success"
+      >Save</button>
+    {{/if}}
+  </div>
 </div>

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -231,6 +231,8 @@
       rel="stylesheet"
     />
 
+    {{{_sections.styles}}}
+
   </head>
 
   <body>

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -1,251 +1,443 @@
-<!DOCTYPE html>
 <!--
 	Copyright (C) 2021, Wanderer's Guide, all rights reserved.
     By Aaron Cassar.
 -->
 <html lang="en-US">
 
-<head>
-	<title>{{title}}</title>
-	<meta charset="UTF-8">
-	
-  <link rel="shortcut icon" href="/images/favicon.svg">
-  <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon.svg">
-  <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon.svg">
-  <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon.svg">
+  <head>
+    <title>{{title}}</title>
+    <meta charset="UTF-8" />
 
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <link rel="shortcut icon" href="/images/favicon.svg" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon.svg" />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/images/favicon.svg"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/images/favicon.svg"
+    />
 
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
-  <meta name="HandheldFriendly" content="True">
-  <meta name="MobileOptimized" content="320">
-  <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-  <meta property="og:title" content="Wanderer's Guide" />
-  <meta property="og:url" content="https://wanderersguide.app/" />
-  <meta data-n-head="ssr" data-hid="og:image" name="og:image" property="og:image" content="/images/favicon.svg">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="upgrade-insecure-requests"
+    />
+    <meta name="HandheldFriendly" content="True" />
+    <meta name="MobileOptimized" content="320" />
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no"
+    />
 
-  <meta name="apple-mobile-web-app-title" content="Wanderer's Guide">
-  <meta name="application-name" content="Wanderer's Guide">
-  <meta name="theme-color" content="#000000">
-  <meta name="author" content="Quzzar">
+    <meta property="og:title" content="Wanderer's Guide" />
+    <meta property="og:url" content="https://wanderersguide.app/" />
+    <meta
+      data-n-head="ssr"
+      data-hid="og:image"
+      name="og:image"
+      property="og:image"
+      content="/images/favicon.svg"
+    />
 
-  <link rel="manifest" href="/manifest.json">
+    <meta name="apple-mobile-web-app-title" content="Wanderer's Guide" />
+    <meta name="application-name" content="Wanderer's Guide" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="author" content="Quzzar" />
 
-  <link rel="canonical" href="https://wanderersguide.app/">
-  <link rel="shortcut icon" href="/images/favicon.svg">
-  <link data-n-head="ssr" data-hid="apple-touch-icon" rel="apple-touch-icon" href="/images/favicon.svg" sizes="180x180">
-  <link rel="icon" type="image/png" href="/images/favicon.svg" sizes="32x32">
-  <link rel="icon" type="image/png" href="/images/favicon.svg" sizes="16x16">
-  <meta property="og:image" content="/images/favicon.svg">
-  <link rel="mask-icon" href="/images/favicon.svg" color="#000000">
+    <link rel="manifest" href="/manifest.json" />
 
-  <!-- OGP -->
-  <meta property="og:site_name" content="Wanderer's Guide">
-  <meta property="og:locale" content="en_US">
-  <meta property="og:url" content="https://wanderersguide.app/">
-  <meta property="og:title" content="Wanderer's Guide">
-  <meta property="og:description" content="Semi-automated character manager for Pathfinder 2e">
-  <meta property="og:type" content="website">
-  <meta property="og:image:width" content="600">
-  <meta property="og:image:height" content="400">
+    <link rel="canonical" href="https://wanderersguide.app/" />
+    <link rel="shortcut icon" href="/images/favicon.svg" />
+    <link
+      data-n-head="ssr"
+      data-hid="apple-touch-icon"
+      rel="apple-touch-icon"
+      href="/images/favicon.svg"
+      sizes="180x180"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      href="/images/favicon.svg"
+      sizes="32x32"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      href="/images/favicon.svg"
+      sizes="16x16"
+    />
+    <meta property="og:image" content="/images/favicon.svg" />
+    <link rel="mask-icon" href="/images/favicon.svg" color="#000000" />
 
-  <!-- Keywords -->
-	<meta name="keywords" content="wanderer's guide,wanderers guide,wanderers,wanderer's,guide,pathfinder second edition,pathfinder 2e,character manager,character builder,pf2e,pf 2e" />
+    <!-- OGP -->
+    <meta property="og:site_name" content="Wanderer's Guide" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:url" content="https://wanderersguide.app/" />
+    <meta property="og:title" content="Wanderer's Guide" />
+    <meta
+      property="og:description"
+      content="Semi-automated character manager for Pathfinder 2e"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:image:width" content="600" />
+    <meta property="og:image:height" content="400" />
 
-	<!-- Bulma -->
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
-	<link rel="stylesheet" href="/css/bulma/bulma-steps.min.css">
-	<script src="/js/bulma/bulma-steps.min.js"></script>
-	<link rel="stylesheet" href="/css/bulma/bulma-tooltip.min.css">
-	<link rel="stylesheet" href="/css/bulma/bulma-accordion.min.css">
-	<script src="/js/bulma/bulma-accordion.min.js"></script>
-	<link rel="stylesheet" href="/css/bulma/bulma-divider.min.css">
-	<link rel="stylesheet" href="/css/bulma/bulma-quickview.min.css">
-	<script src="/js/bulma/bulma-quickview.min.js"></script>
-	<link rel="stylesheet" href="/css/bulma/bulma-checkradio.min.css">
-	<link rel="stylesheet" href="/css/bulma/bulma-badge.min.css">
-	<link rel="stylesheet" href="/css/bulma/bulma-switch.min.css">
-	<link rel="stylesheet" href="/css/bulma/bulma-radio-checkbox.min.css">
-	<link rel="stylesheet" href="/css/bulma/bulma-tagsinput.min.css">
-	<script src="/js/bulma/bulma-tagsinput.min.js"></script>
+    <!-- Keywords -->
+    <meta
+      name="keywords"
+      content="wanderer's guide,wanderers guide,wanderers,wanderer's,guide,pathfinder second edition,pathfinder 2e,character manager,character builder,pf2e,pf 2e"
+    />
 
-	<!-- Bootstrap-Core -->
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous">
-	<link rel="stylesheet" href="/css/bootstrap-4-utilities.min.css">
-	
-	<!-- Font-Awesome-Icons -->
-  <script defer src="https://pro.fontawesome.com/releases/v5.12.1/js/all.js"></script>
+    <!-- Bulma -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css"
+    />
+    <link rel="stylesheet" href="/css/bulma/bulma-steps.min.css" />
+    <script src="/js/bulma/bulma-steps.min.js"></script>
+    <link rel="stylesheet" href="/css/bulma/bulma-tooltip.min.css" />
+    <link rel="stylesheet" href="/css/bulma/bulma-accordion.min.css" />
+    <script src="/js/bulma/bulma-accordion.min.js"></script>
+    <link rel="stylesheet" href="/css/bulma/bulma-divider.min.css" />
+    <link rel="stylesheet" href="/css/bulma/bulma-quickview.min.css" />
+    <script src="/js/bulma/bulma-quickview.min.js"></script>
+    <link rel="stylesheet" href="/css/bulma/bulma-checkradio.min.css" />
+    <link rel="stylesheet" href="/css/bulma/bulma-badge.min.css" />
+    <link rel="stylesheet" href="/css/bulma/bulma-switch.min.css" />
+    <link rel="stylesheet" href="/css/bulma/bulma-radio-checkbox.min.css" />
+    <link rel="stylesheet" href="/css/bulma/bulma-tagsinput.min.css" />
+    <script src="/js/bulma/bulma-tagsinput.min.js"></script>
 
-	<!-- General Styles -->
-  {{#ifEqual user.enabledLightMode 1}}
-    <link rel="stylesheet" href="/css/core/site-themes-light.css" type="text/css" media="all" />
-  {{else}}
-    <link rel="stylesheet" href="/css/core/site-themes-dark.css" type="text/css" media="all" />
-  {{/ifEqual}}
+    <!-- Bootstrap-Core -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css"
+      integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N"
+      crossorigin="anonymous"
+    />
+    <link rel="stylesheet" href="/css/bootstrap-4-utilities.min.css" />
 
-	<link rel="stylesheet" href="/css/core/system-styles.css" type="text/css" media="all" />
-	<link rel="stylesheet" href="/css/pageloader.css" type="text/css" media="all" />
-  <link rel="stylesheet" href="/css/chosen/chosen.css" type="text/css" media="all" />
+    <!-- General Styles -->
+    {{#ifEqual user.enabledLightMode 1}}
+      <link
+        rel="stylesheet"
+        href="/css/core/site-themes-light.css"
+        type="text/css"
+        media="all"
+      />
+    {{else}}
+      <link
+        rel="stylesheet"
+        href="/css/core/site-themes-dark.css"
+        type="text/css"
+        media="all"
+      />
+    {{/ifEqual}}
 
-	<link rel="stylesheet" href="/css/core/bulma-extension.css" type="text/css" media="all" />
-	<link rel="stylesheet" href="/css/core/fonts.css" type="text/css" media="all" />
-	<link rel="stylesheet" href="/css/core/modals.css" type="text/css" media="all" />
-	<link rel="stylesheet" href="/css/core/quickviews.css" type="text/css" media="all" />
+    <link
+      rel="stylesheet"
+      href="/css/core/system-styles.css"
+      type="text/css"
+      media="all"
+    />
+    <link
+      rel="stylesheet"
+      href="/css/pageloader.css"
+      type="text/css"
+      media="all"
+    />
+    <link
+      rel="stylesheet"
+      href="/css/chosen/chosen.css"
+      type="text/css"
+      media="all"
+    />
 
-	<!-- General Utils -->
-	<script type="text/javascript" src="/js/general-utils.js"></script>
-  <script type="text/javascript" src="/js/cache-storing.js"></script>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/9.3.0/math.js"></script>
+    <link
+      rel="stylesheet"
+      href="/css/core/bulma-extension.css"
+      type="text/css"
+      media="all"
+    />
+    <link
+      rel="stylesheet"
+      href="/css/core/fonts.css"
+      type="text/css"
+      media="all"
+    />
+    <link
+      rel="stylesheet"
+      href="/css/core/modals.css"
+      type="text/css"
+      media="all"
+    />
+    <link
+      rel="stylesheet"
+      href="/css/core/quickviews.css"
+      type="text/css"
+      media="all"
+    />
 
-  <!-- Loading Bars/Spinners -->
-  <link rel="stylesheet" href="/css/loading-bar.css">
-  <script src="/js/loading_bar/loadingHandler.js"></script>
-  <script src="/js/loading_bar/loading-bar.js"></script>
+    <!-- Loading Bars/Spinners -->
+    <link rel="stylesheet" href="/css/loading-bar.css" />
 
-  <!-- Quill JS -->
-  <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
-  <link href="/css/quill.css" rel="stylesheet">
-  <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
+    <!-- Quill JS -->
+    <link
+      href="https://cdn.quilljs.com/1.3.6/quill.snow.css"
+      rel="stylesheet"
+    />
+    <link href="/css/quill.css" rel="stylesheet" />
 
-	<!-- Web-Fonts -->
-	<link rel="preconnect" href="https://fonts.googleapis.com">
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <!-- Web-Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 
-	<link href="https://fonts.googleapis.com/css?family=Nunito+Sans:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i&amp;subset=latin-ext,vietnamese"
-	 rel="stylesheet">
-	<link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:300,300i,400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese"
-	 rel="stylesheet">
-	 <link href="https://fonts.googleapis.com/css?family=Noto+Sans&display=swap" rel="stylesheet">
-	 <link href="https://fonts.googleapis.com/css?family=Bebas+Neue&display=swap" rel="stylesheet">
-	 <link href="https://fonts.googleapis.com/css2?family=Nanum+Gothic+Coding&display=swap" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css?family=Nunito+Sans:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i&amp;subset=latin-ext,vietnamese"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css?family=Roboto+Condensed:300,300i,400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css?family=Noto+Sans&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css?family=Bebas+Neue&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Nanum+Gothic+Coding&display=swap"
+      rel="stylesheet"
+    />
 
-   <link href="https://fonts.googleapis.com/css2?family=Proza+Libre&display=swap" rel="stylesheet">
-   <link href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Proza+Libre&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap"
+      rel="stylesheet"
+    />
 
-	<!-- Socket IO -->
-  <script src="/socket.io/socket.io.js"></script>
+  </head>
 
-  <!-- jQuery -->
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.0/jquery.min.js"></script>
-	<script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
-	<script src="/js/jQuery/jquery.ui.touch-punch.min.js"></script>
-  <script src="/js/jQuery/chosen.jquery.min.js"></script>
+  <body>
 
-	<!-- Mobile View Message -->
-	<script type="text/javascript" src="/js/mobile-view.js"></script>
+    <div id="main-container">
 
-  <!-- Misc Scripts -->
-	<script type="text/javascript" src="/js/back-to-top.js"></script>
-  <script type="text/javascript" src="/js/show-more.js"></script>
+      <div id="main-top">
+        <header>
+          <div class="container-fluid pl-0">
+            <div
+              class="header d-md-flex justify-content-between align-items-center pt-1 pl-1 pr-5"
+            >
+              <div>
+                <a href="/"><img
+                    src="/images/logo.png"
+                    style="height:50px;"
+                    alt="Wanderer's Guide"
+                  /></a>
+                <sup
+                  class="is-inline has-txt-value-number is-size-6-5 font-bebas-neue text-overflow-none is-hidden-mobile"
+                >Beta 1.9.3</sup>
+              </div>
 
-	{{{_sections.header}}}
+              <div>
+                <nav>
 
-</head>
+                  <a class="icon is-medium nav-menu-toggle">
+                    <i class="fa fa-2x fa-bars"></i>
+                  </a>
+                  <div id="mobile-nav-menu-container"></div>
 
-<body>
+                  <ul class="nav-menu pt-1">
+                    {{{_sections.nav_home}}}
 
-	<div id="main-container">
+                    {{#if user}}
+                      {{{_sections.nav_characters}}}
+                    {{else}}
+                      <span class="ml-lg-4 ml-md-3"></span>
+                    {{/if}}
 
-		<div id="main-top">
-			<header>
-				<div class="container-fluid pl-0">
-					<div class="header d-md-flex justify-content-between align-items-center pt-1 pl-1 pr-5">
-						<div>
-							<a href="/"><img src="/images/logo.png" style="height:50px;" alt="Wanderer's Guide"></a>
-							<sup class="is-inline has-txt-value-number is-size-6-5 font-bebas-neue text-overflow-none is-hidden-mobile">Beta 1.9.3</sup>
-						</div>
+                    {{{_sections.nav_builds}}}
 
-						<div>
-							<nav>
+                    {{{_sections.nav_homebrew}}}
 
-                <a class="icon is-medium nav-menu-toggle">
-                  <i class="fa fa-2x fa-bars"></i>
-                </a>
-                <div id="mobile-nav-menu-container"></div>
+                    {{{_sections.nav_gm_tools}}}
 
-				<ul class="nav-menu pt-1">
-				  {{{_sections.nav_home}}}
+                    {{{_sections.nav_browse}}}
 
-				  {{#if user}}
-					{{{_sections.nav_characters}}}
-                  {{else}}
-					<span class="ml-lg-4 ml-md-3"></span>
-				  {{/if}}
+                    {{#if user}}
+                      <li class="mr-4">
+                        <a href="#" id="nav-profile-picture">
+                          <object
+                            class="profile-header-icon"
+                            data="{{user.thumbnail}}"
+                            type="image/png"
+                          >
+                            <img
+                              class="profile-header-icon"
+                              src="/images/fb_profile_pic.png"
+                              alt="Profile Image"
+                            />
+                          </object>
+                        </a>
+                        <ul>
+                          <li><a href="/profile" class="drop-text"><i
+                                class="fas fa-user-circle"
+                              ></i>
+                              Account
+                            </a></li>
+                          {{#ifEqual user.isAdmin 1}}
+                            <li><a href="/admin/panel" class="drop-text"><i
+                                  class="fas fa-tools"
+                                ></i>
+                                Admin Panel
+                              </a></li>
+                          {{/ifEqual}}
+                          <li><a
+                              href="https://discord.gg/kxCpa6G"
+                              target="_blank"
+                              class="drop-text"
+                            ><i class="fab fa-discord"></i>
+                              Discord<sup class="icon is-small"><i
+                                  class="fas fa-xs fa-external-link-alt"
+                                ></i></sup></a></li>
+                          <li><a
+                              href="https://www.patreon.com/wanderersguide"
+                              target="_blank"
+                              class="drop-text"
+                            ><i class="fab fa-patreon"></i>
+                              Patreon<sup class="icon is-small"><i
+                                  class="fas fa-xs fa-external-link-alt"
+                                ></i></sup></a></li>
+                          <li><a href="/api_docs" class="drop-text"><i
+                                class="fas fa-cog"
+                              ></i>
+                              API Docs
+                            </a></li>
+                          <li><a href="/license" class="drop-text"><i
+                                class="fas fa-scroll"
+                              ></i>
+                              License
+                            </a></li>
+                          <li><a href="/auth/logout" class="drop-text"><i
+                                class="fas fa-sign-out-alt"
+                              ></i>
+                              Logout
+                            </a></li>
+                        </ul>
+                      </li>
+                    {{else}}
+                      {{{_sections.nav_login}}}
+                    {{/if}}
+                  </ul>
+                </nav>
+              </div>
+            </div>
+          </div>
+        </header>
 
-                  {{{_sections.nav_builds}}}
+        {{{_sections.banner_nav}}}
 
-                  {{{_sections.nav_homebrew}}}
+      </div>
 
-                  {{{_sections.nav_gm_tools}}}
+      <div class="top-border"></div>
 
-				  {{{_sections.nav_browse}}}
-									
-									{{#if user}}
-										<li class="mr-4">
-											<a href="#" id="nav-profile-picture">
-												<object class="profile-header-icon" data="{{user.thumbnail}}" type="image/png">
-													<img class="profile-header-icon" src="/images/fb_profile_pic.png" alt="Profile Image">
-												</object>
-											</a>
-											<ul>
-												<li><a href="/profile" class="drop-text"><i class="fas fa-user-circle"></i> Account </a></li>
-												{{#ifEqual user.isAdmin 1}}
-													<li><a href="/admin/panel" class="drop-text"><i class="fas fa-tools"></i> Admin Panel </a></li>
-												{{/ifEqual}}
-                        <li><a href="https://discord.gg/kxCpa6G" target="_blank" class="drop-text"><i class="fab fa-discord"></i> Discord<sup class="icon is-small"><i class="fas fa-xs fa-external-link-alt"></i></sup></a></li>
-												<li><a href="https://www.patreon.com/wanderersguide" target="_blank" class="drop-text"><i class="fab fa-patreon"></i> Patreon<sup class="icon is-small"><i class="fas fa-xs fa-external-link-alt"></i></sup></a></li>
-                        <li><a href="/api_docs" class="drop-text"><i class="fas fa-cog"></i> API Docs </a></li>
-												<li><a href="/license" class="drop-text"><i class="fas fa-scroll"></i> License </a></li>
-												<li><a href="/auth/logout" class="drop-text"><i class="fas fa-sign-out-alt"></i> Logout </a></li>
-											</ul>
-										</li>
-									{{else}}
-										{{{_sections.nav_login}}}
-									{{/if}}
-								</ul>
-							</nav>
-						</div>
-					</div>
-				</div>
-			</header>
+      <div id="center-body">
+        {{{body}}}
+      </div>
 
-			{{{_sections.banner_nav}}}
-			
-		</div>
+      {{{_sections.overlay}}}
 
-		<div class="top-border"></div>
-    
-		<div id="center-body">
-			{{{body}}}
-		</div>
+      <!-- Pre-Load Fonts -->
+      <div class="font_preload" style="opacity: 0">
+        <span class="pf-icon"></span>
+      </div>
 
-		{{{_sections.overlay}}}
+      <footer id="wanderers-guide-footer">
+        <div class="cpy-right text-center py-3">
+          <p class="text-center is-size-7">
+            Wanderer's Guide<sup class="icon is-small"><i
+                class="fas fa-xs fa-trademark"
+              ></i></sup>
+            <span class="has-txt-faded"> | </span>
+            <a href="/license" target="_blank">Licenses and Policies</a>
+            <span class="has-txt-faded"> | </span>
+            <a
+              class="has-tooltip-top"
+              data-tooltip="wanderersguide2e@gmail.com"
+            ><sub class="icon is-small"><i
+                  class="far fa-lg fa-envelope"
+                ></i></sub></a>
+            <span class="has-txt-faded"> | </span>
+            <a href="https://discord.gg/kxCpa6G" target="_blank"><sub
+                class="icon is-small"
+              ><i class="fab fa-lg fa-discord"></i></sub></a>
+            <span class="has-txt-faded"> | </span>
+            <a
+              href="https://www.patreon.com/wanderersguide"
+              target="_blank"
+            ><sub class="icon is-small"><i
+                  class="fab fa-lg fa-patreon"
+                ></i></sub></a>
+          </p>
+        </div>
+      </footer>
 
-		<!-- Pre-Load Fonts -->
-		<div class="font_preload" style="opacity: 0">
-			<span class="pf-icon"></span>
-		</div>
-		
-		<footer id="wanderers-guide-footer">
-			<div class="cpy-right text-center py-3">
-				<p class="text-center is-size-7">
-					Wanderer's Guide<sup class="icon is-small"><i class="fas fa-xs fa-trademark"></i></sup>
-					<span class="has-txt-faded"> | </span>
-					<a href="/license" target="_blank">Licenses and Policies</a>
-					<span class="has-txt-faded"> | </span>
-					<a class="has-tooltip-top" data-tooltip="wanderersguide2e@gmail.com"><sub class="icon is-small"><i class="far fa-lg fa-envelope"></i></sub></a>
-					<span class="has-txt-faded"> | </span>
-					<a href="https://discord.gg/kxCpa6G" target="_blank"><sub class="icon is-small"><i class="fab fa-lg fa-discord"></i></sub></a>
-					<span class="has-txt-faded"> | </span>
-					<a href="https://www.patreon.com/wanderersguide" target="_blank"><sub class="icon is-small"><i class="fab fa-lg fa-patreon"></i></sub></a>
-				</p>
-			</div>
-		</footer>
+    </div>
 
-	</div>
+    <!-- jQuery -->
+    <script
+      src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.0/jquery.min.js"
+    ></script>
+    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
 
-</body>
+    <!-- General Utils -->
+    <script type="text/javascript" src="/js/general-utils.js"></script>
+    <script type="text/javascript" src="/js/cache-storing.js"></script>
 
+    <script src="/js/jQuery/jquery.ui.touch-punch.min.js"></script>
+    <script src="/js/jQuery/chosen.jquery.min.js"></script>
+
+    <script src="/js/loading_bar/loadingHandler.js"></script>
+    <script src="/js/loading_bar/loading-bar.js"></script>
+    <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
+
+    <!-- Font-Awesome-Icons -->
+    <script
+      defer
+      src="https://pro.fontawesome.com/releases/v5.12.1/js/all.js"
+    ></script>
+
+    <script
+      type="text/javascript"
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/9.3.0/math.js"
+    ></script>
+
+    <!-- Mobile View Message -->
+    <script type="text/javascript" src="/js/mobile-view.js"></script>
+
+    <!-- Misc Scripts -->
+    <script type="text/javascript" src="/js/back-to-top.js"></script>
+    <script type="text/javascript" src="/js/show-more.js"></script>
+
+    <!-- Socket IO -->
+    <script src="/socket.io/socket.io.js"></script>
+
+    {{{_sections.header}}}
+
+  </body>
 </html>

--- a/views/pages/api_request_access.handlebars
+++ b/views/pages/api_request_access.handlebars
@@ -1,52 +1,73 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/api-request-access.css">
-    <script src="/js/api/api-request-access.js"></script>
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/api-request-access.css" />
 {{/section}}
 
-<div id="access-container" class="container text-center" data-char-id="{{charID}}" data-client-id="{{clientID}}" data-access-rights="{{apiClient.accessRights}}" data-state="{{state}}">
+{{#section "header"}}
+  <script src="/js/api/api-request-access.js"></script>
+{{/section}}
 
-    {{#if apiClient.iconURL}}
-      <figure class="image is-64x64 app-icon">
-        <img src="{{apiClient.iconURL}}">
-      </figure>
-    {{else}}
-      <figure class="image is-64x64 app-icon">
-        <img src="https://wanderersguide.app/images/favicon.svg">
-      </figure>
-		{{/if}}
+<div
+  id="access-container"
+  class="container text-center"
+  data-char-id="{{charID}}"
+  data-client-id="{{clientID}}"
+  data-access-rights="{{apiClient.accessRights}}"
+  data-state="{{state}}"
+>
 
-    <div>
-      <p class="is-size-6"><span class="is-bold lighter-text">{{apiClient.appName}}</span> would like access to...</p>
-      <span style="position: relative;"><span class="is-size-5 lighter-text is-thin">{{charName}}</span><sup class="is-size-8 is-italic has-txt-noted pl-1" style="position: absolute; top: 1px;">#{{charID}}</sup></span>
+  {{#if apiClient.iconURL}}
+    <figure class="image is-64x64 app-icon">
+      <img src="{{apiClient.iconURL}}" />
+    </figure>
+  {{else}}
+    <figure class="image is-64x64 app-icon">
+      <img src="https://wanderersguide.app/images/favicon.svg" />
+    </figure>
+  {{/if}}
+
+  <div>
+    <p class="is-size-6"><span
+        class="is-bold lighter-text"
+      >{{apiClient.appName}}</span>
+      would like access to...</p>
+    <span style="position: relative;"><span
+        class="is-size-5 lighter-text is-thin"
+      >{{charName}}</span><sup
+        class="is-size-8 is-italic has-txt-noted pl-1"
+        style="position: absolute; top: 1px;"
+      >#{{charID}}</sup></span>
+  </div>
+
+  <div class="mt-4 mb-2">
+    <p>They would be given permission to:</p>
+    {{#ifEqual apiClient.accessRights "READ-ONLY"}}
+      <p class="is-size-6-5 lighter-text is-bold">&#x2022; Read Information</p>
+    {{/ifEqual}}
+    {{#ifEqual apiClient.accessRights "READ-UPDATE"}}
+      <p class="is-size-6-5 lighter-text is-bold">&#x2022; Read and Update
+        Information</p>
+    {{/ifEqual}}
+    {{#ifEqual apiClient.accessRights "READ-UPDATE-ADD-DELETE"}}
+      <p class="is-size-6-5 lighter-text is-bold">&#x2022; Read, Update, Add,
+        and Delete Information</p>
+    {{/ifEqual}}
+  </div>
+
+  <div class="">
+    <a id="character-access-btn" class="button is-info is-rounded"><span
+        class="has-txt-value-string"
+      >Allow Access</span></a>
+  </div>
+
+  {{#if apiClient.description}}
+    <hr class="hr-light m-3" />
+    <div class="px-4">
+      <p class="text-left is-bold lighter-text">{{apiClient.appName}}</p>
+      <p class="text-left is-size-6-5">{{apiClient.description}}</p>
+      {{#if apiClient.companyName}}
+        <p class="text-left is-size-7 is-thin">By {{apiClient.companyName}}</p>
+      {{/if}}
     </div>
-
-    <div class="mt-4 mb-2">
-      <p>They would be given permission to:</p>
-      {{#ifEqual apiClient.accessRights 'READ-ONLY'}}
-        <p class="is-size-6-5 lighter-text is-bold">&#x2022; Read Information</p>
-      {{/ifEqual}}
-      {{#ifEqual apiClient.accessRights 'READ-UPDATE'}}
-        <p class="is-size-6-5 lighter-text is-bold">&#x2022; Read and Update Information</p>
-      {{/ifEqual}}
-      {{#ifEqual apiClient.accessRights 'READ-UPDATE-ADD-DELETE'}}
-        <p class="is-size-6-5 lighter-text is-bold">&#x2022; Read, Update, Add, and Delete Information</p>
-      {{/ifEqual}}
-    </div>
-
-    <div class="">
-      <a id="character-access-btn" class="button is-info is-rounded"><span class="has-txt-value-string">Allow Access</span></a>
-    </div>
-
-    {{#if apiClient.description}}
-      <hr class="hr-light m-3">
-      <div class="px-4">
-        <p class="text-left is-bold lighter-text">{{apiClient.appName}}</p>
-        <p class="text-left is-size-6-5">{{apiClient.description}}</p>
-        {{#if apiClient.companyName}}
-          <p class="text-left is-size-7 is-thin">By {{apiClient.companyName}}</p>
-        {{/if}}
-      </div>
-    {{/if}}
+  {{/if}}
 
 </div>

--- a/views/pages/browse.handlebars
+++ b/views/pages/browse.handlebars
@@ -1,78 +1,84 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/browse.css">
-    <script src="/js/browse/general-browse.js"></script>
-    <script src="/js/browse/query-params.js"></script>
-    <script src="/js/browse/browse-utils.js"></script>
-
-    <script src="/js/libraries/display_class/display-class.js"></script>
-    <script src="/js/libraries/display_ancestry/display-ancestry.js"></script>
-    <script src="/js/libraries/display_archetype/display-archetype.js"></script>
-    <script src="/js/libraries/display_background/display-background.js"></script>
-    <script src="/js/libraries/display_uni_heritage/display-uni-heritage.js"></script>
-
-    <script src="/js/browse/feat/feat-browse.js"></script>
-    <script src="/js/browse/item/item-browse.js"></script>
-    <script src="/js/browse/spell/spell-browse.js"></script>
-    <script src="/js/browse/cClass/class-browse.js"></script>
-    <script src="/js/browse/ancestry/ancestry-browse.js"></script>
-    <script src="/js/browse/archetype/archetype-browse.js"></script>
-    <script src="/js/browse/background/background-browse.js"></script>
-    <script src="/js/browse/uni_heritage/uni-heritage-browse.js"></script>
-
-    <!-- Quickview -->
-    <script src="/js/sheet/quickviews/_quickviews.js"></script>
-    <script src="/js/sheet/quickviews/feat-view.js"></script>
-    <script src="/js/sheet/quickviews/language-view.js"></script>
-    <script src="/js/sheet/quickviews/spell-view.js"></script>
-    <script src="/js/sheet/quickviews/item-view.js"></script>
-    <script src="/js/sheet/quickviews/tag-view.js"></script>
-    <script src="/js/sheet/quickviews/ability-view.js"></script>
-    <script src="/js/sheet/quickviews/condition-view.js"></script>
-    <script src="/js/sheet/utils/item-utils.js"></script>
-    <script src="/js/sheet/utils/material-utils.js"></script>
-
-    <script src="/js/wsc/text-processing.js"></script>
-    <script src="/js/wsc/add-text-processing.js"></script>
-    <script src="/js/wsc/variable-processing.js"></script>
-    <script src="/js/wsc/expression-processing.js"></script>
-    <script src="/js/wsc/expression-utils.js"></script>
-    <script src="/js/wsc/errorHandling.js"></script>
-
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/browse.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script src="/js/browse/general-browse.js"></script>
+  <script src="/js/browse/query-params.js"></script>
+  <script src="/js/browse/browse-utils.js"></script>
+
+  <script src="/js/libraries/display_class/display-class.js"></script>
+  <script src="/js/libraries/display_ancestry/display-ancestry.js"></script>
+  <script src="/js/libraries/display_archetype/display-archetype.js"></script>
+  <script src="/js/libraries/display_background/display-background.js"></script>
+  <script
+    src="/js/libraries/display_uni_heritage/display-uni-heritage.js"
+  ></script>
+
+  <script src="/js/browse/feat/feat-browse.js"></script>
+  <script src="/js/browse/item/item-browse.js"></script>
+  <script src="/js/browse/spell/spell-browse.js"></script>
+  <script src="/js/browse/cClass/class-browse.js"></script>
+  <script src="/js/browse/ancestry/ancestry-browse.js"></script>
+  <script src="/js/browse/archetype/archetype-browse.js"></script>
+  <script src="/js/browse/background/background-browse.js"></script>
+  <script src="/js/browse/uni_heritage/uni-heritage-browse.js"></script>
+
+  <!-- Quickview -->
+  <script src="/js/sheet/quickviews/_quickviews.js"></script>
+  <script src="/js/sheet/quickviews/feat-view.js"></script>
+  <script src="/js/sheet/quickviews/language-view.js"></script>
+  <script src="/js/sheet/quickviews/spell-view.js"></script>
+  <script src="/js/sheet/quickviews/item-view.js"></script>
+  <script src="/js/sheet/quickviews/tag-view.js"></script>
+  <script src="/js/sheet/quickviews/ability-view.js"></script>
+  <script src="/js/sheet/quickviews/condition-view.js"></script>
+  <script src="/js/sheet/utils/item-utils.js"></script>
+  <script src="/js/sheet/utils/material-utils.js"></script>
+
+  <script src="/js/wsc/text-processing.js"></script>
+  <script src="/js/wsc/add-text-processing.js"></script>
+  <script src="/js/wsc/variable-processing.js"></script>
+  <script src="/js/wsc/expression-processing.js"></script>
+  <script src="/js/wsc/expression-utils.js"></script>
+  <script src="/js/wsc/errorHandling.js"></script>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse" class="active"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse" class="active"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
+{{/section}}
 
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <div class="">
@@ -92,79 +98,197 @@
   </div>
 </div>
 
-<div class="subpageloader is-hidden"><div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div></div>
+<div class="subpageloader is-hidden"><div class="lds-roller"><div></div><div
+    ></div><div></div><div></div><div></div><div></div><div></div><div
+    ></div></div></div>
 
 <div class="container browse-container pb-4">
 
   <div class="tabs is-centered is-boxed use-custom-scrollbar">
     <ul class="category-tabs">
-      <li><a id="ancestriesSearchTab" class="searchTab" data-tab-name="ancestry">Ancestries</a></li>
-      <li><a id="archetypesSearchTab" class="searchTab" data-tab-name="archetype">Archetypes</a></li>
-      <li><a id="backgroundsSearchTab" class="searchTab" data-tab-name="background">Backgrounds</a></li>
-      <li><a id="classesSearchTab" class="searchTab" data-tab-name="class">Classes</a></li>
-      <li><a id="featsSearchTab" class="searchTab" data-tab-name="feat">Feats</a></li>
-      <li><a id="itemsSearchTab" class="searchTab" data-tab-name="item">Items</a></li>
-      <li><a id="spellsSearchTab" class="searchTab" data-tab-name="spell">Spells</a></li>
-      <li><a id="vHeritagesSearchTab" class="searchTab" data-tab-name="v-heritage">Versatile Heritages</a></li>
+      <li><a
+          id="ancestriesSearchTab"
+          class="searchTab"
+          data-tab-name="ancestry"
+        >Ancestries</a></li>
+      <li><a
+          id="archetypesSearchTab"
+          class="searchTab"
+          data-tab-name="archetype"
+        >Archetypes</a></li>
+      <li><a
+          id="backgroundsSearchTab"
+          class="searchTab"
+          data-tab-name="background"
+        >Backgrounds</a></li>
+      <li><a
+          id="classesSearchTab"
+          class="searchTab"
+          data-tab-name="class"
+        >Classes</a></li>
+      <li><a
+          id="featsSearchTab"
+          class="searchTab"
+          data-tab-name="feat"
+        >Feats</a></li>
+      <li><a
+          id="itemsSearchTab"
+          class="searchTab"
+          data-tab-name="item"
+        >Items</a></li>
+      <li><a
+          id="spellsSearchTab"
+          class="searchTab"
+          data-tab-name="spell"
+        >Spells</a></li>
+      <li><a
+          id="vHeritagesSearchTab"
+          class="searchTab"
+          data-tab-name="v-heritage"
+        >Versatile Heritages</a></li>
     </ul>
   </div>
-  <div id="tabContent" class="mx-3 mb-3" data-content-filter="{{contentFilter}}" data-content-section="{{contentSection}}" data-content-id="{{contentID}}">
+  <div
+    id="tabContent"
+    class="mx-3 mb-3"
+    data-content-filter="{{contentFilter}}"
+    data-content-section="{{contentSection}}"
+    data-content-id="{{contentID}}"
+  >
 
     <div class="columns">
-      <div id="searchFilterSection" class="column is-4 m-1 is-paddingless " style="">
+      <div
+        id="searchFilterSection"
+        class="column is-4 m-1 is-paddingless"
+        style=""
+      >
         <div class="section-box" style="position: relative;">
-          <p id="browsingFilter" class="is-size-6 text-center"><strong class="has-txt-value-number">Search Filters</strong></p>
+          <p id="browsingFilter" class="is-size-6 text-center"><strong
+              class="has-txt-value-number"
+            >Search Filters</strong></p>
 
-          <div class="use-custom-scrollbar" style="max-height: 550px; overflow-y: auto;">
+          <div
+            class="use-custom-scrollbar"
+            style="max-height: 550px; overflow-y: auto;"
+          >
 
-            <div id="filterNameSection" class="is-hidden filterFieldSection field">
+            <div
+              id="filterNameSection"
+              class="is-hidden filterFieldSection field"
+            >
               <div class="control">
-                <input class="input" id="filterNameInput" type="text" placeholder="Name" autocomplete="off">
+                <input
+                  class="input"
+                  id="filterNameInput"
+                  type="text"
+                  placeholder="Name"
+                  autocomplete="off"
+                />
               </div>
             </div>
 
-            <div id="filterTagsSection" class="is-hidden filterFieldSection field">
+            <div
+              id="filterTagsSection"
+              class="is-hidden filterFieldSection field"
+            >
               <select id="filterTagsInput" data-placeholder="Traits" multiple>
               </select>
             </div>
 
-            <div id="filterFeatPrereqSection" class="is-hidden filterFieldSection field">
+            <div
+              id="filterFeatPrereqSection"
+              class="is-hidden filterFieldSection field"
+            >
               <div class="control">
-                <input class="input" id="filterFeatPrereqInput" type="text" placeholder="Prerequisites" autocomplete="off">
+                <input
+                  class="input"
+                  id="filterFeatPrereqInput"
+                  type="text"
+                  placeholder="Prerequisites"
+                  autocomplete="off"
+                />
               </div>
             </div>
 
-            <div id="filterItemUsageSection" class="is-hidden filterFieldSection field">
+            <div
+              id="filterItemUsageSection"
+              class="is-hidden filterFieldSection field"
+            >
               <div class="control">
-                <input class="input" id="filterItemUsageInput" type="text" placeholder="Usage" autocomplete="off">
+                <input
+                  class="input"
+                  id="filterItemUsageInput"
+                  type="text"
+                  placeholder="Usage"
+                  autocomplete="off"
+                />
               </div>
             </div>
 
-            <div id="filterAreaSection" class="is-hidden filterFieldSection field">
+            <div
+              id="filterAreaSection"
+              class="is-hidden filterFieldSection field"
+            >
               <div class="control">
-                <input class="input" id="filterAreaInput" type="text" placeholder="Area" autocomplete="off">
+                <input
+                  class="input"
+                  id="filterAreaInput"
+                  type="text"
+                  placeholder="Area"
+                  autocomplete="off"
+                />
               </div>
             </div>
 
-            <div id="filterRangeSection" class="is-hidden filterFieldSection field">
+            <div
+              id="filterRangeSection"
+              class="is-hidden filterFieldSection field"
+            >
               <div class="control">
-                <input class="input" id="filterRangeInput" type="text" placeholder="Range" autocomplete="off">
+                <input
+                  class="input"
+                  id="filterRangeInput"
+                  type="text"
+                  placeholder="Range"
+                  autocomplete="off"
+                />
               </div>
             </div>
 
-            <div id="filterTargetsSection" class="is-hidden filterFieldSection field">
+            <div
+              id="filterTargetsSection"
+              class="is-hidden filterFieldSection field"
+            >
               <div class="control">
-                <input class="input" id="filterTargetsInput" type="text" placeholder="Targets" autocomplete="off">
+                <input
+                  class="input"
+                  id="filterTargetsInput"
+                  type="text"
+                  placeholder="Targets"
+                  autocomplete="off"
+                />
               </div>
             </div>
 
-            <div id="filterDescSection" class="is-hidden filterFieldSection field">
+            <div
+              id="filterDescSection"
+              class="is-hidden filterFieldSection field"
+            >
               <div class="control">
-                <input class="input" id="filterDescInput" type="text" placeholder="Description" autocomplete="off">
+                <input
+                  class="input"
+                  id="filterDescInput"
+                  type="text"
+                  placeholder="Description"
+                  autocomplete="off"
+                />
               </div>
             </div>
 
-            <div id="filterSpellTraditionSection" class="is-hidden filterFieldSection field is-horizontal">
+            <div
+              id="filterSpellTraditionSection"
+              class="is-hidden filterFieldSection field is-horizontal"
+            >
               <div class="field-label is-normal ml-2">
                 <label class="label">Tradition</label>
               </div>
@@ -185,7 +309,10 @@
               </div>
             </div>
 
-            <div id="filterActionsSection" class="is-hidden filterFieldSection field is-horizontal">
+            <div
+              id="filterActionsSection"
+              class="is-hidden filterFieldSection field is-horizontal"
+            >
               <div class="field-label is-normal ml-2">
                 <label class="label">Actions</label>
               </div>
@@ -208,7 +335,10 @@
               </div>
             </div>
 
-            <div id="filterCastTimeSection" class="is-hidden filterFieldSection field is-horizontal">
+            <div
+              id="filterCastTimeSection"
+              class="is-hidden filterFieldSection field is-horizontal"
+            >
               <div class="field-label is-normal ml-2">
                 <label class="label" style="white-space: nowrap;">Cast Time</label>
               </div>
@@ -223,13 +353,20 @@
                         <option value="THREE_ACTIONS">[three-actions]</option>
                         <option value="FREE_ACTION">[free-action]</option>
                         <option value="REACTION">[reaction]</option>
-                        <option value="ONE_TO_THREE_ACTIONS">[one-action] to [three-actions]</option>
-                        <option value="ONE_TO_TWO_ACTIONS">[one-action] to [two-actions]</option>
-                        <option value="TWO_TO_THREE_ACTIONS">[two-actions] to [three-actions]</option>
-                        <option value="TWO_TO_TWO_ROUNDS">[two-actions] to 2 rounds</option>
-                        <option value="TWO_TO_THREE_ROUNDS">[two-actions] to 3 rounds</option>
-                        <option value="THREE_TO_TWO_ROUNDS">[three-actions] to 2 rounds</option>
-                        <option value="THREE_TO_THREE_ROUNDS">[three-actions] to 3 rounds</option>
+                        <option value="ONE_TO_THREE_ACTIONS">[one-action] to
+                          [three-actions]</option>
+                        <option value="ONE_TO_TWO_ACTIONS">[one-action] to
+                          [two-actions]</option>
+                        <option value="TWO_TO_THREE_ACTIONS">[two-actions] to
+                          [three-actions]</option>
+                        <option value="TWO_TO_TWO_ROUNDS">[two-actions] to 2
+                          rounds</option>
+                        <option value="TWO_TO_THREE_ROUNDS">[two-actions] to 3
+                          rounds</option>
+                        <option value="THREE_TO_TWO_ROUNDS">[three-actions] to 2
+                          rounds</option>
+                        <option value="THREE_TO_THREE_ROUNDS">[three-actions] to
+                          3 rounds</option>
                         <option value="TWO_ROUNDS">2 rounds</option>
                         <option value="THREE_ROUNDS">3 rounds</option>
                         <option value="ONE_MINUTE">1 minute</option>
@@ -246,7 +383,10 @@
               </div>
             </div>
 
-            <div id="filterComponentsSection" class="is-hidden filterFieldSection field is-horizontal">
+            <div
+              id="filterComponentsSection"
+              class="is-hidden filterFieldSection field is-horizontal"
+            >
               <div class="field-label is-normal ml-2">
                 <label class="label">Components</label>
               </div>
@@ -267,7 +407,10 @@
               </div>
             </div>
 
-            <div id="filterLevelSection" class="is-hidden filterFieldSection field is-horizontal">
+            <div
+              id="filterLevelSection"
+              class="is-hidden filterFieldSection field is-horizontal"
+            >
               <div class="field-label is-normal ml-2">
                 <label class="label">Level</label>
               </div>
@@ -286,13 +429,22 @@
                     </span>
                   </p>
                   <p class="control">
-                    <input class="input" id="filterLevelInput" type="number" placeholder="Lvl" autocomplete="off">
+                    <input
+                      class="input"
+                      id="filterLevelInput"
+                      type="number"
+                      placeholder="Lvl"
+                      autocomplete="off"
+                    />
                   </p>
                 </div>
               </div>
             </div>
 
-            <div id="filterSpellSavingThrowSection" class="is-hidden filterFieldSection field is-horizontal">
+            <div
+              id="filterSpellSavingThrowSection"
+              class="is-hidden filterFieldSection field is-horizontal"
+            >
               <div class="field-label is-normal ml-2">
                 <label class="label">Saving Throw</label>
               </div>
@@ -315,7 +467,10 @@
               </div>
             </div>
 
-            <div id="filterSpellHeightenSection" class="is-hidden filterFieldSection field is-horizontal">
+            <div
+              id="filterSpellHeightenSection"
+              class="is-hidden filterFieldSection field is-horizontal"
+            >
               <div class="field-label is-normal ml-2">
                 <label class="label">Heighten</label>
               </div>
@@ -347,7 +502,10 @@
               </div>
             </div>
 
-            <div id="filterSpellFocusSection" class="is-hidden filterFieldSection field is-horizontal">
+            <div
+              id="filterSpellFocusSection"
+              class="is-hidden filterFieldSection field is-horizontal"
+            >
               <div class="field-label is-normal ml-2">
                 <label class="label">Focus</label>
               </div>
@@ -366,7 +524,10 @@
               </div>
             </div>
 
-            <div id="filterItemPriceSection" class="is-hidden filterFieldSection field is-horizontal">
+            <div
+              id="filterItemPriceSection"
+              class="is-hidden filterFieldSection field is-horizontal"
+            >
               <div class="field-label is-normal ml-2">
                 <label class="label">Price</label>
               </div>
@@ -385,13 +546,24 @@
                     </span>
                   </p>
                   <p class="control">
-                    <input class="input" id="filterItemPriceInput" type="number" placeholder="Price (in cp)" min="0" max="99999999" autocomplete="off">
+                    <input
+                      class="input"
+                      id="filterItemPriceInput"
+                      type="number"
+                      placeholder="Price (in cp)"
+                      min="0"
+                      max="99999999"
+                      autocomplete="off"
+                    />
                   </p>
                 </div>
               </div>
             </div>
 
-            <div id="filterItemBulkSection" class="is-hidden filterFieldSection field is-horizontal">
+            <div
+              id="filterItemBulkSection"
+              class="is-hidden filterFieldSection field is-horizontal"
+            >
               <div class="field-label is-normal ml-2">
                 <label class="label">Bulk</label>
               </div>
@@ -410,13 +582,25 @@
                     </span>
                   </p>
                   <p class="control">
-                    <input class="input" id="filterItemBulkInput" type="number" placeholder="Bulk" min="0" max="999" step="0.1" autocomplete="off">
+                    <input
+                      class="input"
+                      id="filterItemBulkInput"
+                      type="number"
+                      placeholder="Bulk"
+                      min="0"
+                      max="999"
+                      step="0.1"
+                      autocomplete="off"
+                    />
                   </p>
                 </div>
               </div>
             </div>
 
-            <div id="filterRaritySection" class="is-hidden filterFieldSection field is-horizontal">
+            <div
+              id="filterRaritySection"
+              class="is-hidden filterFieldSection field is-horizontal"
+            >
               <div class="field-label is-normal ml-2">
                 <label class="label">Rarity</label>
               </div>
@@ -437,7 +621,10 @@
               </div>
             </div>
 
-            <div id="filterFeatSkillSection" class="is-hidden filterFieldSection field is-horizontal">
+            <div
+              id="filterFeatSkillSection"
+              class="is-hidden filterFieldSection field is-horizontal"
+            >
               <div class="field-label is-normal ml-2">
                 <label class="label">Skill</label>
               </div>
@@ -453,7 +640,10 @@
               </div>
             </div>
 
-            <div id="filterItemCategorySection" class="is-hidden filterFieldSection field is-horizontal">
+            <div
+              id="filterItemCategorySection"
+              class="is-hidden filterFieldSection field is-horizontal"
+            >
               <div class="field-label is-normal ml-2">
                 <label class="label">Category</label>
               </div>
@@ -517,7 +707,10 @@
               </div>
             </div>
 
-            <div id="filterSourceSection" class="is-hidden filterFieldSection field is-horizontal">
+            <div
+              id="filterSourceSection"
+              class="is-hidden filterFieldSection field is-horizontal"
+            >
               <div class="field-label is-normal ml-2">
                 <label class="label">Source</label>
               </div>
@@ -535,42 +728,49 @@
 
           </div>
 
-          <hr class="mt-0 mb-2 mx-2">
+          <hr class="mt-0 mb-2 mx-2" />
 
           <div class="field is-grouped is-grouped-centered pb-2">
             <div class="control">
-              <button id="updateFilterButton" class="button is-info is-rounded ">Search</button>
+              <button
+                id="updateFilterButton"
+                class="button is-info is-rounded"
+              >Search</button>
             </div>
           </div>
 
-          <div id="searchResultCountContainer" style="position: absolute; bottom: -30px; right: 5px;"></div>
+          <div
+            id="searchResultCountContainer"
+            style="position: absolute; bottom: -30px; right: 5px;"
+          ></div>
         </div>
       </div>
-      <div id="browsingList" class="column section-box m-1 use-custom-scrollbar" style="height: 650px; max-height: 650px;overflow-y: auto;">
-
-
+      <div
+        id="browsingList"
+        class="column section-box m-1 use-custom-scrollbar"
+        style="height: 650px; max-height: 650px;overflow-y: auto;"
+      >
 
       </div>
     </div>
 
   </div>
-  
 
 </div>
 
-{{#section 'overlay'}}
-    <!-- Right Quickview -->
-    <div id="quickviewDefault" class="quickview">
-        <div class="quickview-header">
-            <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
-            <div class="is-inline-flex">
-                <p id="quickViewTitleRight"></p>
-                <p id="quickViewTitleClose"></p>
-            </div>
-        </div>
-        <div class="quickview-body use-custom-scrollbar">
-            <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
-            </div>
-        </div>
+{{#section "overlay"}}
+  <!-- Right Quickview -->
+  <div id="quickviewDefault" class="quickview">
+    <div class="quickview-header">
+      <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
+      <div class="is-inline-flex">
+        <p id="quickViewTitleRight"></p>
+        <p id="quickViewTitleClose"></p>
+      </div>
     </div>
+    <div class="quickview-body use-custom-scrollbar">
+      <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
+      </div>
+    </div>
+  </div>
 {{/section}}

--- a/views/pages/character_list.handlebars
+++ b/views/pages/character_list.handlebars
@@ -1,178 +1,242 @@
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/character-list.css" />
+{{/section}}
 
-{{#section 'header'}}
+{{#section "header"}}
 
-    <!-- PDF Lib -->
-    <script src="https://unpkg.com/pdf-lib/dist/pdf-lib.min.js"></script>
-    <script src="https://unpkg.com/downloadjs@1.4.7"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.8.0/html2pdf.bundle.min.js"></script>
-    
+  <!-- PDF Lib -->
+  <script src="https://unpkg.com/pdf-lib/dist/pdf-lib.min.js"></script>
+  <script src="https://unpkg.com/downloadjs@1.4.7"></script>
+  <script
+    src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.8.0/html2pdf.bundle.min.js"
+  ></script>
 
-    <script type="text/javascript" src="/js/character-list.js"></script>
-    <link rel="stylesheet" href="/css/character-list.css">
+  <script type="text/javascript" src="/js/character-list.js"></script>
 
-    <script src="/js/require-signin.js"></script>
+  <script src="/js/require-signin.js"></script>
 
-    <script type="text/javascript" src="/js/char_export/export-handler.js"></script>
-    <script type="text/javascript" src="/js/char_export/populate-pdf.js"></script>
-    <!--<script type="text/javascript" src="/js/char_export/pdf-sheet.js"></script>-->
-    <script type="application/pdf" src="/pdf/character_sheet.pdf"></script>
+  <script
+    type="text/javascript"
+    src="/js/char_export/export-handler.js"
+  ></script>
+  <script type="text/javascript" src="/js/char_export/populate-pdf.js"></script>
+  <!--<script type="text/javascript" src="/js/char_export/pdf-sheet.js"></script>-->
+  <script type="application/pdf" src="/pdf/character_sheet.pdf"></script>
 
-    <!-- Discord Widget Bot -->
-    <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
-      new Crate({
-        server: '735260060682289254',
-        channel: '735260060682289257'
-      })
-    </script>
+  <!-- Discord Widget Bot -->
+  <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
+    new Crate({ server: '735260060682289254', channel: '735260060682289257' })
+  </script>
 
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters" class="active">Characters</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+      class="active"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
-
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
-<div class="subpageloader is-hidden"><div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div></div>
+<div class="subpageloader is-hidden"><div class="lds-roller"><div></div><div
+    ></div><div></div><div></div><div></div><div></div><div></div><div
+    ></div></div></div>
 
 <div class="container">
 
-    <div class="columns is-mobile is-centered is-vcentered pt-3 is-marginless">
-        <div class="column is-5 is-paddingless" style="white-space: nowrap;">
-            <h1 class="is-size-2 is-inline-block has-txt-value-string title-font">Characters</h1>
-            {{#ifEqual user.isPatreonMember 0}}
-                <span class="is-size-5 ml-3 has-tooltip-bottom has-tooltip-multiline has-txt-listing" data-tooltip="You can only have up to six characters at once. To get unlimited characters, support us and what we're doing on Patreon!">({{characters.length}}/{{characterLimit}})</span>
-            {{/ifEqual}}
-        </div>
-        <div class="column is-5 is-paddingless">
-            {{#if canMakeCharacter}}
-              <a id="icon-character-import" class="is-size-3-5 is-pulled-right">
-                <label for="input-character-import">
-                  <span class="icon is-large has-text-info has-tooltip-bottom" data-tooltip="Import Character">
-                    <i class="fas fa-upload cursor-clickable"></i>
-                  </span>
-                </label>
-                <input id="input-character-import" type="file" accept=".guidechar"/>
-              </a>
-              <a class="is-size-3 is-pulled-right" href="/profile/characters/add"><span class="icon is-large has-text-info has-tooltip-bottom" data-tooltip="Create Character"><i class="fas fa-user-plus"></i></span></a>
-            {{else}}
+  <div class="columns is-mobile is-centered is-vcentered pt-3 is-marginless">
+    <div class="column is-5 is-paddingless" style="white-space: nowrap;">
+      <h1
+        class="is-size-2 is-inline-block has-txt-value-string title-font"
+      >Characters</h1>
+      {{#ifEqual user.isPatreonMember 0}}
+        <span
+          class="is-size-5 ml-3 has-tooltip-bottom has-tooltip-multiline has-txt-listing"
+          data-tooltip="You can only have up to six characters at once. To get unlimited characters, support us and what we're doing on Patreon!"
+        >({{characters.length}}/{{characterLimit}})</span>
+      {{/ifEqual}}
+    </div>
+    <div class="column is-5 is-paddingless">
+      {{#if canMakeCharacter}}
+        <a id="icon-character-import" class="is-size-3-5 is-pulled-right">
+          <label for="input-character-import">
+            <span
+              class="icon is-large has-text-info has-tooltip-bottom"
+              data-tooltip="Import Character"
+            >
+              <i class="fas fa-upload cursor-clickable"></i>
+            </span>
+          </label>
+          <input id="input-character-import" type="file" accept=".guidechar" />
+        </a>
+        <a
+          class="is-size-3 is-pulled-right"
+          href="/profile/characters/add"
+        ><span
+            class="icon is-large has-text-info has-tooltip-bottom"
+            data-tooltip="Create Character"
+          ><i class="fas fa-user-plus"></i></span></a>
+      {{else}}
 
-              <a class="is-size-3-5 is-pulled-right">
-                <label for="input-character-import">
-                  <span class="icon is-large has-text-danger has-tooltip-bottom" data-tooltip="Import Character">
-                    <i class="fas fa-upload cursor-clickable"></i>
-                  </span>
-                </label>
-              </a>
-              <a class="is-size-3 is-pulled-right"><span class="icon is-large has-text-danger has-tooltip-bottom" data-tooltip="Create Character"><i class="fas fa-user-times"></i></span></a>
+        <a class="is-size-3-5 is-pulled-right">
+          <label for="input-character-import">
+            <span
+              class="icon is-large has-text-danger has-tooltip-bottom"
+              data-tooltip="Import Character"
+            >
+              <i class="fas fa-upload cursor-clickable"></i>
+            </span>
+          </label>
+        </a>
+        <a class="is-size-3 is-pulled-right"><span
+            class="icon is-large has-text-danger has-tooltip-bottom"
+            data-tooltip="Create Character"
+          ><i class="fas fa-user-times"></i></span></a>
 
-              <a href="https://www.patreon.com/bePatron?u=32932027" target="_blank" class="button is-rounded is-small is-hidden-mobile mt-2 mx-3 is-pulled-right" style="background-color: rgb(255, 66, 77);color: white;">
+        <a
+          href="https://www.patreon.com/bePatron?u=32932027"
+          target="_blank"
+          class="button is-rounded is-small is-hidden-mobile mt-2 mx-3 is-pulled-right"
+          style="background-color: rgb(255, 66, 77);color: white;"
+        >
+          <span class="icon is-small">
+            <i class="fab fa-patreon"></i>
+          </span>
+          <span>Become a patron</span>
+        </a>
+
+      {{/if}}
+    </div>
+  </div>
+  <hr />
+
+  <div class="columns is-centered is-multiline is-marginless mb-2">
+    {{#each characters}}
+      <div class="column is-4">
+        <div
+          class="card character-card is-unselectable"
+          data-char-id="{{id}}"
+          data-char-name="{{name}}"
+        >
+          <div class="card-content cursor-clickable pt-2">
+            <a href="/profile/characters/{{id}}">
+              <span class="is-size-8 has-txt-noted char-id"># {{id}}</span>
+              <p
+                class="is-size-5 has-txt-value-number text-overflow-ellipsis"
+              >{{name}}</p>
+              <p class="is-size-7 pl-4 text-overflow-ellipsis">
+                Lvl
+                {{level}}
+                |
+                {{heritageName}}
+                {{className}}</p>
+            </a>
+          </div>
+          <div class="card-footer is-paddingless">
+            <a class="card-footer-item character-card-edit has-txt-listing">
+              {{#if isPlayable}}
+                <span
+                  class="character-card-edit-text is-size-6 pr-1"
+                >Edit</span>
                 <span class="icon is-small">
-                  <i class="fab fa-patreon"></i>
+                  <i class="fas fa-sm fa-edit"></i>
                 </span>
-                <span>Become a patron</span>
-              </a>
-
-            {{/if}}
+              {{else}}
+                <span
+                  class="character-card-edit-text is-size-6 pr-1"
+                >Continue</span>
+                <span class="icon is-small">
+                  <i class="fas fa-sm fa-wrench"></i>
+                </span>
+              {{/if}}
+            </a>
+            <a class="card-footer-item character-card-options has-txt-listing">
+              <span
+                class="character-card-options-text is-size-6 pr-1"
+              >Options</span>
+              <span class="icon is-small">
+                <i class="fas fa-sm fa-ellipsis-h"></i>
+              </span>
+            </a>
+            <a
+              class="card-footer-item character-card-delete has-txt-listing"
+              style="overflow: hidden;"
+            >
+              <span
+                class="character-card-delete-text is-size-6 pr-1"
+              >Delete</span>
+              <span class="icon is-small">
+                <i class="fas fa-sm fa-trash"></i>
+              </span>
+            </a>
+          </div>
         </div>
-    </div>
-    <hr>
-
-
-    <div class="columns is-centered is-multiline is-marginless mb-2">
-        {{#each characters}}
-            <div class="column is-4">
-                <div class="card character-card is-unselectable" data-char-id="{{id}}" data-char-name="{{name}}">
-                    <div class="card-content cursor-clickable pt-2">
-                      <a href="/profile/characters/{{id}}">
-                        <span class="is-size-8 has-txt-noted char-id"># {{id}}</span>
-                        <p class="is-size-5 has-txt-value-number text-overflow-ellipsis">{{name}}</p>
-                        <p class="is-size-7 pl-4 text-overflow-ellipsis"> Lvl {{level}} | {{heritageName}} {{className}}</p>
-                      </a>
-                    </div>
-                    <div class="card-footer is-paddingless">
-                        <a class="card-footer-item character-card-edit has-txt-listing">
-                            {{#if isPlayable}}
-                                <span class="character-card-edit-text is-size-6 pr-1">Edit</span>
-                                <span class="icon is-small">
-                                    <i class="fas fa-sm fa-edit"></i>
-                                </span>
-                            {{else}}
-                                <span class="character-card-edit-text is-size-6 pr-1">Continue</span>
-                                <span class="icon is-small">
-                                    <i class="fas fa-sm fa-wrench"></i>
-                                </span>
-                            {{/if}}
-                        </a>
-                        <a class="card-footer-item character-card-options has-txt-listing">
-                            <span class="character-card-options-text is-size-6 pr-1">Options</span>
-                            <span class="icon is-small">
-                                <i class="fas fa-sm fa-ellipsis-h"></i>
-                            </span>
-                        </a>
-                        <a class="card-footer-item character-card-delete has-txt-listing" style="overflow: hidden;">
-                            <span class="character-card-delete-text is-size-6 pr-1">Delete</span>
-                            <span class="icon is-small">
-                                <i class="fas fa-sm fa-trash"></i>
-                            </span>
-                        </a>
-                    </div>
-                </div>
-            </div>
-        {{else}}
-            <div class="column">
-                <p class="has-text-centered is-italic">You have no characters.</p>
-            </div>
-        {{/each}}
-    </div>
+      </div>
+    {{else}}
+      <div class="column">
+        <p class="has-text-centered is-italic">You have no characters.</p>
+      </div>
+    {{/each}}
+  </div>
 
 </div>
 
 <!-- Character Delete Modal -->
 <div class="modal modal-char-delete">
-    <div class="modal-background"></div>
-    <div class="modal-card">
-        <header class="modal-card-head">
-            <p id="modal-char-delete-title" class="modal-card-title is-size-4 has-txt-value-string">Delete Character</p>
-            <button class="delete modal-card-close" aria-label="close"></button>
-        </header>
-        <section class="modal-card-body">
-            <p class="has-txt-value-string has-text-centered">Are you sure you want to delete this character?</p>
-        </section>
-        <footer class="modal-card-foot is-paddingless p-3 field is-grouped is-grouped-centered">
-            <p class="control">
-                <a class="button is-danger is-outlined" id="delete-confirmation-btn">Delete</a>
-            </p>
-        </footer>
-    </div>
+  <div class="modal-background"></div>
+  <div class="modal-card">
+    <header class="modal-card-head">
+      <p
+        id="modal-char-delete-title"
+        class="modal-card-title is-size-4 has-txt-value-string"
+      >Delete Character</p>
+      <button class="delete modal-card-close" aria-label="close"></button>
+    </header>
+    <section class="modal-card-body">
+      <p class="has-txt-value-string has-text-centered">Are you sure you want to
+        delete this character?</p>
+    </section>
+    <footer
+      class="modal-card-foot is-paddingless p-3 field is-grouped is-grouped-centered"
+    >
+      <p class="control">
+        <a
+          class="button is-danger is-outlined"
+          id="delete-confirmation-btn"
+        >Delete</a>
+      </p>
+    </footer>
+  </div>
 </div>
 
 <!-- Character Options Modal -->
@@ -180,21 +244,33 @@
   <div class="modal-background"></div>
   <div class="modal-card">
     <header class="modal-card-head">
-      <p class="modal-card-title is-size-4 has-txt-value-number">Character Options</p>
+      <p class="modal-card-title is-size-4 has-txt-value-number">Character
+        Options</p>
       <button class="delete modal-card-close" aria-label="close"></button>
     </header>
     <section class="modal-card-body pb-3">
 
       <div class="buttons is-centered">
         {{#if canMakeCharacter}}
-          <button id="btn-duplicate-character" class="button is-info"><span>Create Copy</span><span class="icon"><i class="fas fa-user-friends"></i></span></button>
+          <button id="btn-duplicate-character" class="button is-info"><span
+            >Create Copy</span><span class="icon"><i
+                class="fas fa-user-friends"
+              ></i></span></button>
         {{else}}
-          <button class="button is-danger"><span>Create Copy</span><span class="icon"><i class="fas fa-user-friends"></i></span></button>
+          <button class="button is-danger"><span>Create Copy</span><span
+              class="icon"
+            ><i class="fas fa-user-friends"></i></span></button>
         {{/if}}
-        <button id="btn-export-character" class="button is-info"><span>Export</span><span class="icon"><i class="fas fa-download"></i></span></button>
-        <button id="btn-export-to-pdf" class="button is-info"><span>Export to PDF</span><span class="icon"><i class="fas fa-file-pdf"></i></span></button>
+        <button id="btn-export-character" class="button is-info"><span
+          >Export</span><span class="icon"><i
+              class="fas fa-download"
+            ></i></span></button>
+        <button id="btn-export-to-pdf" class="button is-info"><span>Export to
+            PDF</span><span class="icon"><i
+              class="fas fa-file-pdf"
+            ></i></span></button>
       </div>
-      
+
     </section>
     <footer class="modal-card-foot">
     </footer>

--- a/views/pages/home.handlebars
+++ b/views/pages/home.handlebars
@@ -1,57 +1,77 @@
-
-{{#section 'header'}}
-	<script src="/js/home-page.js"></script>
-	<link rel="stylesheet" href="/css/home-page.css">
-    <style>
-		.banner_w3lspvt-1 {
-			background-image: url("{{background.artworkURL}}"), url('../images/fb_back.png');
-			opacity: 0;
-		}
-	</style>
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/home-page.css" />
+  <style>
+    .banner_w3lspvt-1 { background-image: url("{{background.artworkURL}}"),
+    url('../images/fb_back.png'); opacity: 0; }
+  </style>
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/" class="active">Home</a></li>
+{{#section "header"}}
+  <script src="/js/home-page.js"></script>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/" class="active">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2">
+    <a href="/browse">
+      <i class="fas fa-lg fa-search"></i>
+    </a>
+  </li>
+{{/section}}
+
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
 <div class="banner_w3lspvt-1">
-	<div class="w3ls_banner_txt">
+  <div class="w3ls_banner_txt">
 
     <div id="home-mobile-layout" class="columns is-hidden">
       <div class="column home-containers">
-        <h4 class="w3ls_pvt-title has-text-white text-center">Your Guide to Pathfinder 2e</h4>
-        <hr class="my-0 mx-2">
+        <h4 class="w3ls_pvt-title has-text-white text-center">Your Guide to
+          Pathfinder 2e</h4>
+        <hr class="my-0 mx-2" />
 
         <p class="text-center pt-2">
-          <a href="/browse" style="max-width: 150px;" class="btn button-style m-1"><i class="fas fa-search"></i> Search Pf2e</a>
+          <a
+            href="/browse"
+            style="max-width: 150px;"
+            class="btn button-style m-1"
+          ><i class="fas fa-search"></i> Search Pf2e</a>
           {{#if user}}
-            <a href="/profile/characters" style="max-width: 180px;" class="btn button-style m-1">Create Character</a>
+            <a
+              href="/profile/characters"
+              style="max-width: 180px;"
+              class="btn button-style m-1"
+            >Create Character</a>
           {{else}}
-            <a href="/auth/login" style="max-width: 180px;" class="btn button-style m-1">Create Character</a>
+            <a
+              href="/auth/login"
+              style="max-width: 180px;"
+              class="btn button-style m-1"
+            >Create Character</a>
           {{/if}}
         </p>
       </div>
@@ -60,7 +80,7 @@
     <div id="home-desktop-layout" class="columns">
       <div class="column home-containers">
         <h4 class="w3ls_pvt-title has-text-white text-center">Announcements</h4>
-        <hr class="my-0 mx-2">
+        <hr class="my-0 mx-2" />
 
         <div class="my-2">
           <widgetbot
@@ -69,104 +89,182 @@
             width="400"
             height="500"
           ></widgetbot>
-          <script src="https://cdn.jsdelivr.net/npm/@widgetbot/html-embed"></script>
+          <script
+            src="https://cdn.jsdelivr.net/npm/@widgetbot/html-embed"
+          ></script>
         </div>
 
-        <hr class="my-0 mx-2">
-        
+        <hr class="my-0 mx-2" />
+
         <p class="text-center pt-2">
-          <a href="/browse" style="max-width: 150px;" class="btn button-style m-1"><i class="fas fa-search"></i> Search Pf2e</a>
+          <a
+            href="/browse"
+            style="max-width: 150px;"
+            class="btn button-style m-1"
+          ><i class="fas fa-search"></i> Search Pf2e</a>
           {{#if user}}
-            <a href="/profile/characters" style="max-width: 180px;" class="btn button-style m-1">Create Character</a>
+            <a
+              href="/profile/characters"
+              style="max-width: 180px;"
+              class="btn button-style m-1"
+            >Create Character</a>
           {{else}}
-            <a href="/auth/login" style="max-width: 180px;" class="btn button-style m-1">Create Character</a>
+            <a
+              href="/auth/login"
+              style="max-width: 180px;"
+              class="btn button-style m-1"
+            >Create Character</a>
           {{/if}}
         </p>
 
       </div>
       <div class="column">
-      
+
       </div>
       <div class="column is-2 home-containers">
         <h4 class="w3ls_pvt-title has-text-white text-center">Top Builds</h4>
-        <hr class="my-0 mx-2">
-        <div id="top-builds-list" class="pos-relative" style="margin-top: 0.75rem; margin-bottom: 1rem;">
+        <hr class="my-0 mx-2" />
+        <div
+          id="top-builds-list"
+          class="pos-relative"
+          style="margin-top: 0.75rem; margin-bottom: 1rem;"
+        >
 
           <div id="top-builds-loader" class="pageloader mt-5">
-            <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+            <div class="lds-roller"><div></div><div></div><div></div><div
+              ></div><div></div><div></div><div></div><div></div></div>
           </div>
 
         </div>
       </div>
       <div class="column is-2 home-containers">
         <h4 class="w3ls_pvt-title has-text-white text-center">Top Homebrew</h4>
-        <hr class="my-0 mx-2">
-        <div id="top-homebrew-list" class="pos-relative" style="margin-top: 0.75rem; margin-bottom: 1rem;">
+        <hr class="my-0 mx-2" />
+        <div
+          id="top-homebrew-list"
+          class="pos-relative"
+          style="margin-top: 0.75rem; margin-bottom: 1rem;"
+        >
 
           <div id="top-homebrew-loader" class="pageloader mt-5">
-            <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+            <div class="lds-roller"><div></div><div></div><div></div><div
+              ></div><div></div><div></div><div></div><div></div></div>
           </div>
 
         </div>
       </div>
     </div>
 
-	</div>
-	<a class="banner-1-artist" rel="author" target="_blank" href="{{background.artistPage}}"><span class="icon"><i class="fas fa-paint-brush"></i></span> <span>{{background.name}}</span></a>
-	<span id="backReportBtn" class="banner-1-image-report cursor-clickable icon" name="{{background.id}}"><i class="fas fa-exclamation-circle"></i></span>
+  </div>
+  <a
+    class="banner-1-artist"
+    rel="author"
+    target="_blank"
+    href="{{background.artistPage}}"
+  ><span class="icon"><i class="fas fa-paint-brush"></i></span>
+    <span>{{background.name}}</span></a>
+  <span
+    id="backReportBtn"
+    class="banner-1-image-report cursor-clickable icon"
+    name="{{background.id}}"
+  ><i class="fas fa-exclamation-circle"></i></span>
 </div>
 
 <div class="what py-5" id="about_wanderers_guide">
-	<div class="container py-xl-5 py-lg-3">
-		<h3 class="title-w3 mb-2 text-center has-text-weight-bold has-txt-listing">What is Wanderer's Guide?</h3>
-		<p class="text-center mb-4">
-			Wanderer's Guide is a semi-automated character manager for Pathfinder Second Edition. Designed for desktop and tablets, Wanderer's Guide has an interactive inventory, conditions, and spells management system. Character building in Wanderer's Guide is intuitive and easier than ever, try it out for yourself!
-		</p>
-			
-		<h3 class="title-w2 mb-1 text-center has-text-weight-semibold has-txt-listing">Pathfinder 2e and License</h3>
-		<p class="text-center mb-3">
-			This website uses trademarks and/or copyrights owned by Paizo Inc., which are used under Paizo's Community Use Policy. We are expressly prohibited from charging you to use or access this content. This website is not published, endorsed, or specifically approved by Paizo Inc. For more information about Paizo's Community Use Policy, please visit paizo.com/communityuse. For more information about Paizo Inc. and Paizo products, please visit paizo.com.
-			<br>
-			Wanderer's Guide is produced under the <a href="/license" class="has-text-info-lighter">Open Game License 1.0a</a>.
-			<br>
-			Pathfinder Second Edition contains an enormous amount of content, as such, there are a few features with ambiguous wording. In these cases, we try to follow the ruling of what the community generally agrees upon (we may also adjust the feature's wording to support this). If there is any doubt on how a mechanic or feature works, we highly recommend referring back to the source books. In addition, Wanderer's Guide contains features which are not included in the official Pathfinder Second Edition source material. These features are included in cases where we believe such content was missing in the source material and will be replaced by official content if it is made available in the future (examples include an item for a piece of paper, things like that).
-		</p>
+  <div class="container py-xl-5 py-lg-3">
+    <h3
+      class="title-w3 mb-2 text-center has-text-weight-bold has-txt-listing"
+    >What is Wanderer's Guide?</h3>
+    <p class="text-center mb-4">
+      Wanderer's Guide is a semi-automated character manager for Pathfinder
+      Second Edition. Designed for desktop and tablets, Wanderer's Guide has an
+      interactive inventory, conditions, and spells management system. Character
+      building in Wanderer's Guide is intuitive and easier than ever, try it out
+      for yourself!
+    </p>
 
-		<h3 class="title-w2 mb-1 text-center has-text-weight-semibold has-txt-listing">Artwork</h3>
-		<p class="text-center">
-			Wanderer's Guide does not own any of the background artwork above.
-		</p>
-		<!--We have been given permission by the artists to use their work on our site.-->
-		<p class="text-center mb-3">
-			The creator of each piece has their name in the bottom right corner, which links to their website.
-		</p>
+    <h3
+      class="title-w2 mb-1 text-center has-text-weight-semibold has-txt-listing"
+    >Pathfinder 2e and License</h3>
+    <p class="text-center mb-3">
+      This website uses trademarks and/or copyrights owned by Paizo Inc., which
+      are used under Paizo's Community Use Policy. We are expressly prohibited
+      from charging you to use or access this content. This website is not
+      published, endorsed, or specifically approved by Paizo Inc. For more
+      information about Paizo's Community Use Policy, please visit
+      paizo.com/communityuse. For more information about Paizo Inc. and Paizo
+      products, please visit paizo.com.
+      <br />
+      Wanderer's Guide is produced under the
+      <a href="/license" class="has-text-info-lighter">Open Game License 1.0a</a>.
+      <br />
+      Pathfinder Second Edition contains an enormous amount of content, as such,
+      there are a few features with ambiguous wording. In these cases, we try to
+      follow the ruling of what the community generally agrees upon (we may also
+      adjust the feature's wording to support this). If there is any doubt on
+      how a mechanic or feature works, we highly recommend referring back to the
+      source books. In addition, Wanderer's Guide contains features which are
+      not included in the official Pathfinder Second Edition source material.
+      These features are included in cases where we believe such content was
+      missing in the source material and will be replaced by official content if
+      it is made available in the future (examples include an item for a piece
+      of paper, things like that).
+    </p>
 
-	</div>
+    <h3
+      class="title-w2 mb-1 text-center has-text-weight-semibold has-txt-listing"
+    >Artwork</h3>
+    <p class="text-center">
+      Wanderer's Guide does not own any of the background artwork above.
+    </p>
+    <!--We have been given permission by the artists to use their work on our site.-->
+    <p class="text-center mb-3">
+      The creator of each piece has their name in the bottom right corner, which
+      links to their website.
+    </p>
+
+  </div>
 </div>
 
 <div class="modal">
-    <div class="modal-background"></div>
-    <div class="modal-card">
-        <header class="modal-card-head">
-            <p class="modal-card-title is-size-4 has-txt-value-string">Report Background</p>
-            <button class="delete modal-card-close" aria-label="close"></button>
-        </header>
-        <section class="modal-card-body">
-			<div class="field">
-                <div class="control">
-                    <input id="inputEmail" class="input" type="text" placeholder="Email">
-                </div>
-            </div>
-            <div class="field">
-                <div class="control">
-                    <textarea id="reportMessage" class="textarea" maxlength="500" placeholder="What's the problem?"></textarea>
-                </div>
-            </div>
-        </section>
-        <footer class="modal-card-foot is-paddingless p-3 field is-grouped is-grouped-centered">
-            <p class="control">
-                <a class="button is-danger is-outlined" id="report-confirmation-btn">Report</a>
-            </p>
-        </footer>
-    </div>
+  <div class="modal-background"></div>
+  <div class="modal-card">
+    <header class="modal-card-head">
+      <p class="modal-card-title is-size-4 has-txt-value-string">Report
+        Background</p>
+      <button class="delete modal-card-close" aria-label="close"></button>
+    </header>
+    <section class="modal-card-body">
+      <div class="field">
+        <div class="control">
+          <input
+            id="inputEmail"
+            class="input"
+            type="text"
+            placeholder="Email"
+          />
+        </div>
+      </div>
+      <div class="field">
+        <div class="control">
+          <textarea
+            id="reportMessage"
+            class="textarea"
+            maxlength="500"
+            placeholder="What's the problem?"
+          ></textarea>
+        </div>
+      </div>
+    </section>
+    <footer
+      class="modal-card-foot is-paddingless p-3 field is-grouped is-grouped-centered"
+    >
+      <p class="control">
+        <a
+          class="button is-danger is-outlined"
+          id="report-confirmation-btn"
+        >Report</a>
+      </p>
+    </footer>
+  </div>
 </div>

--- a/views/pages/homebrew.handlebars
+++ b/views/pages/homebrew.handlebars
@@ -1,91 +1,103 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/homebrew.css">
-    <link rel="stylesheet" href="/css/browse.css">
-
-    <script src="/js/require-signin.js"></script>
-
-    <script src="/js/homebrew/general-homebrew.js"></script>
-    <script src="/js/homebrew/user-content.js"></script>
-    <script src="/js/homebrew/user-collection.js"></script>
-    <script src="/js/homebrew/bundle-browse.js"></script>
-    <script src="/js/browse/browse-utils.js"></script>
-
-    <script src="/js/libraries/display_class/display-class.js"></script>
-    <script src="/js/libraries/display_ancestry/display-ancestry.js"></script>
-    <script src="/js/libraries/display_archetype/display-archetype.js"></script>
-    <script src="/js/libraries/display_background/display-background.js"></script>
-    <script src="/js/libraries/display_uni_heritage/display-uni-heritage.js"></script>
-
-    <script src="/js/homebrew/bundle-view.js"></script>
-    <script src="/js/homebrew/bundle-manage-keys.js"></script>
-
-    <script src="/js/homebrew/builder/bundle-editor.js"></script>
-    <script src="/js/homebrew/builder/builder-templating.js"></script>
-
-    <script src="/js/libraries/confirm_message/confirm-message.js"></script>
-
-    <!-- Quickview -->
-    <script src="/js/sheet/quickviews/_quickviews.js"></script>
-    <script src="/js/sheet/quickviews/feat-view.js"></script>
-    <script src="/js/sheet/quickviews/language-view.js"></script>
-    <script src="/js/sheet/quickviews/spell-view.js"></script>
-    <script src="/js/sheet/quickviews/item-view.js"></script>
-    <script src="/js/sheet/quickviews/tag-view.js"></script>
-    <script src="/js/sheet/quickviews/ability-view.js"></script>
-    <script src="/js/sheet/quickviews/condition-view.js"></script>
-    <script src="/js/sheet/utils/item-utils.js"></script>
-    <script src="/js/sheet/utils/material-utils.js"></script>
-    <script src="/js/wsc/text-processing.js"></script>
-    <script src="/js/wsc/add-text-processing.js"></script>
-    <script src="/js/wsc/expression-utils.js"></script>
-
-    <!-- Discord Widget Bot -->
-    <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
-      new Crate({
-        server: '735260060682289254',
-        channel: '735260060682289257'
-      })
-    </script>
-
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/homebrew.css" />
+  <link rel="stylesheet" href="/css/browse.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script src="/js/require-signin.js"></script>
+
+  <script src="/js/homebrew/general-homebrew.js"></script>
+  <script src="/js/homebrew/user-content.js"></script>
+  <script src="/js/homebrew/user-collection.js"></script>
+  <script src="/js/homebrew/bundle-browse.js"></script>
+  <script src="/js/browse/browse-utils.js"></script>
+
+  <script src="/js/libraries/display_class/display-class.js"></script>
+  <script src="/js/libraries/display_ancestry/display-ancestry.js"></script>
+  <script src="/js/libraries/display_archetype/display-archetype.js"></script>
+  <script src="/js/libraries/display_background/display-background.js"></script>
+  <script
+    src="/js/libraries/display_uni_heritage/display-uni-heritage.js"
+  ></script>
+
+  <script src="/js/homebrew/bundle-view.js"></script>
+  <script src="/js/homebrew/bundle-manage-keys.js"></script>
+
+  <script src="/js/homebrew/builder/bundle-editor.js"></script>
+  <script src="/js/homebrew/builder/builder-templating.js"></script>
+
+  <script src="/js/libraries/confirm_message/confirm-message.js"></script>
+
+  <!-- Quickview -->
+  <script src="/js/sheet/quickviews/_quickviews.js"></script>
+  <script src="/js/sheet/quickviews/feat-view.js"></script>
+  <script src="/js/sheet/quickviews/language-view.js"></script>
+  <script src="/js/sheet/quickviews/spell-view.js"></script>
+  <script src="/js/sheet/quickviews/item-view.js"></script>
+  <script src="/js/sheet/quickviews/tag-view.js"></script>
+  <script src="/js/sheet/quickviews/ability-view.js"></script>
+  <script src="/js/sheet/quickviews/condition-view.js"></script>
+  <script src="/js/sheet/utils/item-utils.js"></script>
+  <script src="/js/sheet/utils/material-utils.js"></script>
+  <script src="/js/wsc/text-processing.js"></script>
+  <script src="/js/wsc/add-text-processing.js"></script>
+  <script src="/js/wsc/expression-utils.js"></script>
+
+  <!-- Discord Widget Bot -->
+  <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
+    new Crate({ server: '735260060682289254', channel: '735260060682289257' })
+  </script>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew" class="active">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/homebrew"
+      class="active"
+    >Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
-<div id="homebrew-container" class="container" data-edit-homebrew-id="{{editHomebrewID}}" data-view-homebrew-id="{{viewHomebrewID}}" data-direct-to-tab="{{homebrewTabName}}" data-user-id="{{user.id}}">
-  
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
+{{/section}}
+
+<div
+  id="homebrew-container"
+  class="container"
+  data-edit-homebrew-id="{{editHomebrewID}}"
+  data-view-homebrew-id="{{viewHomebrewID}}"
+  data-direct-to-tab="{{homebrewTabName}}"
+  data-user-id="{{user.id}}"
+>
+
   <div class="tabs is-centered is-boxed use-custom-scrollbar mb-2">
     <ul class="category-tabs">
       <li><a id="browseTab">Browse Homebrew</a></li>
@@ -93,36 +105,45 @@
       {{#if user}}<li><a id="userContentTab">My Creations</a></li>{{/if}}
     </ul>
   </div>
-  <div id="tabContent" class="mx-3 mb-3"></div><!-- tabContent must be empty! -->
-  <div class="subpageloader mt-5 pt-5 is-hidden"><div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div></div>
+  <div
+    id="tabContent"
+    class="mx-3 mb-3"
+  ></div><!-- tabContent must be empty! -->
+  <div class="subpageloader mt-5 pt-5 is-hidden"><div class="lds-roller"><div
+      ></div><div></div><div></div><div></div><div></div><div></div><div
+      ></div><div></div></div></div>
 
 </div>
 
-{{#section 'overlay'}}
-    <!-- Right Quickview -->
-    <div id="quickviewDefault" class="quickview">
-        <div class="quickview-header">
-            <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
-            <div class="is-inline-flex">
-                <p id="quickViewTitleRight"></p>
-                <p id="quickViewTitleClose"></p>
-            </div>
-        </div>
-        <div class="quickview-body use-custom-scrollbar">
-            <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
-            </div>
-        </div>
+{{#section "overlay"}}
+  <!-- Right Quickview -->
+  <div id="quickviewDefault" class="quickview">
+    <div class="quickview-header">
+      <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
+      <div class="is-inline-flex">
+        <p id="quickViewTitleRight"></p>
+        <p id="quickViewTitleClose"></p>
+      </div>
     </div>
+    <div class="quickview-body use-custom-scrollbar">
+      <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
+      </div>
+    </div>
+  </div>
 {{/section}}
 
 <div id="manage-keys-modal" class="modal">
   <div id="manage-keys-modal-background" class="modal-background"></div>
   <div class="modal-card">
-      <header class="modal-card-head">
-          <p class="modal-card-title is-size-4 has-txt-value-number">Key Management</p>
-          <button id="manage-keys-modal-close" class="delete modal-card-close" aria-label="close"></button>
-      </header>
-      <section id="manage-keys-modal-body" class="modal-card-body">
-      </section>
+    <header class="modal-card-head">
+      <p class="modal-card-title is-size-4 has-txt-value-number">Key Management</p>
+      <button
+        id="manage-keys-modal-close"
+        class="delete modal-card-close"
+        aria-label="close"
+      ></button>
+    </header>
+    <section id="manage-keys-modal-body" class="modal-card-body">
+    </section>
   </div>
 </div>

--- a/views/pages/license.handlebars
+++ b/views/pages/license.handlebars
@@ -1,204 +1,493 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/license-styles.css">
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/license-styles.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}{{/section}}
+
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
-
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
 {{/section}}
 
 <section class="section">
-    <div class="container">
-        <h1 class="title text-center">Community Use Policy</h1>
-        <p>
-            This website uses trademarks and/or copyrights owned by Paizo Publishing, LLC, which are used under Paizo's Community Use Policy. We are expressly prohibited from charging you to use or access this content. This website is not published, endorsed, or specifically approved by Paizo Publishing. For more information about Paizo's Community Use Policy, please visit paizo.com/communityuse. For more information about Paizo Publishing and Paizo products, please visit paizo.com.
-        </p>
-        <h1 class="title pt-4 text-center">Open Game License</h1>
-        <h2 class="subtitle text-center">Open Game License Version 1.0a</h2>
-        <p>
-            The following text is the property of Wizards of the Coast, Inc. and is Copyright 2000 Wizards of the Coast, Inc ("Wizards"). All Rights Reserved.
-        </p>
-        <p>
-            <strong>1. Definitions:</strong> (a)"Contributors" means the copyright and/or trademark owners who have contributed Open Game Content; (b)"Derivative Material" means copyrighted material including derivative works and translations (including into other computer languages), potation, modification, correction, addition, extension, upgrade, improvement, compilation, abridgment or other form in which an existing work may be recast, transformed or adapted; (c) "Distribute" means to reproduce, license, rent, lease, sell, broadcast, publicly display, transmit or otherwise distribute; (d)"Open Game Content" means the game mechanic and includes the methods, procedures, processes and routines to the extent such content does not embody the Product Identity and is an enhancement over the prior art and any additional content clearly identified as Open Game Content by the Contributor, and means any work covered by this License, including translations and derivative works under copyright law, but specifically excludes Product Identity. (e) "Product Identity" means product and product line names, logos and identifying marks including trade dress; artifacts; creatures characters; stories, storylines, plots, thematic elements, dialogue, incidents, language, artwork, symbols, designs, depictions, likenesses, formats, poses, concepts, themes and graphic, photographic and other visual or audio representations; names and descriptions of characters, spells, enchantments, personalities, teams, personas, likenesses and special abilities; places, locations, environments, creatures, equipment, magical or supernatural abilities or effects, logos, symbols, or graphic designs; and any other trademark or registered trademark clearly identified as Product identity by the owner of the Product Identity, and which specifically excludes the Open Game Content; (f) "Trademark" means the logos, names, mark, sign, motto, designs that are used by a Contributor to identify itself or its products or the associated products contributed to the Open Game License by the Contributor (g) "Use", "Used" or "Using" means to use, Distribute, copy, edit, format, modify, translate and otherwise create Derivative Material of Open Game Content. (h) "You" or "Your" means the licensee in terms of this agreement.
-        </p>
-        <p>
-            <strong>2. The License:</strong> This License applies to any Open Game Content that contains a notice indicating that the Open Game Content may only be Used under and in terms of this License. You must affix such a notice to any Open Game Content that you Use. No terms may be added to or subtracted from this License except as described by the License itself. No other terms or conditions may be applied to any Open Game Content distributed using this License.
-        </p>
-        <p>
-            <strong>3. Offer and Acceptance:</strong> By Using the Open Game Content You indicate Your acceptance of the terms of this License.
-        </p>
-        <p>
-            <strong>4. Grant and Consideration:</strong> In consideration for agreeing to use this License, the Contributors grant You a perpetual, worldwide, royalty-free, non-exclusive license with the exact terms of this License to Use, the Open Game Content.
-        </p>
-        <p>
-            <strong>5. Representation of Authority to Contribute:</strong> If You are contributing original material as Open Game Content, You represent that Your Contributions are Your original creation and/or You have sufficient rights to grant the rights conveyed by this License.
-        </p>
-        <p>
-            <strong>6. Notice of License Copyright:</strong> You must update the COPYRIGHT NOTICE portion of this License to include the exact text of the COPYRIGHT NOTICE of any Open Game Content You are copying, modifying or distributing, and You must add the title, the copyright date, and the copyright holder's name to the COPYRIGHT NOTICE of any original Open Game Content you Distribute.
-        </p>
-        <p>
-            <strong>7. Use of Product Identity:</strong> You agree not to Use any Product Identity, including as an indication as to compatibility, except as expressly licensed in another, independent Agreement with the owner of each element of that Product Identity. You agree not to indicate compatibility or co-adaptability with any Trademark or Registered Trademark in conjunction with a work containing Open Game Content except as expressly licensed in another, independent Agreement with the owner of such Trademark or Registered Trademark. The use of any Product Identity in Open Game Content does not constitute a challenge to the ownership of that Product Identity. The owner of any Product Identity used in Open Game Content shall retain all rights, title and interest in and to that Product Identity.
-        </p>
-        <p>
-            <strong>8. Identification:</strong> If you distribute Open Game Content You must clearly indicate which portions of the work that you are distributing are Open Game Content.
-        </p>
-        <p>
-            <strong>9. Updating the License:</strong> Wizards or its designated Agents may publish updated versions of this License. You may use any authorized version of this License to copy, modify and distribute any Open Game Content originally distributed under any version of this License.
-        </p>
-        <p>
-            <strong>10. Copy of this License:</strong> You MUST include a copy of this License with every copy of the Open Game Content You Distribute.
-        </p>
-        <p>
-            <strong>11. Use of Contributor Credits:</strong> You may not market or advertise the Open Game Content using the name of any Contributor unless You have written permission from the Contributor to do so.
-        </p>
-        <p>
-            <strong>12. Inability to Comply:</strong> If it is impossible for You to comply with any of the terms of this License with respect to some or all of the Open Game Content due to statute, judicial order, or governmental regulation then You may not Use any Open Game Material so affected.
-        </p>
-        <p>
-            <strong>13. Termination:</strong> This License will terminate automatically if You fail to comply with all terms herein and fail to cure such breach within 30 days of becoming aware of the breach. All sublicenses shall survive the termination of this License.
-        </p>
-        <p>
-            <strong>14. Reformation:</strong> If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable.
-        </p>
-        <p>
-            <strong>15. COPYRIGHT NOTICE</strong>
-        </p>
-        <p>
-            <strong>Open Game License v 1.0</strong> Copyright 2000, Wizards of the Coast, Inc.
-        </p>
-        <p>
-            <strong>System Reference Document.</strong> Copyright 2000. Wizards of the Coast, Inc; Authors: Jonathan Tweet, Monte Cook, Skip Williams, based on material by E. Gary Gygax and Dave Arneson.
-        </p>
-        
-        <div class="has-background-grey"><p class="has-text-weight-bold has-text-dark pl-3">Advanced Player's Guide</p></div>
-        <p><strong>Pathfinder Core Rulebook (Second Edition)</strong> © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.</p>
-        <p><strong>Genie, Marid from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Pathfinder Advanced Player’s Guide</strong> © 2020, Paizo Inc.; Authors: Amirali Attar Olyaee, Alexander Augunas, Kate Baker, Brian Bauman, Logan Bonner, Carlos Cabrera, James Case, Jessica Catalan, John Compton, Paris Crenshaw, Jesse Decker, Fabby Garza Marroquín, Steven Hammond, Sasha Laranoa Harving, Joan Hong, Nicolas Hornyak, Vanessa Hoskins, James Jacobs, Erik Keith, Lyz Liddell, Luis Loza, Ron Lundeen, Patchen Mortimer, Dennis Muldoon, Stephen Radney-MacFarland, Jessica Redekop, Mikhail Rekun, Alex Riggs, David N. Ross, Michael Sayre, Mark Seifter, Kendra Leigh Speedling, Jason Tondro, Clark Valentine, and Andrew White.</p>
+  <div class="container">
+    <h1 class="title text-center">Community Use Policy</h1>
+    <p>
+      This website uses trademarks and/or copyrights owned by Paizo Publishing,
+      LLC, which are used under Paizo's Community Use Policy. We are expressly
+      prohibited from charging you to use or access this content. This website
+      is not published, endorsed, or specifically approved by Paizo Publishing.
+      For more information about Paizo's Community Use Policy, please visit
+      paizo.com/communityuse. For more information about Paizo Publishing and
+      Paizo products, please visit paizo.com.
+    </p>
+    <h1 class="title pt-4 text-center">Open Game License</h1>
+    <h2 class="subtitle text-center">Open Game License Version 1.0a</h2>
+    <p>
+      The following text is the property of Wizards of the Coast, Inc. and is
+      Copyright 2000 Wizards of the Coast, Inc ("Wizards"). All Rights Reserved.
+    </p>
+    <p>
+      <strong>1. Definitions:</strong>
+      (a)"Contributors" means the copyright and/or trademark owners who have
+      contributed Open Game Content; (b)"Derivative Material" means copyrighted
+      material including derivative works and translations (including into other
+      computer languages), potation, modification, correction, addition,
+      extension, upgrade, improvement, compilation, abridgment or other form in
+      which an existing work may be recast, transformed or adapted; (c)
+      "Distribute" means to reproduce, license, rent, lease, sell, broadcast,
+      publicly display, transmit or otherwise distribute; (d)"Open Game Content"
+      means the game mechanic and includes the methods, procedures, processes
+      and routines to the extent such content does not embody the Product
+      Identity and is an enhancement over the prior art and any additional
+      content clearly identified as Open Game Content by the Contributor, and
+      means any work covered by this License, including translations and
+      derivative works under copyright law, but specifically excludes Product
+      Identity. (e) "Product Identity" means product and product line names,
+      logos and identifying marks including trade dress; artifacts; creatures
+      characters; stories, storylines, plots, thematic elements, dialogue,
+      incidents, language, artwork, symbols, designs, depictions, likenesses,
+      formats, poses, concepts, themes and graphic, photographic and other
+      visual or audio representations; names and descriptions of characters,
+      spells, enchantments, personalities, teams, personas, likenesses and
+      special abilities; places, locations, environments, creatures, equipment,
+      magical or supernatural abilities or effects, logos, symbols, or graphic
+      designs; and any other trademark or registered trademark clearly
+      identified as Product identity by the owner of the Product Identity, and
+      which specifically excludes the Open Game Content; (f) "Trademark" means
+      the logos, names, mark, sign, motto, designs that are used by a
+      Contributor to identify itself or its products or the associated products
+      contributed to the Open Game License by the Contributor (g) "Use", "Used"
+      or "Using" means to use, Distribute, copy, edit, format, modify, translate
+      and otherwise create Derivative Material of Open Game Content. (h) "You"
+      or "Your" means the licensee in terms of this agreement.
+    </p>
+    <p>
+      <strong>2. The License:</strong>
+      This License applies to any Open Game Content that contains a notice
+      indicating that the Open Game Content may only be Used under and in terms
+      of this License. You must affix such a notice to any Open Game Content
+      that you Use. No terms may be added to or subtracted from this License
+      except as described by the License itself. No other terms or conditions
+      may be applied to any Open Game Content distributed using this License.
+    </p>
+    <p>
+      <strong>3. Offer and Acceptance:</strong>
+      By Using the Open Game Content You indicate Your acceptance of the terms
+      of this License.
+    </p>
+    <p>
+      <strong>4. Grant and Consideration:</strong>
+      In consideration for agreeing to use this License, the Contributors grant
+      You a perpetual, worldwide, royalty-free, non-exclusive license with the
+      exact terms of this License to Use, the Open Game Content.
+    </p>
+    <p>
+      <strong>5. Representation of Authority to Contribute:</strong>
+      If You are contributing original material as Open Game Content, You
+      represent that Your Contributions are Your original creation and/or You
+      have sufficient rights to grant the rights conveyed by this License.
+    </p>
+    <p>
+      <strong>6. Notice of License Copyright:</strong>
+      You must update the COPYRIGHT NOTICE portion of this License to include
+      the exact text of the COPYRIGHT NOTICE of any Open Game Content You are
+      copying, modifying or distributing, and You must add the title, the
+      copyright date, and the copyright holder's name to the COPYRIGHT NOTICE of
+      any original Open Game Content you Distribute.
+    </p>
+    <p>
+      <strong>7. Use of Product Identity:</strong>
+      You agree not to Use any Product Identity, including as an indication as
+      to compatibility, except as expressly licensed in another, independent
+      Agreement with the owner of each element of that Product Identity. You
+      agree not to indicate compatibility or co-adaptability with any Trademark
+      or Registered Trademark in conjunction with a work containing Open Game
+      Content except as expressly licensed in another, independent Agreement
+      with the owner of such Trademark or Registered Trademark. The use of any
+      Product Identity in Open Game Content does not constitute a challenge to
+      the ownership of that Product Identity. The owner of any Product Identity
+      used in Open Game Content shall retain all rights, title and interest in
+      and to that Product Identity.
+    </p>
+    <p>
+      <strong>8. Identification:</strong>
+      If you distribute Open Game Content You must clearly indicate which
+      portions of the work that you are distributing are Open Game Content.
+    </p>
+    <p>
+      <strong>9. Updating the License:</strong>
+      Wizards or its designated Agents may publish updated versions of this
+      License. You may use any authorized version of this License to copy,
+      modify and distribute any Open Game Content originally distributed under
+      any version of this License.
+    </p>
+    <p>
+      <strong>10. Copy of this License:</strong>
+      You MUST include a copy of this License with every copy of the Open Game
+      Content You Distribute.
+    </p>
+    <p>
+      <strong>11. Use of Contributor Credits:</strong>
+      You may not market or advertise the Open Game Content using the name of
+      any Contributor unless You have written permission from the Contributor to
+      do so.
+    </p>
+    <p>
+      <strong>12. Inability to Comply:</strong>
+      If it is impossible for You to comply with any of the terms of this
+      License with respect to some or all of the Open Game Content due to
+      statute, judicial order, or governmental regulation then You may not Use
+      any Open Game Material so affected.
+    </p>
+    <p>
+      <strong>13. Termination:</strong>
+      This License will terminate automatically if You fail to comply with all
+      terms herein and fail to cure such breach within 30 days of becoming aware
+      of the breach. All sublicenses shall survive the termination of this
+      License.
+    </p>
+    <p>
+      <strong>14. Reformation:</strong>
+      If any provision of this License is held to be unenforceable, such
+      provision shall be reformed only to the extent necessary to make it
+      enforceable.
+    </p>
+    <p>
+      <strong>15. COPYRIGHT NOTICE</strong>
+    </p>
+    <p>
+      <strong>Open Game License v 1.0</strong>
+      Copyright 2000, Wizards of the Coast, Inc.
+    </p>
+    <p>
+      <strong>System Reference Document.</strong>
+      Copyright 2000. Wizards of the Coast, Inc; Authors: Jonathan Tweet, Monte
+      Cook, Skip Williams, based on material by E. Gary Gygax and Dave Arneson.
+    </p>
 
-        <div class="has-background-grey"><p class="has-text-weight-bold has-text-dark pl-3">Age of Ashes Player's Guide</p></div>
-        <p><strong>Age of Ashes Player’s Guide</strong> © 2019, Paizo Inc.; Authors: James Jacobs, with Amanda Hamon.</p>
+    <div class="has-background-grey"><p
+        class="has-text-weight-bold has-text-dark pl-3"
+      >Advanced Player's Guide</p></div>
+    <p><strong>Pathfinder Core Rulebook (Second Edition)</strong>
+      © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen
+      Radney-MacFarland, and Mark Seifter.</p>
+    <p><strong>Genie, Marid from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Pathfinder Advanced Player’s Guide</strong>
+      © 2020, Paizo Inc.; Authors: Amirali Attar Olyaee, Alexander Augunas, Kate
+      Baker, Brian Bauman, Logan Bonner, Carlos Cabrera, James Case, Jessica
+      Catalan, John Compton, Paris Crenshaw, Jesse Decker, Fabby Garza
+      Marroquín, Steven Hammond, Sasha Laranoa Harving, Joan Hong, Nicolas
+      Hornyak, Vanessa Hoskins, James Jacobs, Erik Keith, Lyz Liddell, Luis
+      Loza, Ron Lundeen, Patchen Mortimer, Dennis Muldoon, Stephen
+      Radney-MacFarland, Jessica Redekop, Mikhail Rekun, Alex Riggs, David N.
+      Ross, Michael Sayre, Mark Seifter, Kendra Leigh Speedling, Jason Tondro,
+      Clark Valentine, and Andrew White.</p>
 
-        <div class="has-background-grey"><p class="has-text-weight-bold has-text-dark pl-3">Agents of Edgewatch Player's Guide</p></div>
-        <p><strong>Pathfinder Core Rulebook (Second Edition)</strong> © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.</p>
-        <p><strong>Agents of Edgewatch Player's Guide</strong> © 2020, Paizo Inc.; Author: Patrick Renie.</p>
+    <div class="has-background-grey"><p
+        class="has-text-weight-bold has-text-dark pl-3"
+      >Age of Ashes Player's Guide</p></div>
+    <p><strong>Age of Ashes Player’s Guide</strong>
+      © 2019, Paizo Inc.; Authors: James Jacobs, with Amanda Hamon.</p>
 
-        <div class="has-background-grey"><p class="has-text-weight-bold has-text-dark pl-3">Bestiary</p></div>
-        <p><strong>Daemon, Guardian from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.</p>
-        <p><strong>Dark Creeper from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Rik Shepard.</p>
-        <p><strong>Dark Stalker from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.</p>
-        <p><strong>Dragon, Faerie from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Brian Jaeger and Gary Gygax.</p>
-        <p><strong>Genie, Marid from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Mite from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian Livingstone and Mark Barnes.</p>
-        <p><strong>Pathfinder Bestiary (Second Edition)</strong> © 2019, Paizo Inc.; Authors: Alexander Augunas, Logan Bonner, Jason Bulmahn, John Compton, Paris Crenshaw, Adam Daigle, Eleanor Ferron, Leo Glass, Thurston Hillman, James Jacobs, Jason Keeley, Lyz Liddell, Ron Lundeen, Robert G. McCreary, Tim Nightengale, Stephen Radney-MacFarland, Alex Riggs, David N. Ross, Michael Sayre, Mark Seifter, Chris S. Sims, Jeffrey Swank, Jason Tondro, Tonya Woldridge, and Linda Zayas-Palmer.</p>
+    <div class="has-background-grey"><p
+        class="has-text-weight-bold has-text-dark pl-3"
+      >Agents of Edgewatch Player's Guide</p></div>
+    <p><strong>Pathfinder Core Rulebook (Second Edition)</strong>
+      © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen
+      Radney-MacFarland, and Mark Seifter.</p>
+    <p><strong>Agents of Edgewatch Player's Guide</strong>
+      © 2020, Paizo Inc.; Author: Patrick Renie.</p>
 
-        <div class="has-background-grey"><p class="has-text-weight-bold has-text-dark pl-3">Bestiary 2</p></div>
-        <p><strong>Angel, Monadic Deva from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Aurumvorax from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Basidirond from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Blindheim from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Roger Musson.</p>
-        <p><strong>The Book of Fiends</strong> © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.</p>
-        <p><strong>Armies of the Abyss</strong> © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.</p>
-        <p><strong>The Avatar's Handbook</strong> © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.</p>
-        <p><strong>Book of the Righteous</strong> © 2002, Aaron Loeb.</p>
-        <p><strong>Legions of Hell</strong> © 2001, Green Ronin Publishing; Author: Chris Pramas.</p>
-        <p><strong>The Unholy Warrior's Handbook</strong> © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.</p>
-        <p><strong>Carbuncle from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.</p>
-        <p><strong>Cave Fisher from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Lawrence Schick.</p>
-        <p><strong>Daemon, Derghodaemon from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Daemon, Piscodaemon from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Dark Creeper from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Rik Shepard.</p>
-        <p><strong>Dark Stalker from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.</p>
-        <p><strong>Demon, Nabasu from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Demon, Shadow from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Neville White.</p>
-        <p><strong>Dracolisk from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Froghemoth from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Genie, Marid from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Grippli from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Korred from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Necrophidius from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Tillbrook.</p>
-        <p><strong>Nereid from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Quickling from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Quickwood from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Scythe Tree from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene.</p>
-        <p><strong>Skulk from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.</p>
-        <p><strong>Soul Eater from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by David Cook.</p>
-        <p><strong>Troll, Two-Headed from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Oliver Charles MacDonald.</p>
-        <p><strong>Yellow Musk Creeper from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.</p>
-        <p><strong>Yellow Musk Zombie from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.</p>
-        <p><strong>Pathfinder Core Rulebook (Second Edition)</strong> © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.</p>
-        <p><strong>Pathfinder Bestiary 2 (Second Edition)</strong> © 2020, Paizo Inc.; Authors: Alexander Augunas, Dennis Baker, Jesse Benner, Joseph Blomquist, Logan Bonner, Paris Crenshaw, Adam Daigle, Jesse Decker, Darrin Drader, Brian Duckwitz, Robert N. Emerson, Scott Fernandez, Keith Garrett, Scott Gladstein, Matthew Goodall, T.H. Gulliver, BJ Hensley, Tim Hitchcock, Vanessa Hoskins, James Jacobs, Brian R. James, Jason Keeley, John Laffan, Lyz Liddell, Colm Lundberg, Ron Lundeen, Jason Nelson, Randy Price, Jessica Redekop, Patrick Renie, Alistair Rigg, Alex Riggs, David N. Ross, David Schwartz, Mark Seifter, Amber Stewart, Jeffrey Swank, Russ Taylor, and Jason Tondro.</p>
+    <div class="has-background-grey"><p
+        class="has-text-weight-bold has-text-dark pl-3"
+      >Bestiary</p></div>
+    <p><strong>Daemon, Guardian from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Ian McDowall.</p>
+    <p><strong>Dark Creeper from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Rik Shepard.</p>
+    <p><strong>Dark Stalker from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Simon Muth.</p>
+    <p><strong>Dragon, Faerie from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Brian Jaeger
+      and Gary Gygax.</p>
+    <p><strong>Genie, Marid from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Mite from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Ian Livingstone
+      and Mark Barnes.</p>
+    <p><strong>Pathfinder Bestiary (Second Edition)</strong>
+      © 2019, Paizo Inc.; Authors: Alexander Augunas, Logan Bonner, Jason
+      Bulmahn, John Compton, Paris Crenshaw, Adam Daigle, Eleanor Ferron, Leo
+      Glass, Thurston Hillman, James Jacobs, Jason Keeley, Lyz Liddell, Ron
+      Lundeen, Robert G. McCreary, Tim Nightengale, Stephen Radney-MacFarland,
+      Alex Riggs, David N. Ross, Michael Sayre, Mark Seifter, Chris S. Sims,
+      Jeffrey Swank, Jason Tondro, Tonya Woldridge, and Linda Zayas-Palmer.</p>
 
-        <div class="has-background-grey"><p class="has-text-weight-bold has-text-dark pl-3">Core Rulebook</p></div>
-        <p><strong>Pathfinder Core Rulebook (Second Edition)</strong> © 2019, Paizo Inc.; Designers: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.</p>
+    <div class="has-background-grey"><p
+        class="has-text-weight-bold has-text-dark pl-3"
+      >Bestiary 2</p></div>
+    <p><strong>Angel, Monadic Deva from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Aurumvorax from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Basidirond from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Blindheim from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Roger Musson.</p>
+    <p><strong>The Book of Fiends</strong>
+      © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris
+      Pramas, and Robert J. Schwalb.</p>
+    <p><strong>Armies of the Abyss</strong>
+      © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.</p>
+    <p><strong>The Avatar's Handbook</strong>
+      © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.</p>
+    <p><strong>Book of the Righteous</strong> © 2002, Aaron Loeb.</p>
+    <p><strong>Legions of Hell</strong>
+      © 2001, Green Ronin Publishing; Author: Chris Pramas.</p>
+    <p><strong>The Unholy Warrior's Handbook</strong>
+      © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.</p>
+    <p><strong>Carbuncle from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Albie Fiore.</p>
+    <p><strong>Cave Fisher from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Lawrence
+      Schick.</p>
+    <p><strong>Daemon, Derghodaemon from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Daemon, Piscodaemon from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Dark Creeper from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Rik Shepard.</p>
+    <p><strong>Dark Stalker from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Simon Muth.</p>
+    <p><strong>Demon, Nabasu from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Demon, Shadow from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Neville White.</p>
+    <p><strong>Dracolisk from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Froghemoth from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Genie, Marid from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Grippli from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Korred from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Necrophidius from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Simon
+      Tillbrook.</p>
+    <p><strong>Nereid from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Quickling from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Quickwood from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Scythe Tree from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene.</p>
+    <p><strong>Skulk from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Simon Muth.</p>
+    <p><strong>Soul Eater from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by David Cook.</p>
+    <p><strong>Troll, Two-Headed from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Oliver Charles
+      MacDonald.</p>
+    <p><strong>Yellow Musk Creeper from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Albie Fiore.</p>
+    <p><strong>Yellow Musk Zombie from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Albie Fiore.</p>
+    <p><strong>Pathfinder Core Rulebook (Second Edition)</strong>
+      © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen
+      Radney-MacFarland, and Mark Seifter.</p>
+    <p><strong>Pathfinder Bestiary 2 (Second Edition)</strong>
+      © 2020, Paizo Inc.; Authors: Alexander Augunas, Dennis Baker, Jesse
+      Benner, Joseph Blomquist, Logan Bonner, Paris Crenshaw, Adam Daigle, Jesse
+      Decker, Darrin Drader, Brian Duckwitz, Robert N. Emerson, Scott Fernandez,
+      Keith Garrett, Scott Gladstein, Matthew Goodall, T.H. Gulliver, BJ
+      Hensley, Tim Hitchcock, Vanessa Hoskins, James Jacobs, Brian R. James,
+      Jason Keeley, John Laffan, Lyz Liddell, Colm Lundberg, Ron Lundeen, Jason
+      Nelson, Randy Price, Jessica Redekop, Patrick Renie, Alistair Rigg, Alex
+      Riggs, David N. Ross, David Schwartz, Mark Seifter, Amber Stewart, Jeffrey
+      Swank, Russ Taylor, and Jason Tondro.</p>
 
-        <div class="has-background-grey"><p class="has-text-weight-bold has-text-dark pl-3">Extinction Curse Player's Guide</p></div>
-        <p><strong>Pathfinder Core Rulebook (Second Edition)</strong> © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.</p>
-        <p><strong>Extinction Curse Player’s Guide</strong> © 2020, Paizo Inc.; Author: Ron Lundeen.</p>
+    <div class="has-background-grey"><p
+        class="has-text-weight-bold has-text-dark pl-3"
+      >Core Rulebook</p></div>
+    <p><strong>Pathfinder Core Rulebook (Second Edition)</strong>
+      © 2019, Paizo Inc.; Designers: Logan Bonner, Jason Bulmahn, Stephen
+      Radney-MacFarland, and Mark Seifter.</p>
 
-        <div class="has-background-grey"><p class="has-text-weight-bold has-text-dark pl-3">Gamemastery Guide</p></div>
-        <p><strong>Pathfinder Core Rulebook (Second Edition)</strong> © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.</p>
-        <p><strong>Pathfinder Adventure Path #152: Legacy of the Lost God</strong> © 2020, Paizo Inc.; Authors: Jenny Jarzabski, with Stephen Glicker, Luis Loza, Ron Lundeen, Andrew Mullen, and David N. Ross.</p>
+    <div class="has-background-grey"><p
+        class="has-text-weight-bold has-text-dark pl-3"
+      >Extinction Curse Player's Guide</p></div>
+    <p><strong>Pathfinder Core Rulebook (Second Edition)</strong>
+      © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen
+      Radney-MacFarland, and Mark Seifter.</p>
+    <p><strong>Extinction Curse Player’s Guide</strong>
+      © 2020, Paizo Inc.; Author: Ron Lundeen.</p>
 
-        <div class="has-background-grey"><p class="has-text-weight-bold has-text-dark pl-3">Lost Omens Character Guide</p></div>
-        <p><strong>Genie, Marid from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Pathfinder Lost Omens Character Guide (Second Edition)</strong> © 2019, Paizo Inc.; Authors: John Compton, Sasha Lindley Hall, Amanda Hamon, Mike Kimmel, Luis Loza, Ron Lundeen, Matt Morris, Patchen Mortimer, Andrew Mullen, Mikhail Rekun, Micheal Sayre, Owen K.C. Stephens, Isabelle Thorne, and Linda Zayas-Palmer.</p>
+    <div class="has-background-grey"><p
+        class="has-text-weight-bold has-text-dark pl-3"
+      >Gamemastery Guide</p></div>
+    <p><strong>Pathfinder Core Rulebook (Second Edition)</strong>
+      © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen
+      Radney-MacFarland, and Mark Seifter.</p>
+    <p><strong>Pathfinder Adventure Path #152: Legacy of the Lost God</strong>
+      © 2020, Paizo Inc.; Authors: Jenny Jarzabski, with Stephen Glicker, Luis
+      Loza, Ron Lundeen, Andrew Mullen, and David N. Ross.</p>
 
-        <div class="has-background-grey"><p class="has-text-weight-bold has-text-dark pl-3">Lost Omens Gods & Magic</p></div>
-        <p><strong>Genie, Marid from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Pathfinder Lost Omens Gods & Magic (Second Edition)</strong> © 2020, Paizo Inc.; Authors: Robert Adducci, Amirali Attar Olyaee, Calder CaDavid, James Case, Adam Daigle, Katina Davis, Leo Glass, Joshua Grinlinton, James Jacobs, Virginia Jordan, Jason Keeley, Jacky Leung, Lyz Liddell, Ron Lundeen, Stephanie Lundeen, Jacob W. Michaels, Matt Morris, Dave Nelson, Samantha Phelan, Jennifer Povey, Jessica Redekop, Nathan Reinecke, Patrick Renie, David N. Ross, Simone D. Sallé, Michael Sayre, David Schwartz, Shahreena Shahrani, Isabelle Thorne, Marc Thuot, Jason Tondro, and Diego Valdez.</p>
+    <div class="has-background-grey"><p
+        class="has-text-weight-bold has-text-dark pl-3"
+      >Lost Omens Character Guide</p></div>
+    <p><strong>Genie, Marid from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Pathfinder Lost Omens Character Guide (Second Edition)</strong>
+      © 2019, Paizo Inc.; Authors: John Compton, Sasha Lindley Hall, Amanda
+      Hamon, Mike Kimmel, Luis Loza, Ron Lundeen, Matt Morris, Patchen Mortimer,
+      Andrew Mullen, Mikhail Rekun, Micheal Sayre, Owen K.C. Stephens, Isabelle
+      Thorne, and Linda Zayas-Palmer.</p>
 
-        <div class="has-background-grey"><p class="has-text-weight-bold has-text-dark pl-3">Lost Omens Legends</p></div>
-        <p><strong>Genie, Marid from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Pathfinder Core Rulebook (Second Edition)</strong> © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.</p>
-        <p><strong>Pathfinder Lost Omens Legends</strong> © 2020, Paizo Inc.; Authors: Alexander Augunas, Kate Baker, Jason Bulmahn, Alexandria Bustion, Carlos Cabrera, Calder CaDavid, Jessica Catalan, Natalie Collazo, Ryan Costello, Greg Diaz, Fabby Garza Marroquín, Jaym Gates, Alice Grizzle, Steven Hammond, Nicolas Hornyak, James Jacobs, Michelle Jones, Kristina Sisto Kindel, Aaron Lascano, Ron Lundeen, Stephanie Lundeen, Sydney Meeker, Liane Merciel, Matt Morris, Patchen Mortimer, Hilary Moon Murphy, Dennis Muldoon, Andrew Mullen, Amirali Attar Olyaee, Mikhail Rekun, Michael Sayre, Mark Seifter, Ashton Sperry, Owen K.C. Stephens, and Isabelle Thorne</p>
+    <div class="has-background-grey"><p
+        class="has-text-weight-bold has-text-dark pl-3"
+      >Lost Omens Gods & Magic</p></div>
+    <p><strong>Genie, Marid from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Pathfinder Lost Omens Gods & Magic (Second Edition)</strong>
+      © 2020, Paizo Inc.; Authors: Robert Adducci, Amirali Attar Olyaee, Calder
+      CaDavid, James Case, Adam Daigle, Katina Davis, Leo Glass, Joshua
+      Grinlinton, James Jacobs, Virginia Jordan, Jason Keeley, Jacky Leung, Lyz
+      Liddell, Ron Lundeen, Stephanie Lundeen, Jacob W. Michaels, Matt Morris,
+      Dave Nelson, Samantha Phelan, Jennifer Povey, Jessica Redekop, Nathan
+      Reinecke, Patrick Renie, David N. Ross, Simone D. Sallé, Michael Sayre,
+      David Schwartz, Shahreena Shahrani, Isabelle Thorne, Marc Thuot, Jason
+      Tondro, and Diego Valdez.</p>
 
-        <div class="has-background-grey"><p class="has-text-weight-bold has-text-dark pl-3">Lost Omens World Guide</p></div>
-        <p><strong>Genie, Marid from the Tome of Horrors Complete</strong> © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
-        <p><strong>Pathfinder Lost Omens World Guide (Second Edition)</strong> © 2019, Paizo Inc.; Authors: Tanya DePass, James Jacobs, Lyz Liddell, Ron Lundeen, Liane Merciel, Erik Mona, Mark Seifter, James L. Sutter.</p>
+    <div class="has-background-grey"><p
+        class="has-text-weight-bold has-text-dark pl-3"
+      >Lost Omens Legends</p></div>
+    <p><strong>Genie, Marid from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Pathfinder Core Rulebook (Second Edition)</strong>
+      © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen
+      Radney-MacFarland, and Mark Seifter.</p>
+    <p><strong>Pathfinder Lost Omens Legends</strong>
+      © 2020, Paizo Inc.; Authors: Alexander Augunas, Kate Baker, Jason Bulmahn,
+      Alexandria Bustion, Carlos Cabrera, Calder CaDavid, Jessica Catalan,
+      Natalie Collazo, Ryan Costello, Greg Diaz, Fabby Garza Marroquín, Jaym
+      Gates, Alice Grizzle, Steven Hammond, Nicolas Hornyak, James Jacobs,
+      Michelle Jones, Kristina Sisto Kindel, Aaron Lascano, Ron Lundeen,
+      Stephanie Lundeen, Sydney Meeker, Liane Merciel, Matt Morris, Patchen
+      Mortimer, Hilary Moon Murphy, Dennis Muldoon, Andrew Mullen, Amirali Attar
+      Olyaee, Mikhail Rekun, Michael Sayre, Mark Seifter, Ashton Sperry, Owen
+      K.C. Stephens, and Isabelle Thorne</p>
 
+    <div class="has-background-grey"><p
+        class="has-text-weight-bold has-text-dark pl-3"
+      >Lost Omens World Guide</p></div>
+    <p><strong>Genie, Marid from the Tome of Horrors Complete</strong>
+      © 2011, Necromancer Games, Inc., published and distributed by Frog God
+      Games; Author: Scott Greene, based on original material by Gary Gygax.</p>
+    <p><strong>Pathfinder Lost Omens World Guide (Second Edition)</strong>
+      © 2019, Paizo Inc.; Authors: Tanya DePass, James Jacobs, Lyz Liddell, Ron
+      Lundeen, Liane Merciel, Erik Mona, Mark Seifter, James L. Sutter.</p>
 
-        <div class="has-background-grey"><p class="has-text-weight-bold has-text-dark pl-3">The Fall of Plaguestone</p></div>
-        <p><strong>Pathfinder Adventure: The Fall of Plaguestone</strong> © 2019, Paizo Inc.; Author: Jason Bulmahn.</p>
+    <div class="has-background-grey"><p
+        class="has-text-weight-bold has-text-dark pl-3"
+      >The Fall of Plaguestone</p></div>
+    <p><strong>Pathfinder Adventure: The Fall of Plaguestone</strong>
+      © 2019, Paizo Inc.; Author: Jason Bulmahn.</p>
 
-        <div class="has-background-grey"><p class="has-text-weight-bold has-text-dark pl-3">The Slithering</p></div>
-        <p><strong>Pathfinder Core Rulebook (Second Edition)</strong> © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.</p>
-        <p><strong>Pathfinder Adventure: The Slithering</strong> © 2020, Paizo Inc.; Author: Ron Lundeen.</p>
+    <div class="has-background-grey"><p
+        class="has-text-weight-bold has-text-dark pl-3"
+      >The Slithering</p></div>
+    <p><strong>Pathfinder Core Rulebook (Second Edition)</strong>
+      © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen
+      Radney-MacFarland, and Mark Seifter.</p>
+    <p><strong>Pathfinder Adventure: The Slithering</strong>
+      © 2020, Paizo Inc.; Author: Ron Lundeen.</p>
 
-        <div class="has-background-grey"><p class="has-text-weight-bold has-text-dark pl-3">Troubles in Otari</p></div>
-        <p><strong>Pathfinder Core Rulebook (Second Edition)</strong> © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.</p>
-        <p><strong>Pathfinder Adventure: Troubles in Otari</strong> © 2020, Paizo Inc.; Authors: Jason Keeley, Lyz Liddell, and Ron Lundeen.</p>
+    <div class="has-background-grey"><p
+        class="has-text-weight-bold has-text-dark pl-3"
+      >Troubles in Otari</p></div>
+    <p><strong>Pathfinder Core Rulebook (Second Edition)</strong>
+      © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen
+      Radney-MacFarland, and Mark Seifter.</p>
+    <p><strong>Pathfinder Adventure: Troubles in Otari</strong>
+      © 2020, Paizo Inc.; Authors: Jason Keeley, Lyz Liddell, and Ron Lundeen.</p>
 
-        <p><strong>Battlezoo Bestiary</strong> © 2021, Skyscraper Studios, Inc.; Authors: Stephen Glicker, Patrick Renie, and Mark Seifter.</p>
+    <p><strong>Battlezoo Bestiary</strong>
+      © 2021, Skyscraper Studios, Inc.; Authors: Stephen Glicker, Patrick Renie,
+      and Mark Seifter.</p>
 
-    </div>
+  </div>
 </section>

--- a/views/pages/login.handlebars
+++ b/views/pages/login.handlebars
@@ -1,69 +1,97 @@
-
-{{#section 'header'}}
-      <!-- Login Options -->
-	<link href="/css/login-options.css" rel="stylesheet">
-    <style>
-		.banner_w3lspvt-1 {
-			background-image: url('../images/login_back.jpg');
-		}
-	</style>
+{{#section "styles"}}
+  <!-- Login Options -->
+  <link href="/css/login-options.css" rel="stylesheet" />
+  <style>
+    .banner_w3lspvt-1 { background-image: url('../images/login_back.jpg'); }
+  </style>
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}{{/section}}
+
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login" class="active">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login" class="active">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
-
-
-{{#section 'banner_nav'}}
-    
-{{/section}}
+{{#section "banner_nav"}}{{/section}}
 
 <div class="banner_w3lspvt-1">
-    <div class="columns is-mobile is-centered">
-        <div class="column is-narrow login-container">
-            <button type="button" onclick="window.location.href='/auth/google'" class="google-button mx-1">
-                <span class="google-button__icon">
-                    <svg viewBox="0 0 366 372" xmlns="http://www.w3.org/2000/svg"><path d="M125.9 10.2c40.2-13.9 85.3-13.6 125.3 1.1 22.2 8.2 42.5 21 59.9 37.1-5.8 6.3-12.1 12.2-18.1 18.3l-34.2 34.2c-11.3-10.8-25.1-19-40.1-23.6-17.6-5.3-36.6-6.1-54.6-2.2-21 4.5-40.5 15.5-55.6 30.9-12.2 12.3-21.4 27.5-27 43.9-20.3-15.8-40.6-31.5-61-47.3 21.5-43 60.1-76.9 105.4-92.4z" id="Shape" fill="#EA4335"/><path d="M20.6 102.4c20.3 15.8 40.6 31.5 61 47.3-8 23.3-8 49.2 0 72.4-20.3 15.8-40.6 31.6-60.9 47.3C1.9 232.7-3.8 189.6 4.4 149.2c3.3-16.2 8.7-32 16.2-46.8z" id="Shape" fill="#FBBC05"/><path d="M361.7 151.1c5.8 32.7 4.5 66.8-4.7 98.8-8.5 29.3-24.6 56.5-47.1 77.2l-59.1-45.9c19.5-13.1 33.3-34.3 37.2-57.5H186.6c.1-24.2.1-48.4.1-72.6h175z" id="Shape" fill="#4285F4"/><path d="M81.4 222.2c7.8 22.9 22.8 43.2 42.6 57.1 12.4 8.7 26.6 14.9 41.4 17.9 14.6 3 29.7 2.6 44.4.1 14.6-2.6 28.7-7.9 41-16.2l59.1 45.9c-21.3 19.7-48 33.1-76.2 39.6-31.2 7.1-64.2 7.3-95.2-1-24.6-6.5-47.7-18.2-67.6-34.1-20.9-16.6-38.3-38-50.4-62 20.3-15.7 40.6-31.5 60.9-47.3z" fill="#34A853"/></svg>
-                </span>
-                <span class="google-button__text is-unselectable">Sign in with Google</span>
-            </button>
+  <div class="columns is-mobile is-centered">
+    <div class="column is-narrow login-container">
+      <button
+        type="button"
+        onclick="window.location.href='/auth/google'"
+        class="google-button mx-1"
+      >
+        <span class="google-button__icon">
+          <svg viewBox="0 0 366 372" xmlns="http://www.w3.org/2000/svg"><path
+              d="M125.9 10.2c40.2-13.9 85.3-13.6 125.3 1.1 22.2 8.2 42.5 21 59.9 37.1-5.8 6.3-12.1 12.2-18.1 18.3l-34.2 34.2c-11.3-10.8-25.1-19-40.1-23.6-17.6-5.3-36.6-6.1-54.6-2.2-21 4.5-40.5 15.5-55.6 30.9-12.2 12.3-21.4 27.5-27 43.9-20.3-15.8-40.6-31.5-61-47.3 21.5-43 60.1-76.9 105.4-92.4z"
+              id="Shape"
+              fill="#EA4335"
+            /><path
+              d="M20.6 102.4c20.3 15.8 40.6 31.5 61 47.3-8 23.3-8 49.2 0 72.4-20.3 15.8-40.6 31.6-60.9 47.3C1.9 232.7-3.8 189.6 4.4 149.2c3.3-16.2 8.7-32 16.2-46.8z"
+              id="Shape"
+              fill="#FBBC05"
+            /><path
+              d="M361.7 151.1c5.8 32.7 4.5 66.8-4.7 98.8-8.5 29.3-24.6 56.5-47.1 77.2l-59.1-45.9c19.5-13.1 33.3-34.3 37.2-57.5H186.6c.1-24.2.1-48.4.1-72.6h175z"
+              id="Shape"
+              fill="#4285F4"
+            /><path
+              d="M81.4 222.2c7.8 22.9 22.8 43.2 42.6 57.1 12.4 8.7 26.6 14.9 41.4 17.9 14.6 3 29.7 2.6 44.4.1 14.6-2.6 28.7-7.9 41-16.2l59.1 45.9c-21.3 19.7-48 33.1-76.2 39.6-31.2 7.1-64.2 7.3-95.2-1-24.6-6.5-47.7-18.2-67.6-34.1-20.9-16.6-38.3-38-50.4-62 20.3-15.7 40.6-31.5 60.9-47.3z"
+              fill="#34A853"
+            /></svg>
+        </span>
+        <span class="google-button__text is-unselectable">Sign in with Google</span>
+      </button>
 
-            <button class="button is-light mx-1" onclick="window.location.href='/auth/reddit'">
-              <span class="icon">
-                <i class="fab fa-lg fa-reddit"></i>
-              </span>
-              <span class="google-button__text is-unselectable" style="padding: 0px 10px;">Sign in with Reddit</span>
-            </button>
+      <button
+        class="button is-light mx-1"
+        onclick="window.location.href='/auth/reddit'"
+      >
+        <span class="icon">
+          <i class="fab fa-lg fa-reddit"></i>
+        </span>
+        <span
+          class="google-button__text is-unselectable"
+          style="padding: 0px 10px;"
+        >Sign in with Reddit</span>
+      </button>
 
-            <p class="pt-3" style="color: hsl(0, 0%, 81%);">
-                Please sign in with Google or Reddit to login/register.
-            </p>
-        </div>
+      <p class="pt-3" style="color: hsl(0, 0%, 81%);">
+        Please sign in with Google or Reddit to login/register.
+      </p>
     </div>
-    <a class="banner-1-artist" rel="author"><span class="icon"><i class="fas fa-paint-brush"></i></span> <span>Unknown</span></a>
+  </div>
+  <a class="banner-1-artist" rel="author"><span class="icon"><i
+        class="fas fa-paint-brush"
+      ></i></span>
+    <span>Unknown</span></a>
 </div>

--- a/views/pages/material_stats.handlebars
+++ b/views/pages/material_stats.handlebars
@@ -1,83 +1,99 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/docs-styles.css">
-    <script src="/js/wsc/docs-page.js"></script>
-    <script src="/js/wsc/text-processing.js"></script>
+{{#section "header"}}
+  <link rel="stylesheet" href="/css/docs-styles.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script src="/js/wsc/docs-page.js"></script>
+  <script src="/js/wsc/text-processing.js"></script>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
+{{/section}}
 
 <div class="container profile-container mt-5 pt-3">
-    <div class="columns is-centered is-mobile">
-        <div class="column is-8 box p-4">
+  <div class="columns is-centered is-mobile">
+    <div class="column is-8 box p-4">
 
-          <h1 class="main-title is-size-2 is-family-code has-text-centered">Material Statistics</h1>
-          <p class="py-1">&emsp;
-            The table below (Table 11–4 in the CRB, pg. 577) provides the Hardness, Hit Points, Broken Threshold, and example items for some types of common materials. The table has separate entries for thin items (like shields), ordinary items (like armor), and reinforced or durable structures (such as walls).
-          </p>
-          <p class="py-1">&emsp;
-            Stone is a catchall for any hard stone, such as granite and marble. Likewise, wood covers ordinary woods, such as oak and pine. Metal weapons and armor are assumed to be made of iron or steel unless noted otherwise.
-          </p>
-          <p class="py-1">&emsp;
-            If an object consists of more than one material, the GM typically uses the statistics for the strongest material involved. For instance, breaking a wall made of paper panels over a woven wooden framework would require damaging thin wood, not paper. However, the GM might choose the weaker material based on the item’s function. For instance, breaking the wooden handle of a hammer rather than its iron head would still render the item unusable. Sometimes an item is even less sturdy than the Hardness and Hit Points provided for a thin object; for instance, a twig doesn’t take 9 damage to break, even though it’s made of thin wood. Similarly, a particularly sturdy item or structure might have even higher Hardness and Hit Points. Certain structures, particularly thick walls, are so reinforced that you have to break them down over time with tools. (CRB pg. 515 has more information on walls.)
-          </p>
-          <div class="code-block text-processing">
-            Material|Hardness|HP|BT|Example Items
-            :--|:-:|:-:|:-:|:--
-            Paper|0|1|—|Book pages, paper fan, scroll
-            Thin cloth|0|1|—|Kite, silk dress, undershirt
-            Thin glass|0|1|—|Bottle, spectacles, window pane
-            Cloth|1|4|2|Cloth armor, heavy jacket, sack, tent
-            Glass|1|4|2|Glass block, glass table, heavy vase
-            Glass structure|2|8|4|Glass block wall
-            Thin leather|2|8|4|Backpack, jacket, pouch, strap, whip
-            Thin rope|2|8|4|Standard adventuring rope
-            Thin wood|3|12|6|Chair, club, sapling, wooden shield
-            Leather|4|16|8|Leather armor, saddle
-            Rope|4|16|8|Industrial rope, ship rigging
-            Thin stone|4|16|8|Chalkboard, slate tiles, stone cladding
-            Thin iron or steel|5|20|10|Chain, steel shield, sword
-            Wood|5|20|10|Chest, simple door, table, tree trunk
-            Stone|7|28|14|Paving stone, statue
-            Iron or steel|9|36|18|Anvil, iron or steel armor, stove
-            Wooden structure|10|40|20|Reinforced door, wooden wall
-            Stone structure|14|56|28|Stone wall
-            Iron or steel structure|18|72|36|Iron plate wall
-          </div>
+      <h1 class="main-title is-size-2 is-family-code has-text-centered">Material
+        Statistics</h1>
+      <p class="py-1">&emsp; The table below (Table 11–4 in the CRB, pg. 577)
+        provides the Hardness, Hit Points, Broken Threshold, and example items
+        for some types of common materials. The table has separate entries for
+        thin items (like shields), ordinary items (like armor), and reinforced
+        or durable structures (such as walls).
+      </p>
+      <p class="py-1">&emsp; Stone is a catchall for any hard stone, such as
+        granite and marble. Likewise, wood covers ordinary woods, such as oak
+        and pine. Metal weapons and armor are assumed to be made of iron or
+        steel unless noted otherwise.
+      </p>
+      <p class="py-1">&emsp; If an object consists of more than one material,
+        the GM typically uses the statistics for the strongest material
+        involved. For instance, breaking a wall made of paper panels over a
+        woven wooden framework would require damaging thin wood, not paper.
+        However, the GM might choose the weaker material based on the item’s
+        function. For instance, breaking the wooden handle of a hammer rather
+        than its iron head would still render the item unusable. Sometimes an
+        item is even less sturdy than the Hardness and Hit Points provided for a
+        thin object; for instance, a twig doesn’t take 9 damage to break, even
+        though it’s made of thin wood. Similarly, a particularly sturdy item or
+        structure might have even higher Hardness and Hit Points. Certain
+        structures, particularly thick walls, are so reinforced that you have to
+        break them down over time with tools. (CRB pg. 515 has more information
+        on walls.)
+      </p>
+      <div class="code-block text-processing">
+        Material|Hardness|HP|BT|Example Items :--|:-:|:-:|:-:|:--
+        Paper|0|1|—|Book pages, paper fan, scroll Thin cloth|0|1|—|Kite, silk
+        dress, undershirt Thin glass|0|1|—|Bottle, spectacles, window pane
+        Cloth|1|4|2|Cloth armor, heavy jacket, sack, tent Glass|1|4|2|Glass
+        block, glass table, heavy vase Glass structure|2|8|4|Glass block wall
+        Thin leather|2|8|4|Backpack, jacket, pouch, strap, whip Thin
+        rope|2|8|4|Standard adventuring rope Thin wood|3|12|6|Chair, club,
+        sapling, wooden shield Leather|4|16|8|Leather armor, saddle
+        Rope|4|16|8|Industrial rope, ship rigging Thin stone|4|16|8|Chalkboard,
+        slate tiles, stone cladding Thin iron or steel|5|20|10|Chain, steel
+        shield, sword Wood|5|20|10|Chest, simple door, table, tree trunk
+        Stone|7|28|14|Paving stone, statue Iron or steel|9|36|18|Anvil, iron or
+        steel armor, stove Wooden structure|10|40|20|Reinforced door, wooden
+        wall Stone structure|14|56|28|Stone wall Iron or steel
+        structure|18|72|36|Iron plate wall
+      </div>
 
-        </div>
     </div>
+  </div>
 </div>

--- a/views/pages/material_stats.handlebars
+++ b/views/pages/material_stats.handlebars
@@ -1,4 +1,4 @@
-{{#section "header"}}
+{{#section "styles"}}
   <link rel="stylesheet" href="/css/docs-styles.css" />
 {{/section}}
 

--- a/views/pages/profile.handlebars
+++ b/views/pages/profile.handlebars
@@ -1,246 +1,311 @@
-
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/profile.css">
-
-    <script src="/js/require-signin.js"></script>
-
-    <script src="/js/profile-page.js"></script>
-    <script src="/js/api/profile-api-clients.js"></script>
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/profile.css" />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script src="/js/require-signin.js"></script>
+
+  <script src="/js/profile-page.js"></script>
+  <script src="/js/api/profile-api-clients.js"></script>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
+{{/section}}
 
 <div class="container profile-container mt-5 pt-3">
-    <div class="columns is-centered is-mobile">
-        <div class="column is-8 box p-4 pos-relative">
-            <div class="columns is-centered is-mobile">
-                <div class="column is-4">
-                    <figure class="image is-128x128 is-pulled-right">
-                        <img class="is-rounded" src="{{user.thumbnail}}" alt="Profile Image">
-                        <p class="has-text-centered is-size-7 pt-1">ID #{{user.id}}</p>
-                    </figure>
-                </div>
-                <div class="column is-8">
-                    <p class="is-size-3"><span id="profileName" data-profile-name="{{user.username}}" class="title-font has-txt-value-number is-bold">{{user.username}}</span><sup id="profileNameBtn" class="icon has-text-info is-size-6 pl-2 cursor-clickable"><i class="far fa-edit"></i></sup></p>
-
-                    <p id="developerStatusListing" class="is-italic is-size-6 pl-4 {{#ifEqual user.isDeveloper 0}}is-hidden{{/ifEqual}}">Developer</p>
-                    {{#ifEqual user.isAdmin 1}}
-                        <p class="is-italic is-size-6 pl-4">Admin</p>
-                    {{/ifEqual}}
-                    {{#ifEqual user.isPatreonSupporter 1}}
-                        {{#ifEqual user.isPatreonLegend 1}}
-                            <p class="is-italic is-size-6 pl-4">Patron - Legend</p>
-                        {{else}}
-                          {{#ifEqual user.isPatreonMember 1}}
-                              <p class="is-italic is-size-6 pl-4">Patron - Wanderer</p>
-                          {{/ifEqual}}
-                          {{#ifEqual user.isPatreonMember 0}}
-                              <p class="is-italic is-size-6 pl-4">Patron - Advocate</p>
-                          {{/ifEqual}}
-                        {{/ifEqual}}
-                    {{/ifEqual}}
-                    {{#ifEqual user.isPatreonSupporter 0}}
-                        <p class="is-italic is-size-6 pl-4">Non-Patron</p>
-                    {{/ifEqual}}
-
-
-                    <div class="field pos-absolute pos-t-10 pos-r-10 is-unselectable">
-                      <input class="is-checkradio is-rtl is-small has-background-color {{#ifEqual user.isDeveloper 1}}is-info{{else}}is-dark{{/ifEqual}}" id="developerModeBtn" type="checkbox" name="developerModeBtn" {{#ifEqual user.isDeveloper 1}}checked="checked"{{/ifEqual}}>
-                      <label for="developerModeBtn" class="is-size-6 pt-0 has-txt-partial-noted">Developer Mode</label>
-                    </div>
-                    <div class="field pos-absolute pos-t-40 pos-r-10 is-unselectable">
-                      <input class="is-checkradio is-rtl is-small has-background-color {{#ifEqual user.enabledLightMode 1}}is-info{{else}}is-dark{{/ifEqual}}" id="lightModeBtn" type="checkbox" name="lightModeBtn" {{#ifEqual user.enabledLightMode 1}}checked="checked"{{/ifEqual}}>
-                      <label for="lightModeBtn" class="is-size-6 pt-0 has-txt-partial-noted">Light Mode</label>
-                    </div>
-
-                </div>
-            </div>
-
-            <div class="text-center mt-5 py-2">
-                {{#if isPatreonConnected}}
-                    <a class="button is-info is-outlined" href="{{patreonAuthURL}}"><span class="icon"><i class="fab fa-patreon"></i></span><span>Refresh Patreon Link</span></a>
-                {{else}}
-                    <a class="button is-info" href="{{patreonAuthURL}}"><span class="icon"><i class="fab fa-patreon"></i></span><span class="has-txt-value-string">Connect to Patreon</span></a>
-                {{/if}}
-            </div>
-
-            <hr class="m-4">
-
-            <div class="text-center">
-              <p>Clients & API Keys <sub id="add-new-client-btn" class="icon cursor-clickable is-small has-text-success is-hidden"><i class="fal fa-plus-circle fa-lg"></i></sub></p> 
-              <div id="clients-section" class="mb-2">
-              </div>
-            </div>
+  <div class="columns is-centered is-mobile">
+    <div class="column is-8 box p-4 pos-relative">
+      <div class="columns is-centered is-mobile">
+        <div class="column is-4">
+          <figure class="image is-128x128 is-pulled-right">
+            <img
+              class="is-rounded"
+              src="{{user.thumbnail}}"
+              alt="Profile Image"
+            />
+            <p class="has-text-centered is-size-7 pt-1">ID #{{user.id}}</p>
+          </figure>
         </div>
+        <div class="column is-8">
+          <p class="is-size-3"><span
+              id="profileName"
+              data-profile-name="{{user.username}}"
+              class="title-font has-txt-value-number is-bold"
+            >{{user.username}}</span><sup
+              id="profileNameBtn"
+              class="icon has-text-info is-size-6 pl-2 cursor-clickable"
+            ><i class="far fa-edit"></i></sup></p>
+
+          <p id="developerStatusListing" class="is-italic is-size-6 pl-4 {{#ifEqual user.isDeveloper 0}}is-hidden{{/ifEqual}}">Developer</p>
+          {{#ifEqual user.isAdmin 1}}
+            <p class="is-italic is-size-6 pl-4">Admin</p>
+          {{/ifEqual}}
+          {{#ifEqual user.isPatreonSupporter 1}}
+            {{#ifEqual user.isPatreonLegend 1}}
+              <p class="is-italic is-size-6 pl-4">Patron - Legend</p>
+            {{else}}
+              {{#ifEqual user.isPatreonMember 1}}
+                <p class="is-italic is-size-6 pl-4">Patron - Wanderer</p>
+              {{/ifEqual}}
+              {{#ifEqual user.isPatreonMember 0}}
+                <p class="is-italic is-size-6 pl-4">Patron - Advocate</p>
+              {{/ifEqual}}
+            {{/ifEqual}}
+          {{/ifEqual}}
+          {{#ifEqual user.isPatreonSupporter 0}}
+            <p class="is-italic is-size-6 pl-4">Non-Patron</p>
+          {{/ifEqual}}
+
+          <div class="field pos-absolute pos-t-10 pos-r-10 is-unselectable">
+            <input class="is-checkradio is-rtl is-small has-background-color {{#ifEqual user.isDeveloper 1}}is-info{{else}}is-dark{{/ifEqual}}" id="developerModeBtn" type="checkbox" name="developerModeBtn" {{#ifEqual user.isDeveloper 1}}checked="checked"{{/ifEqual}}>
+            <label
+              for="developerModeBtn"
+              class="is-size-6 pt-0 has-txt-partial-noted"
+            >Developer Mode</label>
+          </div>
+          <div class="field pos-absolute pos-t-40 pos-r-10 is-unselectable">
+            <input class="is-checkradio is-rtl is-small has-background-color {{#ifEqual user.enabledLightMode 1}}is-info{{else}}is-dark{{/ifEqual}}" id="lightModeBtn" type="checkbox" name="lightModeBtn" {{#ifEqual user.enabledLightMode 1}}checked="checked"{{/ifEqual}}>
+            <label
+              for="lightModeBtn"
+              class="is-size-6 pt-0 has-txt-partial-noted"
+            >Light Mode</label>
+          </div>
+
+        </div>
+      </div>
+
+      <div class="text-center mt-5 py-2">
+        {{#if isPatreonConnected}}
+          <a class="button is-info is-outlined" href="{{patreonAuthURL}}"><span
+              class="icon"
+            ><i class="fab fa-patreon"></i></span><span>Refresh Patreon Link</span></a>
+        {{else}}
+          <a class="button is-info" href="{{patreonAuthURL}}"><span
+              class="icon"
+            ><i class="fab fa-patreon"></i></span><span
+              class="has-txt-value-string"
+            >Connect to Patreon</span></a>
+        {{/if}}
+      </div>
+
+      <hr class="m-4" />
+
+      <div class="text-center">
+        <p>Clients & API Keys
+          <sub
+            id="add-new-client-btn"
+            class="icon cursor-clickable is-small has-text-success is-hidden"
+          ><i class="fal fa-plus-circle fa-lg"></i></sub></p>
+        <div id="clients-section" class="mb-2">
+        </div>
+      </div>
     </div>
+  </div>
 </div>
 
 <div class="modal create-modal">
-    <div class="modal-background"></div>
-    <div class="modal-card">
-        <header class="modal-card-head">
-            <p class="modal-card-title is-size-4 has-txt-value-string">Create Client</p>
-            <button class="delete modal-card-close" aria-label="close"></button>
-        </header>
-        <section class="modal-card-body">
-			      <div class="field">
-                <label class="label">App Name (required)</label>
-                <div class="control">
-                    <input class="input inputAppName" type="text" maxlength="115">
-                </div>
-            </div>
-            <div class="field">
-                <label class="label">Description</label>
-                <div class="control">
-                    <input class="input inputAppDescription" type="text" maxlength="395">
-                </div>
-            </div>
-            <div class="field">
-                <label class="label">Company Name</label>
-                <div class="control">
-                    <input class="input inputCompanyName" type="text" maxlength="115">
-                </div>
-            </div>
-            <div class="field">
-                <label class="label">Icon URL (square image URL that ends with png, jpeg, jpg, or gif)</label>
-                <div class="control">
-                    <input class="input inputIconURL" type="text" maxlength="295">
-                </div>
-            </div>
-            <div class="field">
-                <label class="label">Redirect URI (required, valid URL with http or https)</label>
-                <div class="control">
-                    <input class="input inputRedirectURI" type="text" maxlength="295">
-                </div>
-            </div>
-            <div class="field">
-                <label class="label">Character Access Rights</label>
-                <div class="control">
-                    <div class="select">
-                        <select class="inputAppPermissions">
-                            <option value="READ-ONLY" selected>Read Only</option>
-                            <option value="READ-UPDATE">Read / Update</option>
-                            <option value="READ-UPDATE-ADD-DELETE">Read / Update / Add / Delete</option>
-                        </select>
-                    </div>
-                </div>
-            </div>
-            <p class="is-size-6-5">By clicking create you are agreeing to follow the <a class="has-text-info" href="https://paizo.com/community/communityuse" target="_blank">Community Use Policy</a> for any project that makes use of Wanderer's Guide's API.</p>
-        </section>
-        <footer class="modal-card-foot is-paddingless p-3 field is-grouped is-grouped-centered">
-            <p class="control">
-                <a class="button is-success is-outlined is-rounded" id="create-client-btn">Create</a>
-            </p>
-        </footer>
-    </div>
+  <div class="modal-background"></div>
+  <div class="modal-card">
+    <header class="modal-card-head">
+      <p class="modal-card-title is-size-4 has-txt-value-string">Create Client</p>
+      <button class="delete modal-card-close" aria-label="close"></button>
+    </header>
+    <section class="modal-card-body">
+      <div class="field">
+        <label class="label">App Name (required)</label>
+        <div class="control">
+          <input class="input inputAppName" type="text" maxlength="115" />
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Description</label>
+        <div class="control">
+          <input
+            class="input inputAppDescription"
+            type="text"
+            maxlength="395"
+          />
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Company Name</label>
+        <div class="control">
+          <input class="input inputCompanyName" type="text" maxlength="115" />
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Icon URL (square image URL that ends with png,
+          jpeg, jpg, or gif)</label>
+        <div class="control">
+          <input class="input inputIconURL" type="text" maxlength="295" />
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Redirect URI (required, valid URL with http or
+          https)</label>
+        <div class="control">
+          <input class="input inputRedirectURI" type="text" maxlength="295" />
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Character Access Rights</label>
+        <div class="control">
+          <div class="select">
+            <select class="inputAppPermissions">
+              <option value="READ-ONLY" selected>Read Only</option>
+              <option value="READ-UPDATE">Read / Update</option>
+              <option value="READ-UPDATE-ADD-DELETE">Read / Update / Add /
+                Delete</option>
+            </select>
+          </div>
+        </div>
+      </div>
+      <p class="is-size-6-5">By clicking create you are agreeing to follow the
+        <a
+          class="has-text-info"
+          href="https://paizo.com/community/communityuse"
+          target="_blank"
+        >Community Use Policy</a>
+        for any project that makes use of Wanderer's Guide's API.</p>
+    </section>
+    <footer
+      class="modal-card-foot is-paddingless p-3 field is-grouped is-grouped-centered"
+    >
+      <p class="control">
+        <a
+          class="button is-success is-outlined is-rounded"
+          id="create-client-btn"
+        >Create</a>
+      </p>
+    </footer>
+  </div>
 </div>
 
 <div class="modal update-modal">
-    <div class="modal-background"></div>
-    <div class="modal-card">
-        <header class="modal-card-head">
-            <p class="modal-card-title is-size-4 has-txt-value-string">Update Client</p>
-            <button class="delete modal-card-close" aria-label="close"></button>
-        </header>
-        <section class="modal-card-body">
-			      <div class="field">
-                <label class="label">App Name (required)</label>
-                <div class="control">
-                    <input class="input inputAppName" type="text" maxlength="115">
-                </div>
-            </div>
-            <div class="field">
-                <label class="label">Description</label>
-                <div class="control">
-                    <input class="input inputAppDescription" type="text" maxlength="395">
-                </div>
-            </div>
-            <div class="field">
-                <label class="label">Company Name</label>
-                <div class="control">
-                    <input class="input inputCompanyName" type="text" maxlength="115">
-                </div>
-            </div>
-            <div class="field">
-                <label class="label">Icon URL (square image URL that ends with png, jpeg, jpg, or gif)</label>
-                <div class="control">
-                    <input class="input inputIconURL" type="text" maxlength="295">
-                </div>
-            </div>
-            <div class="field">
-                <label class="label">Redirect URI (required, valid URL with http or https)</label>
-                <div class="control">
-                    <input class="input inputRedirectURI" type="text" maxlength="295">
-                </div>
-            </div>
-            <div class="field">
-                <label class="label">Character Access Rights</label>
-                <div class="control">
-                    <div class="select">
-                        <select class="inputAppPermissions">
-                            <option value="READ-ONLY" selected>Read Only</option>
-                            <option value="READ-UPDATE">Read / Update</option>
-                            <option value="READ-UPDATE-ADD-DELETE">Read / Update / Add / Delete</option>
-                        </select>
-                    </div>
-                </div>
-            </div>
-        </section>
-        <footer class="modal-card-foot is-paddingless p-3 field is-grouped is-grouped-centered">
-            <p class="control">
-                <a class="button is-success is-outlined is-rounded" id="update-client-btn">Update</a>
-            </p>
-        </footer>
-    </div>
+  <div class="modal-background"></div>
+  <div class="modal-card">
+    <header class="modal-card-head">
+      <p class="modal-card-title is-size-4 has-txt-value-string">Update Client</p>
+      <button class="delete modal-card-close" aria-label="close"></button>
+    </header>
+    <section class="modal-card-body">
+      <div class="field">
+        <label class="label">App Name (required)</label>
+        <div class="control">
+          <input class="input inputAppName" type="text" maxlength="115" />
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Description</label>
+        <div class="control">
+          <input
+            class="input inputAppDescription"
+            type="text"
+            maxlength="395"
+          />
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Company Name</label>
+        <div class="control">
+          <input class="input inputCompanyName" type="text" maxlength="115" />
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Icon URL (square image URL that ends with png,
+          jpeg, jpg, or gif)</label>
+        <div class="control">
+          <input class="input inputIconURL" type="text" maxlength="295" />
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Redirect URI (required, valid URL with http or
+          https)</label>
+        <div class="control">
+          <input class="input inputRedirectURI" type="text" maxlength="295" />
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Character Access Rights</label>
+        <div class="control">
+          <div class="select">
+            <select class="inputAppPermissions">
+              <option value="READ-ONLY" selected>Read Only</option>
+              <option value="READ-UPDATE">Read / Update</option>
+              <option value="READ-UPDATE-ADD-DELETE">Read / Update / Add /
+                Delete</option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </section>
+    <footer
+      class="modal-card-foot is-paddingless p-3 field is-grouped is-grouped-centered"
+    >
+      <p class="control">
+        <a
+          class="button is-success is-outlined is-rounded"
+          id="update-client-btn"
+        >Update</a>
+      </p>
+    </footer>
+  </div>
 </div>
 
 <div class="modal delete-modal">
-    <div class="modal-background"></div>
-    <div class="modal-card">
-        <header class="modal-card-head">
-            <p class="modal-card-title is-size-4 has-txt-value-string">Delete Client</p>
-            <button class="delete modal-card-close" aria-label="close"></button>
-        </header>
-        <section class="modal-card-body">
-            <p class="has-txt-value-string has-text-centered">Are you sure you want to delete this client?</p>
-        </section>
-        <footer class="modal-card-foot is-paddingless p-3 field is-grouped is-grouped-centered">
-            <p class="control">
-                <a class="button is-danger is-outlined" id="delete-client-btn">Delete</a>
-            </p>
-        </footer>
-    </div>
+  <div class="modal-background"></div>
+  <div class="modal-card">
+    <header class="modal-card-head">
+      <p class="modal-card-title is-size-4 has-txt-value-string">Delete Client</p>
+      <button class="delete modal-card-close" aria-label="close"></button>
+    </header>
+    <section class="modal-card-body">
+      <p class="has-txt-value-string has-text-centered">Are you sure you want to
+        delete this client?</p>
+    </section>
+    <footer
+      class="modal-card-foot is-paddingless p-3 field is-grouped is-grouped-centered"
+    >
+      <p class="control">
+        <a
+          class="button is-danger is-outlined"
+          id="delete-client-btn"
+        >Delete</a>
+      </p>
+    </footer>
+  </div>
 </div>

--- a/views/pages/website_down.handlebars
+++ b/views/pages/website_down.handlebars
@@ -1,24 +1,22 @@
+{{#section "styles"}}
+  <link rel="stylesheet" href="/css/api-request-access.css" />
+{{/section}}
+{{#section "header"}}
+  <script src="/js/api/api-request-access.js"></script>
 
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/api-request-access.css">
-    <script src="/js/api/api-request-access.js"></script>
-
-    <!-- Discord Widget Bot -->
-    <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
-      new Crate({
-        server: '735260060682289254',
-        channel: '735260060682289257'
-      })
-    </script>
+  <!-- Discord Widget Bot -->
+  <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
+    new Crate({ server: '735260060682289254', channel: '735260060682289257' })
+  </script>
 
 {{/section}}
 
 <div id="access-container" class="container text-center">
 
-    <div>
-      <p class="is-size-4"><span class="is-bold lighter-text">Wanderer's Guide</span></p>
-      <p class="is-size-6">is temporarily down for updates / repairs</p>
-    </div>
-    <p class="pt-4 is-size-6-5 lighter-text is-italic">Check back in later!</p>
+  <div>
+    <p class="is-size-4"><span class="is-bold lighter-text">Wanderer's Guide</span></p>
+    <p class="is-size-6">is temporarily down for updates / repairs</p>
+  </div>
+  <p class="pt-4 is-size-6-5 lighter-text is-italic">Check back in later!</p>
 
 </div>

--- a/views/sheet/charsheet.handlebars
+++ b/views/sheet/charsheet.handlebars
@@ -1,4 +1,4 @@
-{{#section}}
+{{#section "styles"}}
   <link rel="stylesheet" href="/css/sheet-styles.css" />
 
   <!-- Notyf Library -->

--- a/views/sheet/charsheet.handlebars
+++ b/views/sheet/charsheet.handlebars
@@ -1,142 +1,161 @@
+{{#section}}
+  <link rel="stylesheet" href="/css/sheet-styles.css" />
 
-{{#section 'header'}}
-    <link rel="stylesheet" href="/css/sheet-styles.css">
-    <script defer src="/js/sheet/char-sheet.js"></script>
-
-    <!-- Notyf Library -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/notyf@3/notyf.min.css">
-    <script defer src="https://cdn.jsdelivr.net/npm/notyf@3/notyf.min.js"></script>
-
-    <!-- Main Resources -->
-    <script defer src="/js/sheet/tabs/_tabs.js"></script>
-    <script defer src="/js/sheet/tabs/actions-tab.js"></script>
-    <script defer src="/js/sheet/tabs/details-tab.js"></script>
-    <script defer src="/js/sheet/tabs/inventory-tab.js"></script>
-    <script defer src="/js/sheet/tabs/notes-tab.js"></script>
-    <script defer src="/js/sheet/tabs/spells-tab.js"></script>
-    <script defer src="/js/sheet/tabs/companions-tab.js"></script>
-    <script defer src="/js/sheet/tabs/weapons-tab.js"></script>
-
-    <script defer src="/js/sheet/quickviews/_left-quickview.js"></script>
-    <script defer src="/js/sheet/quickviews/_quickviews.js"></script>
-    <script defer src="/js/sheet/quickviews/ability-score-view.js"></script>
-    <script defer src="/js/sheet/quickviews/add-item-view.js"></script>
-    <script defer src="/js/sheet/quickviews/add-spell-view.js"></script>
-    <script defer src="/js/sheet/quickviews/customize-item-view.js"></script>
-    <script defer src="/js/sheet/quickviews/feat-view.js"></script>
-    <script defer src="/js/sheet/quickviews/class-dc-view.js"></script>
-    <script defer src="/js/sheet/quickviews/hero-points-view.js"></script>
-    <script defer src="/js/sheet/quickviews/ac-view.js"></script>
-    <script defer src="/js/sheet/quickviews/inv-item-view.js"></script>
-    <script defer src="/js/sheet/quickviews/language-view.js"></script>
-    <script defer src="/js/sheet/quickviews/perception-view.js"></script>
-    <script defer src="/js/sheet/quickviews/saving-throw-view.js"></script>
-    <script defer src="/js/sheet/quickviews/skill-view.js"></script>
-    <script defer src="/js/sheet/quickviews/spell-view.js"></script>
-    <script defer src="/js/sheet/quickviews/spell-empty-view.js"></script>
-    <script defer src="/js/sheet/quickviews/item-view.js"></script>
-    <script defer src="/js/sheet/quickviews/char-info-view.js"></script>
-    <script defer src="/js/sheet/quickviews/ability-view.js"></script>
-    <script defer src="/js/sheet/quickviews/resist-view.js"></script>
-    <script defer src="/js/sheet/quickviews/speed-view.js"></script>
-    <script defer src="/js/sheet/quickviews/other-profs-view.js"></script>
-    <script defer src="/js/sheet/quickviews/customize-prof-view.js"></script>
-    <script defer src="/js/sheet/quickviews/animal-comp-view.js"></script>
-    <script defer src="/js/sheet/quickviews/familiar-view.js"></script>
-    <script defer src="/js/sheet/quickviews/add-prof-view.js"></script>
-    <script defer src="/js/sheet/quickviews/add-lang-view.js"></script>
-    <script defer src="/js/sheet/quickviews/add-lore-view.js"></script>
-    <script defer src="/js/sheet/quickviews/add-spell-slot-view.js"></script>
-    <script defer src="/js/sheet/quickviews/add-resist-view.js"></script>
-    <script defer src="/js/sheet/quickviews/add-weak-view.js"></script>
-    <script defer src="/js/sheet/quickviews/resist-list-view.js"></script>
-    <script defer src="/js/sheet/quickviews/add-unarmed-attack-view.js"></script>
-    <script defer src="/js/sheet/quickviews/tag-view.js"></script>
-    <script defer src="/js/sheet/quickviews/condition-view.js"></script>
-    <script defer src="/js/sheet/quickviews/item-breakdown-view.js"></script>
-    <script defer src="/js/sheet/quickviews/warnings-view.js"></script>
-
-    <script defer src="/js/sheet/general/stat-manager.js"></script>
-    <script defer src="/js/sheet/general/conditions-manager.js"></script>
-    <script defer src="/js/sheet/general/remote-updates.js"></script> <!-- must be defer -->
-    <script defer src="/js/sheet/general/manage-spells.js"></script>
-    <script defer src="/js/sheet/general/coin-manager.js"></script>
-    <script defer src="/js/sheet/general/sheet-states.js"></script>
-    <script defer src="/js/sheet/general/weap-mod-manager.js"></script>
-    <script defer src="/js/sheet/general/item-runes.js"></script>
-    <script defer src="/js/sheet/general/critical-specializations.js"></script>
-    <script defer src="/js/sheet/general/notes-fields.js"></script>
-
-    <script defer src="/js/prof/prof-manager.js"></script>
-    <script defer src="/js/sheet/general/prof-history-display.js"></script>
-
-    <script defer src="/js/libraries/confirm_message/confirm-message.js"></script>
-
-    <script defer src="/js/char_export/export-handler.js"></script>
-
-    <script defer src="/js/char_builders/variants/auto-bonus-progression.js"></script>
-    <script defer src="/js/char_builders/variants/gradual-ability-boosts.js"></script>
-    
-    <script defer src="/js/wsc/text-processing.js"></script>
-    <script defer src="/js/wsc/variable-processing.js"></script>
-    <script defer src="/js/wsc/expression-processing.js"></script>
-    <script defer src="/js/wsc/expression-utils.js"></script>
-    <script defer src="/js/wsc/statement-processing.js"></script>
-    <script defer src="/js/wsc/removal-processing.js"></script>
-    <script defer src="/js/wsc/misc-feat-processing.js"></script>
-    <script defer src="/js/wsc/add-text-processing.js"></script>
-    <script defer src="/js/wsc/errorHandling.js"></script>
-    <script defer src="/js/wsc/default-statement-processing.js"></script>
-
-    <script defer src="/js/sheet/utils/sheet-reload.js"></script>
-    <script defer src="/js/sheet/utils/calc-utils.js"></script>
-    <script defer src="/js/sheet/utils/prof-map-utils.js"></script>
-    <script defer src="/js/sheet/utils/animal-comp-utils.js"></script>
-    <script defer src="/js/sheet/utils/familiar-utils.js"></script>
-    <script defer src="/js/sheet/utils/item-actions-generator.js"></script>
-    <script defer src="/js/sheet/utils/struct-utils.js"></script>
-    <script defer src="/js/sheet/utils/material-utils.js"></script>
-    <script defer src="/js/sheet/utils/item-utils.js"></script>
-    <script defer src="/js/sheet/utils/spell-utils.js"></script>
-    <script defer src="/js/sheet/utils/utils.js"></script>
-
-    <script defer src="/js/sheet/utils/dice-roller.js"></script>
+  <!-- Notyf Library -->
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/notyf@3/notyf.min.css"
+  />
 {{/section}}
 
-{{#section 'nav_home'}}
-    <li><a href="/">Home</a></li>
+{{#section "header"}}
+  <script defer src="/js/sheet/char-sheet.js"></script>
+
+  <script
+    defer
+    src="https://cdn.jsdelivr.net/npm/notyf@3/notyf.min.js"
+  ></script>
+
+  <!-- Main Resources -->
+  <script defer src="/js/sheet/tabs/_tabs.js"></script>
+  <script defer src="/js/sheet/tabs/actions-tab.js"></script>
+  <script defer src="/js/sheet/tabs/details-tab.js"></script>
+  <script defer src="/js/sheet/tabs/inventory-tab.js"></script>
+  <script defer src="/js/sheet/tabs/notes-tab.js"></script>
+  <script defer src="/js/sheet/tabs/spells-tab.js"></script>
+  <script defer src="/js/sheet/tabs/companions-tab.js"></script>
+  <script defer src="/js/sheet/tabs/weapons-tab.js"></script>
+
+  <script defer src="/js/sheet/quickviews/_left-quickview.js"></script>
+  <script defer src="/js/sheet/quickviews/_quickviews.js"></script>
+  <script defer src="/js/sheet/quickviews/ability-score-view.js"></script>
+  <script defer src="/js/sheet/quickviews/add-item-view.js"></script>
+  <script defer src="/js/sheet/quickviews/add-spell-view.js"></script>
+  <script defer src="/js/sheet/quickviews/customize-item-view.js"></script>
+  <script defer src="/js/sheet/quickviews/feat-view.js"></script>
+  <script defer src="/js/sheet/quickviews/class-dc-view.js"></script>
+  <script defer src="/js/sheet/quickviews/hero-points-view.js"></script>
+  <script defer src="/js/sheet/quickviews/ac-view.js"></script>
+  <script defer src="/js/sheet/quickviews/inv-item-view.js"></script>
+  <script defer src="/js/sheet/quickviews/language-view.js"></script>
+  <script defer src="/js/sheet/quickviews/perception-view.js"></script>
+  <script defer src="/js/sheet/quickviews/saving-throw-view.js"></script>
+  <script defer src="/js/sheet/quickviews/skill-view.js"></script>
+  <script defer src="/js/sheet/quickviews/spell-view.js"></script>
+  <script defer src="/js/sheet/quickviews/spell-empty-view.js"></script>
+  <script defer src="/js/sheet/quickviews/item-view.js"></script>
+  <script defer src="/js/sheet/quickviews/char-info-view.js"></script>
+  <script defer src="/js/sheet/quickviews/ability-view.js"></script>
+  <script defer src="/js/sheet/quickviews/resist-view.js"></script>
+  <script defer src="/js/sheet/quickviews/speed-view.js"></script>
+  <script defer src="/js/sheet/quickviews/other-profs-view.js"></script>
+  <script defer src="/js/sheet/quickviews/customize-prof-view.js"></script>
+  <script defer src="/js/sheet/quickviews/animal-comp-view.js"></script>
+  <script defer src="/js/sheet/quickviews/familiar-view.js"></script>
+  <script defer src="/js/sheet/quickviews/add-prof-view.js"></script>
+  <script defer src="/js/sheet/quickviews/add-lang-view.js"></script>
+  <script defer src="/js/sheet/quickviews/add-lore-view.js"></script>
+  <script defer src="/js/sheet/quickviews/add-spell-slot-view.js"></script>
+  <script defer src="/js/sheet/quickviews/add-resist-view.js"></script>
+  <script defer src="/js/sheet/quickviews/add-weak-view.js"></script>
+  <script defer src="/js/sheet/quickviews/resist-list-view.js"></script>
+  <script defer src="/js/sheet/quickviews/add-unarmed-attack-view.js"></script>
+  <script defer src="/js/sheet/quickviews/tag-view.js"></script>
+  <script defer src="/js/sheet/quickviews/condition-view.js"></script>
+  <script defer src="/js/sheet/quickviews/item-breakdown-view.js"></script>
+  <script defer src="/js/sheet/quickviews/warnings-view.js"></script>
+
+  <script defer src="/js/sheet/general/stat-manager.js"></script>
+  <script defer src="/js/sheet/general/conditions-manager.js"></script>
+  <script defer src="/js/sheet/general/remote-updates.js"></script>
+  <!-- must be defer -->
+  <script defer src="/js/sheet/general/manage-spells.js"></script>
+  <script defer src="/js/sheet/general/coin-manager.js"></script>
+  <script defer src="/js/sheet/general/sheet-states.js"></script>
+  <script defer src="/js/sheet/general/weap-mod-manager.js"></script>
+  <script defer src="/js/sheet/general/item-runes.js"></script>
+  <script defer src="/js/sheet/general/critical-specializations.js"></script>
+  <script defer src="/js/sheet/general/notes-fields.js"></script>
+
+  <script defer src="/js/prof/prof-manager.js"></script>
+  <script defer src="/js/sheet/general/prof-history-display.js"></script>
+
+  <script defer src="/js/libraries/confirm_message/confirm-message.js"></script>
+
+  <script defer src="/js/char_export/export-handler.js"></script>
+
+  <script
+    defer
+    src="/js/char_builders/variants/auto-bonus-progression.js"
+  ></script>
+  <script
+    defer
+    src="/js/char_builders/variants/gradual-ability-boosts.js"
+  ></script>
+
+  <script defer src="/js/wsc/text-processing.js"></script>
+  <script defer src="/js/wsc/variable-processing.js"></script>
+  <script defer src="/js/wsc/expression-processing.js"></script>
+  <script defer src="/js/wsc/expression-utils.js"></script>
+  <script defer src="/js/wsc/statement-processing.js"></script>
+  <script defer src="/js/wsc/removal-processing.js"></script>
+  <script defer src="/js/wsc/misc-feat-processing.js"></script>
+  <script defer src="/js/wsc/add-text-processing.js"></script>
+  <script defer src="/js/wsc/errorHandling.js"></script>
+  <script defer src="/js/wsc/default-statement-processing.js"></script>
+
+  <script defer src="/js/sheet/utils/sheet-reload.js"></script>
+  <script defer src="/js/sheet/utils/calc-utils.js"></script>
+  <script defer src="/js/sheet/utils/prof-map-utils.js"></script>
+  <script defer src="/js/sheet/utils/animal-comp-utils.js"></script>
+  <script defer src="/js/sheet/utils/familiar-utils.js"></script>
+  <script defer src="/js/sheet/utils/item-actions-generator.js"></script>
+  <script defer src="/js/sheet/utils/struct-utils.js"></script>
+  <script defer src="/js/sheet/utils/material-utils.js"></script>
+  <script defer src="/js/sheet/utils/item-utils.js"></script>
+  <script defer src="/js/sheet/utils/spell-utils.js"></script>
+  <script defer src="/js/sheet/utils/utils.js"></script>
+
+  <script defer src="/js/sheet/utils/dice-roller.js"></script>
 {{/section}}
 
-{{#section 'nav_characters'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/profile/characters" class="active">Characters</a></li>
+{{#section "nav_home"}}
+  <li><a href="/">Home</a></li>
 {{/section}}
 
-{{#section 'nav_builds'}}
-    <li><a href="/builds">Builds</a></li>
+{{#section "nav_characters"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a
+      href="/profile/characters"
+      class="active"
+    >Characters</a></li>
 {{/section}}
 
-{{#section 'nav_homebrew'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
+{{#section "nav_builds"}}
+  <li><a href="/builds">Builds</a></li>
 {{/section}}
 
-{{#section 'nav_gm_tools'}}
-    <li><a href="/gm-tools">GM Tools</a></li>
+{{#section "nav_homebrew"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/homebrew">Homebrew</a></li>
 {{/section}}
 
-{{#section 'nav_browse'}}
-    <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i class="fas fa-lg fa-search"></i></a></li>
+{{#section "nav_gm_tools"}}
+  <li><a href="/gm-tools">GM Tools</a></li>
 {{/section}}
 
-{{#section 'nav_login'}}
-    <li class="mr-4"><a href="/auth/login">Login <i class="fas fa-sign-in-alt"></i></a></li>
+{{#section "nav_browse"}}
+  <li class="mx-lg-4 mx-md-3 my-md-0 my-2"><a href="/browse"><i
+        class="fas fa-lg fa-search"
+      ></i></a></li>
 {{/section}}
 
-
-
-{{#section 'banner_nav'}}
-    <div class="banner_w3lspvt-2"></div>
+{{#section "nav_login"}}
+  <li class="mr-4"><a href="/auth/login">Login
+      <i class="fas fa-sign-in-alt"></i></a></li>
 {{/section}}
 
+{{#section "banner_nav"}}
+  <div class="banner_w3lspvt-2"></div>
+{{/section}}
 
 <div class="">
   <div class="dice-pageloader">
@@ -156,528 +175,893 @@
 </div>
 
 <div class="subpageloader is-hidden">
-  <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+  <div class="lds-roller"><div></div><div></div><div></div><div></div><div
+    ></div><div></div><div></div><div></div></div>
 </div>
 
-
 <div class="sticky_buttons_shell sticky_button_leftest">
-  <span class="icon is-small has-text-info cursor-clickable sticky_button is-upper has-tooltip-right" data-tooltip="Open Sheet Tools" id="leftQuickviewButton">
-      <i class="fas fa-2x fa-angle-right"></i>
+  <span
+    class="icon is-small has-text-info cursor-clickable sticky_button is-upper has-tooltip-right"
+    data-tooltip="Open Sheet Tools"
+    id="leftQuickviewButton"
+  >
+    <i class="fas fa-2x fa-angle-right"></i>
   </span>
 </div>
 
-<section id="character-sheet-section" class="section text-center is-paddingless px-4 py-3">
+<section
+  id="character-sheet-section"
+  class="section text-center is-paddingless px-4 py-3"
+>
 
-    <div id="errorDisplay" class="hero is-danger is-hidden">
-        <div class="hero-body is-paddingless py-3">
-            <div id="errorMessage" class="container"></div>
-        </div>
+  <div id="errorDisplay" class="hero is-danger is-hidden">
+    <div class="hero-body is-paddingless py-3">
+      <div id="errorMessage" class="container"></div>
     </div>
+  </div>
 
-    <span id="warnings-icon" class="is-hidden icon has-text-warning pos-absolute pos-t-5 pos-r-5 cursor-clickable has-tooltip-left" data-tooltip="Warnings"><i class="fas fa-exclamation-triangle"></i></span>
+  <span
+    id="warnings-icon"
+    class="is-hidden icon has-text-warning pos-absolute pos-t-5 pos-r-5 cursor-clickable has-tooltip-left"
+    data-tooltip="Warnings"
+  ><i class="fas fa-exclamation-triangle"></i></span>
 
-    <div id="sheet-container" class="tile is-ancestor is-vertical">
-        <div class="tile is-vertical m-2">
-            <div class="tile is-parent is-paddingless">
-                <div class="tile is-3">
-                    <div class="mobile-box tile mb-4 mr-2">
-                        <div class="tile sheet-box">
-                            <div id="charInfoContent" class="tile is-vertical is-7 pb-1 cursor-clickable">
-                                <p id="character-name" class="is-size-5 has-txt-value-string is-clipped"></p>
-                                <div class="tile is-child">
-                                    <p id="character-type" class="is-size-7 has-txt-listing"></p>
-                                </div>
-                            </div>
-                            <div id="charExperienceContent" class="tile is-vertical is-5 pb-1">
-                                <p id="character-level" class="is-size-6 has-txt-value-number"></p>
-                                <div class="tile is-child pb-3">
-                                    <p class="is-size-7 has-txt-listing has-text-weight-semibold">Experience</p>
-                                    <div class="field px-4">
-                                        <p class="control">
-                                            <input id="exp-input" class="input is-small" type="number" value="">
-                                        </p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="tile is-3">
-                    <div class="mobile-box tile is-vertical mx-4 mb-4 sheet-box">
-                        <div class="tile pb-1" style="position: relative;">
-                            <div id="healthPointsContainer" class="tile is-child px-2 pt-2">
-                                <p class="is-size-6"><strong class="has-txt-value-number">Hit Points</strong></p>
-                                <div class="columns is-mobile is-centered">
-                                    <div class="column is-narrow is-paddingless py-2">
-                                        <div id="char-current-health" class="cursor-clickable">
-                                        </div>
-                                    </div>
-                                    <div class="column is-narrow is-paddingless py-2">
-                                        <p class="is-size-5 text-center has-txt-noted">/</p>
-                                    </div>
-                                    <div class="column is-narrow is-paddingless py-2" style="width: 70px;">
-                                        <p id="char-max-health" class="is-size-5 text-center has-txt-value-string"></p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div id="tempPointsContainer" class="tile is-child pt-3">
-                                <p class="is-size-7"><strong class="has-txt-listing">Temp. HP</strong></p>
-                                <div class="columns is-centered">
-                                    <div class="column is-narrow is-paddingless py-2">
-                                        <div id="char-temp-health" class="cursor-clickable">
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div id="staminaPointsContainer" class="tile is-child px-2 pt-2 is-hidden">
-                                <p class="is-size-6"><strong class="has-txt-value-number">Stamina</strong></p>
-                                <div class="columns is-mobile is-centered">
-                                    <div class="column is-narrow is-paddingless py-2">
-                                        <div id="char-current-stamina" class="cursor-clickable">
-                                        </div>
-                                    </div>
-                                    <div class="column is-narrow is-paddingless py-2">
-                                        <p class="is-size-5 text-center has-txt-noted">/</p>
-                                    </div>
-                                    <div class="column is-narrow is-paddingless py-2" style="width: 40px;">
-                                        <p id="char-max-stamina" class="is-size-5 text-center has-txt-value-string"></p>
-                                    </div>
-                                </div>
-                            </div>
-                            <div id="resolvePointsContainer" class="tile is-child pt-3 is-hidden">
-                                <p class="is-size-7"><strong class="has-txt-listing">Resolve</strong></p>
-                                <div class="columns is-mobile is-centered">
-                                    <div class="column is-narrow is-paddingless py-2">
-                                        <div id="char-current-resolve" class="cursor-clickable">
-                                        </div>
-                                    </div>
-                                    <div class="column is-narrow is-paddingless py-2">
-                                        <p class="is-size-5 text-center has-txt-noted">/</p>
-                                    </div>
-                                    <div class="column is-narrow is-paddingless py-2" style="width: 40px;">
-                                        <p id="char-max-resolve" class="is-size-5 text-center has-txt-value-string"></p>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div id="pointSwitchOutContainer" class="is-hidden" style="position: absolute; top: 5px; left: 50%;">
-                              <span id="pointSwitchOutBtn" class="icon is-small has-text-info cursor-clickable"><i class="fas fa-lg fa-retweet"></i></span>
-                            </div>
-                            
-                        </div>
-                        <div class="tile" style="position: relative;">
-                            <div id="resistAndVulnerContent" class="tile is-child cursor-clickable">
-                                <p id="resistAndVulnerText" class="text-center"></p>
-                            </div>
-                            <span id="resistAndVulnerViewAllBtn" class="icon is-small has-text-info cursor-clickable" style="position: absolute; bottom: 7px; right: 7px;">
-                              <i class="fas fa-fire"></i>
-                            </span>
-                        </div>
-                    </div>
-                </div>
-                <div class="tile is-3">
-                    <div class="mobile-box tile ml-1 mr-4 mb-4 mobile-is-marginless sheet-box">
-                        <div class="tile is-child use-custom-scrollbar" style="max-height: 100px; overflow-y: auto;">
-                            <div class="columns is-centered is-vcentered is-marginless">
-                                <div class="column is-paddingless"></div>
-                                <div class="column is-paddingless"><p class="is-size-6"><strong class="has-txt-value-number">Conditions</strong></p></div>
-                                <div class="column is-paddingless">
-                                    <a id="addNewConditionsButton" class="is-pulled-right is-size-6"><span class="icon has-text-info"><i class="fal fa-plus-circle"></i></span></a>
-                                </div>
-                            </div>
-                            <div id="conditionsContent" class="buttons is-centered mx-1"></div>
-                        </div>
-                    </div>
-                </div>
-                <div class="tile is-2">
-                    <div class="mobile-box tile ml-2 mb-4 mobile-is-marginless mobile-apply-flex sheet-box">
-                        <div class="tile is-child pt-2 is-paddingless cursor-clickable" id="classDCSection">
-                            <p class="is-size-6 is-unselectable"><strong class="has-txt-value-number">Class DC</strong></p>
-                            <p id="classDCContent" class="is-size-5 has-txt-listing pl-2"></p>
-                        </div>
-                        <div class="tile is-child pt-2">
-                            <p id="heroPointsTitle" class="is-size-7 cursor-clickable"><strong class="has-txt-value-number">Hero Points</strong></p>
-                            <div class="select">
-                                <select id="heroPointsSelect">
-                                    <option value="0">0</option>
-                                    <option value="1">1</option>
-                                    <option value="2">2</option>
-                                    <option value="3">3</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="tile is-1">
-                    <div class="mobile-box tile ml-2 mt-2 mb-4 mobile-is-marginless">
-                        <div class="tile is-child">
-                                <a id="backToBuilderButton" class="button is-info is-rounded is-small has-text-white mb-2">
-                                  <span>Edit</span>
-                                  <span class="icon">
-                                    <i class="fas fa-cog"></i>
-                                  </span>
-                                </a>
-                                <a id="restButton" class="button is-info is-outlined">
-                                  <span>Rest</span>
-                                  <span class="icon is-very-small">
-                                    <i class="far fa-snooze fa-xs"></i>
-                                  </span>
-                                </a>
-
-                                <a id="copyCharButton" class="button is-info is-outlined mb-2 is-hidden"><span>Copy</span><span class="icon"><i class="fas fa-user-friends"></i></span></a>
-                                <a id="exportCharButton" class="button is-info is-outlined is-hidden"><span>Export</span><span class="icon"><i class="fas fa-download"></i></span></a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="tile is-parent is-paddingless">
-                <div class="tile is-3">
-                    <div class="mobile-box tile my-2 mr-4 mobile-is-marginless">
-                        <div class="tile is-child is-paddingless sheet-box cursor-clickable" id="speedSection">
-                            <p class="is-size-6 is-unselectable"><strong class="has-txt-value-number">Speed</strong></p>
-                            <p id="speedContent" class="is-size-5 has-txt-listing pl-2"></p>
-                            <div id="speedBottom" class="is-hidden">
-                                <hr id="speedDivider" class="m-1">
-                                <p class="is-size-7 has-txt-listing">View Others</p>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="mobile-box tile m-2">
-                        <div class="tile is-child is-paddingless sheet-box cursor-clickable" id="perceptionBonusSection">
-                            <p class="is-size-6 is-unselectable"><strong class="has-txt-value-number">Perception</strong></p>
-                            <p id="perceptionBonusContent" class="is-size-5 has-txt-listing pr-3"></p>
-                            <div id="perceptionBonusBottom">
-                                <hr id="perceptionBonusDivider" class="m-1">
-                                <p id="perceptionPrimaryVisionSense" class="is-size-7 has-txt-listing"></p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="tile is-6">
-                    <div class="mobile-box tile my-2 mx-4 mobile-is-marginless">
-                        <!-- Ability Scores -->
-                        <div class="tile sheet-box mobile-apply-flex">
-                            <div id="strSection" class="tile is-child pt-2 is-paddingless cursor-clickable">
-                                <div class="is-size-7 is-unselectable">Strength</div>
-                                <div id="strMod" class="is-size-4 pr-3"></div>
-                                <span id="strScore" class="sheet-small-box is-size-7 has-txt-listing"></span>
-                            </div>
-                            <div id="dexSection" class="tile is-child pt-2 is-paddingless cursor-clickable">
-                                <div class="is-size-7 is-unselectable">Dexterity</div>
-                                <div id="dexMod" class="is-size-4 pr-3"></div>
-                                <span id="dexScore" class="sheet-small-box is-size-7 has-txt-listing"></span>
-                            </div>
-                            <div id="conSection" class="tile is-child pt-2 is-paddingless cursor-clickable">
-                                <div class="is-size-7 is-unselectable">Constitution</div>
-                                <div id="conMod" class="is-size-4 pr-3"></div>
-                                <span id="conScore" class="sheet-small-box is-size-7 has-txt-listing"></span>
-                            </div>
-                            <div id="intSection" class="tile is-child pt-2 is-paddingless cursor-clickable">
-                                <div class="is-size-7 is-unselectable">Intelligence</div>
-                                <div id="intMod" class="is-size-4 pr-3"></div>
-                                <span id="intScore" class="sheet-small-box is-size-7 has-txt-listing"></span>
-                            </div>
-                            <div id="wisSection" class="tile is-child pt-2 is-paddingless cursor-clickable">
-                                <div class="is-size-7 is-unselectable">Wisdom</div>
-                                <div id="wisMod" class="is-size-4 pr-3"></div>
-                                <span id="wisScore" class="sheet-small-box is-size-7 has-txt-listing"></span>
-                            </div>
-                            <div id="chaSection" class="tile is-child pt-2 is-paddingless cursor-clickable">
-                                <div class="is-size-7 is-unselectable">Charisma</div>
-                                <div id="chaMod" class="is-size-4 pr-3"></div>
-                                <span id="chaScore" class="sheet-small-box is-size-7 has-txt-listing"></span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="tile is-3">
-                    <div class="mobile-box tile is-vertical my-2 ml-2 mobile-is-marginless sheet-box">
-                        <!-- Saving Throws -->
-                        <p class="is-size-6 has-text-centered has-txt-value-number">Saving Throws</p>
-                        <div class="tile is-centered is-paddingless mobile-apply-flex">
-                            <div id="fortSection" class="tile is-child is-paddingless cursor-clickable">
-                                <p class="has-txt-listing">Fortitude</p>
-                                <div id="fortSave" class="is-size-5 pr-2"></div>
-                            </div>
-                            <div id="reflexSection" class="tile is-child is-paddingless cursor-clickable">
-                                <p class="has-txt-listing">Reflex</p>
-                                <div id="reflexSave" class="is-size-5 pr-2"></div>
-                            </div>
-                            <div id="willSection" class="tile is-child is-paddingless cursor-clickable">
-                                <p class="has-txt-listing">Will</p>
-                                <div id="willSave" class="is-size-5 pr-2"></div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="mobile-box tile m-2 pr-4">
-            <div class="tile is-parent is-vertical is-2 my-2 mr-4 mobile-is-marginless is-paddingless">
-                <div class="mobile-box tile is-paddingless p-3">
-                    <div id="acSection" class="tile is-child is-unselectable pt-4 background-ac has-tooltip-bottom" data-tooltip="">
-                        <p id="acText" class="px-2"><strong class="has-txt-listing">AC</strong></p>
-                        <p id="acNumber" class="has-txt-listing"></p>
-                    </div>
-                    <div id="shieldSection" class="tile is-child background-shield pt-4 has-tooltip-bottom is-hidden" data-tooltip="">
-                        <p id="shieldText" class=""><strong class="has-txt-listing">Shield</strong></p>
-                        <p id="shieldBonus" class="has-txt-listing pr-2"></p>
-                    </div>
-                </div>
-                <div class="mobile-box tile is-vertical sheet-box">
-                    <div class="use-custom-scrollbar" style="height: 550px; max-height: 550px; overflow-y: auto; overflow-x: hidden;">
-                        <div class="tile is-paddingless">
-                            <div class="tile is-child">
-                                <p class="is-size-6"><strong class="has-txt-value-number pl-4">Attacks</strong><a id="addNewProfButton" class="is-pulled-right is-size-6"><span class="icon has-text-info"><i class="fal fa-plus-circle"></i></span></a></p>
-                                <p id="attacksContent"></p>
-                            </div>
-                        </div>
-                        <div class="tile is-paddingless">
-                            <div class="tile is-child">
-                                <p class="is-size-6"><strong class="has-txt-value-number">Defenses</strong></p>
-                                <p id="defensesContent"></p>
-                            </div>
-                        </div>
-                        <div id="spellsContentSection" class="tile is-paddingless">
-                            <div class="tile is-child">
-                                <p class="is-size-6"><strong class="has-txt-value-number">Spells</strong></p>
-                                <p id="spellsContent"></p>
-                            </div>
-                        </div>
-                        <div class="tile is-paddingless">
-                            <div class="tile is-child py-2">
-                                <p class="is-size-6"><strong class="has-txt-value-number pl-4">Languages</strong><a id="addNewLangButton" class="is-pulled-right is-size-6"><span class="icon has-text-info"><i class="fal fa-plus-circle"></i></span></a></p>
-                                <p id="languagesContent" class="is-unselectable px-2"></p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="tile is-parent is-2 is-paddingless">
+  <div id="sheet-container" class="tile is-ancestor is-vertical">
+    <div class="tile is-vertical m-2">
+      <div class="tile is-parent is-paddingless">
+        <div class="tile is-3">
+          <div class="mobile-box tile mb-4 mr-2">
+            <div class="tile sheet-box">
+              <div
+                id="charInfoContent"
+                class="tile is-vertical is-7 pb-1 cursor-clickable"
+              >
+                <p
+                  id="character-name"
+                  class="is-size-5 has-txt-value-string is-clipped"
+                ></p>
                 <div class="tile is-child">
-                    <nav class="mobile-box panel is-dark is-shadowless sheet-box my-2 mx-1">
-                        <p class="is-size-5"><strong class="has-txt-value-number pl-4">Skills</strong><a id="addNewLoreButton" class="is-pulled-right is-size-6 is-paddingless"><span class="icon has-text-info"><i class="fal fa-plus-circle"></i></span></a></p>
-                        <hr class="border-secondary is-marginless">
-                        <div id="skills" class="use-custom-scrollbar" style="max-height: 660px; overflow-y: auto;">
-
-                        </div>
-                    </nav>
+                  <p id="character-type" class="is-size-7 has-txt-listing"></p>
                 </div>
-            </div>
-
-            <div class="tile is-parent is-8 is-paddingless">
-                <div class="tile is-child" style="width: 100%;">
-                    <div class="sheet-box use-custom-scrollbar my-2 ml-4 mobile-is-marginless" style="min-height: 700px; overflow-y: auto; overflow-x: scroll;">
-                        <div id="char-sheet-tabs" class="tabs is-centered is-boxed is-medium is-marginless use-custom-scrollbar">
-                            <ul class="sheet-tabs">
-                                <li><a id="actionsTab"><span class="pf-icon">[free-action]</span><span class="pl-2">Actions</span></a></li>
-                                <li><a id="weaponsTab"><i class="far fa-swords"></i><span class="pl-2">Weapons</span></a></li>
-                                <li><a id="spellsTab"><i class="far fa-wand-magic"></i><span class="pl-2">Spells</span></a></li>
-                                <li><a id="inventoryTab"><i class="far fa-backpack"></i><span class="pl-2">Inventory</span></a></li>
-                                <li><a id="companionsTab"><i class="far fa-paw-claws"></i><span class="pl-2">Companions</span></i></a></li>
-                                <li><a id="detailsTab"><i class="far fa-file-search"></i><span class="pl-2">Details</span></i></a></li>
-                                <li><a id="notesTab"><i class="far fa-scroll"></i><span class="pl-2">Notes</span></a></li>
-                            </ul>
-                        </div>
-                        <div id="tabContent" class="mx-3 mb-3 pos-relative">
-                        </div>
-                    </div>
+              </div>
+              <div
+                id="charExperienceContent"
+                class="tile is-vertical is-5 pb-1"
+              >
+                <p
+                  id="character-level"
+                  class="is-size-6 has-txt-value-number"
+                ></p>
+                <div class="tile is-child pb-3">
+                  <p
+                    class="is-size-7 has-txt-listing has-text-weight-semibold"
+                  >Experience</p>
+                  <div class="field px-4">
+                    <p class="control">
+                      <input
+                        id="exp-input"
+                        class="input is-small"
+                        type="number"
+                        value=""
+                      />
+                    </p>
+                  </div>
                 </div>
+              </div>
             </div>
+          </div>
         </div>
+        <div class="tile is-3">
+          <div class="mobile-box tile is-vertical mx-4 mb-4 sheet-box">
+            <div class="tile pb-1" style="position: relative;">
+              <div id="healthPointsContainer" class="tile is-child px-2 pt-2">
+                <p class="is-size-6"><strong class="has-txt-value-number">Hit
+                    Points</strong></p>
+                <div class="columns is-mobile is-centered">
+                  <div class="column is-narrow is-paddingless py-2">
+                    <div id="char-current-health" class="cursor-clickable">
+                    </div>
+                  </div>
+                  <div class="column is-narrow is-paddingless py-2">
+                    <p class="is-size-5 text-center has-txt-noted">/</p>
+                  </div>
+                  <div
+                    class="column is-narrow is-paddingless py-2"
+                    style="width: 70px;"
+                  >
+                    <p
+                      id="char-max-health"
+                      class="is-size-5 text-center has-txt-value-string"
+                    ></p>
+                  </div>
+                </div>
+              </div>
+              <div id="tempPointsContainer" class="tile is-child pt-3">
+                <p class="is-size-7"><strong class="has-txt-listing">Temp. HP</strong></p>
+                <div class="columns is-centered">
+                  <div class="column is-narrow is-paddingless py-2">
+                    <div id="char-temp-health" class="cursor-clickable">
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div
+                id="staminaPointsContainer"
+                class="tile is-child px-2 pt-2 is-hidden"
+              >
+                <p class="is-size-6"><strong
+                    class="has-txt-value-number"
+                  >Stamina</strong></p>
+                <div class="columns is-mobile is-centered">
+                  <div class="column is-narrow is-paddingless py-2">
+                    <div id="char-current-stamina" class="cursor-clickable">
+                    </div>
+                  </div>
+                  <div class="column is-narrow is-paddingless py-2">
+                    <p class="is-size-5 text-center has-txt-noted">/</p>
+                  </div>
+                  <div
+                    class="column is-narrow is-paddingless py-2"
+                    style="width: 40px;"
+                  >
+                    <p
+                      id="char-max-stamina"
+                      class="is-size-5 text-center has-txt-value-string"
+                    ></p>
+                  </div>
+                </div>
+              </div>
+              <div
+                id="resolvePointsContainer"
+                class="tile is-child pt-3 is-hidden"
+              >
+                <p class="is-size-7"><strong
+                    class="has-txt-listing"
+                  >Resolve</strong></p>
+                <div class="columns is-mobile is-centered">
+                  <div class="column is-narrow is-paddingless py-2">
+                    <div id="char-current-resolve" class="cursor-clickable">
+                    </div>
+                  </div>
+                  <div class="column is-narrow is-paddingless py-2">
+                    <p class="is-size-5 text-center has-txt-noted">/</p>
+                  </div>
+                  <div
+                    class="column is-narrow is-paddingless py-2"
+                    style="width: 40px;"
+                  >
+                    <p
+                      id="char-max-resolve"
+                      class="is-size-5 text-center has-txt-value-string"
+                    ></p>
+                  </div>
+                </div>
+              </div>
+
+              <div
+                id="pointSwitchOutContainer"
+                class="is-hidden"
+                style="position: absolute; top: 5px; left: 50%;"
+              >
+                <span
+                  id="pointSwitchOutBtn"
+                  class="icon is-small has-text-info cursor-clickable"
+                ><i class="fas fa-lg fa-retweet"></i></span>
+              </div>
+
+            </div>
+            <div class="tile" style="position: relative;">
+              <div
+                id="resistAndVulnerContent"
+                class="tile is-child cursor-clickable"
+              >
+                <p id="resistAndVulnerText" class="text-center"></p>
+              </div>
+              <span
+                id="resistAndVulnerViewAllBtn"
+                class="icon is-small has-text-info cursor-clickable"
+                style="position: absolute; bottom: 7px; right: 7px;"
+              >
+                <i class="fas fa-fire"></i>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div class="tile is-3">
+          <div
+            class="mobile-box tile ml-1 mr-4 mb-4 mobile-is-marginless sheet-box"
+          >
+            <div
+              class="tile is-child use-custom-scrollbar"
+              style="max-height: 100px; overflow-y: auto;"
+            >
+              <div class="columns is-centered is-vcentered is-marginless">
+                <div class="column is-paddingless"></div>
+                <div class="column is-paddingless"><p class="is-size-6"><strong
+                      class="has-txt-value-number"
+                    >Conditions</strong></p></div>
+                <div class="column is-paddingless">
+                  <a
+                    id="addNewConditionsButton"
+                    class="is-pulled-right is-size-6"
+                  ><span class="icon has-text-info"><i
+                        class="fal fa-plus-circle"
+                      ></i></span></a>
+                </div>
+              </div>
+              <div
+                id="conditionsContent"
+                class="buttons is-centered mx-1"
+              ></div>
+            </div>
+          </div>
+        </div>
+        <div class="tile is-2">
+          <div
+            class="mobile-box tile ml-2 mb-4 mobile-is-marginless mobile-apply-flex sheet-box"
+          >
+            <div
+              class="tile is-child pt-2 is-paddingless cursor-clickable"
+              id="classDCSection"
+            >
+              <p class="is-size-6 is-unselectable"><strong
+                  class="has-txt-value-number"
+                >Class DC</strong></p>
+              <p id="classDCContent" class="is-size-5 has-txt-listing pl-2"></p>
+            </div>
+            <div class="tile is-child pt-2">
+              <p id="heroPointsTitle" class="is-size-7 cursor-clickable"><strong
+                  class="has-txt-value-number"
+                >Hero Points</strong></p>
+              <div class="select">
+                <select id="heroPointsSelect">
+                  <option value="0">0</option>
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                  <option value="3">3</option>
+                </select>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="tile is-1">
+          <div class="mobile-box tile ml-2 mt-2 mb-4 mobile-is-marginless">
+            <div class="tile is-child">
+              <a
+                id="backToBuilderButton"
+                class="button is-info is-rounded is-small has-text-white mb-2"
+              >
+                <span>Edit</span>
+                <span class="icon">
+                  <i class="fas fa-cog"></i>
+                </span>
+              </a>
+              <a id="restButton" class="button is-info is-outlined">
+                <span>Rest</span>
+                <span class="icon is-very-small">
+                  <i class="far fa-snooze fa-xs"></i>
+                </span>
+              </a>
+
+              <a
+                id="copyCharButton"
+                class="button is-info is-outlined mb-2 is-hidden"
+              ><span>Copy</span><span class="icon"><i
+                    class="fas fa-user-friends"
+                  ></i></span></a>
+              <a
+                id="exportCharButton"
+                class="button is-info is-outlined is-hidden"
+              ><span>Export</span><span class="icon"><i
+                    class="fas fa-download"
+                  ></i></span></a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="tile is-parent is-paddingless">
+        <div class="tile is-3">
+          <div class="mobile-box tile my-2 mr-4 mobile-is-marginless">
+            <div
+              class="tile is-child is-paddingless sheet-box cursor-clickable"
+              id="speedSection"
+            >
+              <p class="is-size-6 is-unselectable"><strong
+                  class="has-txt-value-number"
+                >Speed</strong></p>
+              <p id="speedContent" class="is-size-5 has-txt-listing pl-2"></p>
+              <div id="speedBottom" class="is-hidden">
+                <hr id="speedDivider" class="m-1" />
+                <p class="is-size-7 has-txt-listing">View Others</p>
+              </div>
+            </div>
+          </div>
+          <div class="mobile-box tile m-2">
+            <div
+              class="tile is-child is-paddingless sheet-box cursor-clickable"
+              id="perceptionBonusSection"
+            >
+              <p class="is-size-6 is-unselectable"><strong
+                  class="has-txt-value-number"
+                >Perception</strong></p>
+              <p
+                id="perceptionBonusContent"
+                class="is-size-5 has-txt-listing pr-3"
+              ></p>
+              <div id="perceptionBonusBottom">
+                <hr id="perceptionBonusDivider" class="m-1" />
+                <p
+                  id="perceptionPrimaryVisionSense"
+                  class="is-size-7 has-txt-listing"
+                ></p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="tile is-6">
+          <div class="mobile-box tile my-2 mx-4 mobile-is-marginless">
+            <!-- Ability Scores -->
+            <div class="tile sheet-box mobile-apply-flex">
+              <div
+                id="strSection"
+                class="tile is-child pt-2 is-paddingless cursor-clickable"
+              >
+                <div class="is-size-7 is-unselectable">Strength</div>
+                <div id="strMod" class="is-size-4 pr-3"></div>
+                <span
+                  id="strScore"
+                  class="sheet-small-box is-size-7 has-txt-listing"
+                ></span>
+              </div>
+              <div
+                id="dexSection"
+                class="tile is-child pt-2 is-paddingless cursor-clickable"
+              >
+                <div class="is-size-7 is-unselectable">Dexterity</div>
+                <div id="dexMod" class="is-size-4 pr-3"></div>
+                <span
+                  id="dexScore"
+                  class="sheet-small-box is-size-7 has-txt-listing"
+                ></span>
+              </div>
+              <div
+                id="conSection"
+                class="tile is-child pt-2 is-paddingless cursor-clickable"
+              >
+                <div class="is-size-7 is-unselectable">Constitution</div>
+                <div id="conMod" class="is-size-4 pr-3"></div>
+                <span
+                  id="conScore"
+                  class="sheet-small-box is-size-7 has-txt-listing"
+                ></span>
+              </div>
+              <div
+                id="intSection"
+                class="tile is-child pt-2 is-paddingless cursor-clickable"
+              >
+                <div class="is-size-7 is-unselectable">Intelligence</div>
+                <div id="intMod" class="is-size-4 pr-3"></div>
+                <span
+                  id="intScore"
+                  class="sheet-small-box is-size-7 has-txt-listing"
+                ></span>
+              </div>
+              <div
+                id="wisSection"
+                class="tile is-child pt-2 is-paddingless cursor-clickable"
+              >
+                <div class="is-size-7 is-unselectable">Wisdom</div>
+                <div id="wisMod" class="is-size-4 pr-3"></div>
+                <span
+                  id="wisScore"
+                  class="sheet-small-box is-size-7 has-txt-listing"
+                ></span>
+              </div>
+              <div
+                id="chaSection"
+                class="tile is-child pt-2 is-paddingless cursor-clickable"
+              >
+                <div class="is-size-7 is-unselectable">Charisma</div>
+                <div id="chaMod" class="is-size-4 pr-3"></div>
+                <span
+                  id="chaScore"
+                  class="sheet-small-box is-size-7 has-txt-listing"
+                ></span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="tile is-3">
+          <div
+            class="mobile-box tile is-vertical my-2 ml-2 mobile-is-marginless sheet-box"
+          >
+            <!-- Saving Throws -->
+            <p class="is-size-6 has-text-centered has-txt-value-number">Saving
+              Throws</p>
+            <div class="tile is-centered is-paddingless mobile-apply-flex">
+              <div
+                id="fortSection"
+                class="tile is-child is-paddingless cursor-clickable"
+              >
+                <p class="has-txt-listing">Fortitude</p>
+                <div id="fortSave" class="is-size-5 pr-2"></div>
+              </div>
+              <div
+                id="reflexSection"
+                class="tile is-child is-paddingless cursor-clickable"
+              >
+                <p class="has-txt-listing">Reflex</p>
+                <div id="reflexSave" class="is-size-5 pr-2"></div>
+              </div>
+              <div
+                id="willSection"
+                class="tile is-child is-paddingless cursor-clickable"
+              >
+                <p class="has-txt-listing">Will</p>
+                <div id="willSave" class="is-size-5 pr-2"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
+    <div class="mobile-box tile m-2 pr-4">
+      <div
+        class="tile is-parent is-vertical is-2 my-2 mr-4 mobile-is-marginless is-paddingless"
+      >
+        <div class="mobile-box tile is-paddingless p-3">
+          <div
+            id="acSection"
+            class="tile is-child is-unselectable pt-4 background-ac has-tooltip-bottom"
+            data-tooltip=""
+          >
+            <p id="acText" class="px-2"><strong
+                class="has-txt-listing"
+              >AC</strong></p>
+            <p id="acNumber" class="has-txt-listing"></p>
+          </div>
+          <div
+            id="shieldSection"
+            class="tile is-child background-shield pt-4 has-tooltip-bottom is-hidden"
+            data-tooltip=""
+          >
+            <p id="shieldText" class=""><strong
+                class="has-txt-listing"
+              >Shield</strong></p>
+            <p id="shieldBonus" class="has-txt-listing pr-2"></p>
+          </div>
+        </div>
+        <div class="mobile-box tile is-vertical sheet-box">
+          <div
+            class="use-custom-scrollbar"
+            style="height: 550px; max-height: 550px; overflow-y: auto; overflow-x: hidden;"
+          >
+            <div class="tile is-paddingless">
+              <div class="tile is-child">
+                <p class="is-size-6"><strong
+                    class="has-txt-value-number pl-4"
+                  >Attacks</strong><a
+                    id="addNewProfButton"
+                    class="is-pulled-right is-size-6"
+                  ><span class="icon has-text-info"><i
+                        class="fal fa-plus-circle"
+                      ></i></span></a></p>
+                <p id="attacksContent"></p>
+              </div>
+            </div>
+            <div class="tile is-paddingless">
+              <div class="tile is-child">
+                <p class="is-size-6"><strong
+                    class="has-txt-value-number"
+                  >Defenses</strong></p>
+                <p id="defensesContent"></p>
+              </div>
+            </div>
+            <div id="spellsContentSection" class="tile is-paddingless">
+              <div class="tile is-child">
+                <p class="is-size-6"><strong
+                    class="has-txt-value-number"
+                  >Spells</strong></p>
+                <p id="spellsContent"></p>
+              </div>
+            </div>
+            <div class="tile is-paddingless">
+              <div class="tile is-child py-2">
+                <p class="is-size-6"><strong
+                    class="has-txt-value-number pl-4"
+                  >Languages</strong><a
+                    id="addNewLangButton"
+                    class="is-pulled-right is-size-6"
+                  ><span class="icon has-text-info"><i
+                        class="fal fa-plus-circle"
+                      ></i></span></a></p>
+                <p id="languagesContent" class="is-unselectable px-2"></p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="tile is-parent is-2 is-paddingless">
+        <div class="tile is-child">
+          <nav
+            class="mobile-box panel is-dark is-shadowless sheet-box my-2 mx-1"
+          >
+            <p class="is-size-5"><strong
+                class="has-txt-value-number pl-4"
+              >Skills</strong><a
+                id="addNewLoreButton"
+                class="is-pulled-right is-size-6 is-paddingless"
+              ><span class="icon has-text-info"><i
+                    class="fal fa-plus-circle"
+                  ></i></span></a></p>
+            <hr class="border-secondary is-marginless" />
+            <div
+              id="skills"
+              class="use-custom-scrollbar"
+              style="max-height: 660px; overflow-y: auto;"
+            >
+
+            </div>
+          </nav>
+        </div>
+      </div>
+
+      <div class="tile is-parent is-8 is-paddingless">
+        <div class="tile is-child" style="width: 100%;">
+          <div
+            class="sheet-box use-custom-scrollbar my-2 ml-4 mobile-is-marginless"
+            style="min-height: 700px; overflow-y: auto; overflow-x: scroll;"
+          >
+            <div
+              id="char-sheet-tabs"
+              class="tabs is-centered is-boxed is-medium is-marginless use-custom-scrollbar"
+            >
+              <ul class="sheet-tabs">
+                <li><a id="actionsTab"><span
+                      class="pf-icon"
+                    >[free-action]</span><span
+                      class="pl-2"
+                    >Actions</span></a></li>
+                <li><a id="weaponsTab"><i class="far fa-swords"></i><span
+                      class="pl-2"
+                    >Weapons</span></a></li>
+                <li><a id="spellsTab"><i class="far fa-wand-magic"></i><span
+                      class="pl-2"
+                    >Spells</span></a></li>
+                <li><a id="inventoryTab"><i class="far fa-backpack"></i><span
+                      class="pl-2"
+                    >Inventory</span></a></li>
+                <li>
+                  <a id="companionsTab">
+                    <i class="far fa-paw-claws"></i>
+                    <span class="pl-2">Companions</span>
+                  </a>
+                </li>
+                <li><a id="detailsTab"><i class="far fa-file-search"></i><span
+                      class="pl-2"
+                    >Details</span></a></li>
+                <li><a id="notesTab"><i class="far fa-scroll"></i><span
+                      class="pl-2"
+                    >Notes</span></a></li>
+              </ul>
+            </div>
+            <div id="tabContent" class="mx-3 mb-3 pos-relative">
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 
 </section>
 
+{{#section "overlay"}}
 
-
-{{#section 'overlay'}}
-    
-    <!-- Right Quickview -->
-    <div id="quickviewDefault" class="quickview">
-        <div class="quickview-header">
-            <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
-            <div class="is-inline-flex">
-                <p id="quickViewTitleRight"></p>
-                <p id="quickViewTitleClose"></p>
-            </div>
-        </div>
-        <div class="quickview-body use-custom-scrollbar">
-            <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
-            </div>
-        </div>
-    </div>
-
-    <!-- Left Quickview -->
-    <div id="quickviewLeftDefault" class="quickview is-left">
-        <div class="quickview-header">
-            <p id="quickViewLeftTitle" class="title is-size-5 has-txt-value-number">Sheet Tools</p>
-            <div class="is-inline-flex">
-                <p id="quickViewLeftTitleClose"></p>
-            </div>
-        </div>
-        <div class="quickview-body use-custom-scrollbar">
-            <div class="quickview-block pb-3 px-3">
-
-              <div class="tabs is-centered is-marginless">
-                <ul class="quickViewLeft-Tabs">
-                  <li><a id="quickViewLeftTab-Toggleables">Toggleables</a></li>
-                  <li><a id="quickViewLeftTab-DiceRoller">Dice Roller</a></li>
-                  <li class="is-hidden"><a id="quickViewLeftTab-Campaign">Campaign</a></li>
-                </ul>
-              </div>
-              <div id="quickViewLeftContent" class="pt-3 pos-relative"></div>
-
-            </div>
-        </div>
-        <div id="quickViewLeftOuterExtra" class=""></div>
-    </div>
-
-
-    <!-- Conditions Modal -->
-    <div id="conditionsModalDefault" name="" class="modal" style="z-index:30;">
-    <div id="conditionsModalBackground" class="modal-background"></div>
-    <div class="modal-card">
-        <div class="modal-card-head">
-        <p id="conditionsModalTitle" class="modal-card-title has-text-centered is-size-4 has-txt-value-number"></p>
-        <a id="conditionsModalRemoveButton" class="is-pulled-right is-size-6"><span class="icon is-medium has-text-danger"><i class="fal fa-minus-circle"></i></span></a>
-        </div>
-        <section class="modal-card-body py-2">
-            <p id="conditionsModalSourceSection" class="has-text-centered"><strong class="has-txt-listing">From: </strong><em id="conditionsModalSourceContent"></em></p>
-            <p id="conditionsModalContent"></p>
-        </section>
-        <div id="conditionsModalFooter" class="modal-card-foot buttons is-centered">
-                <button id="conditionsModalSubtractButton" class="button is-very-small is-info is-rounded">
-                    <span class="icon">
-                        <i class="fas fa-heading fa-minus"></i>
-                    </span>
-                </button>
-                <button id="conditionsModalValueButton" class="button is-static has-bg-selectable-hover border-dark">
-                    <p id="conditionsModalValue" class="has-txt-value-number"></p>
-                </button>
-                <button id="conditionsModalAddButton" class="button is-very-small is-info is-rounded">
-                    <span class="icon">
-                        <i class="fas fa-heading fa-plus"></i>
-                    </span>
-                </button>
-        </div>
-    </div>
-    <button id="conditionsModalCloseButton" class="modal-close is-large is-hidden-mobile" aria-label="close"></button>
-    </div>
-
-    <!-- Conditions Select Modal -->
-    <div id="conditionsSelectModalDefault" name="" class="modal" style="z-index:30;">
-    <div id="conditionsSelectModalBackground" class="modal-background"></div>
-    <div class="modal-card">
-        <div class="modal-card-head">
-        <p id="conditionsSelectModalTitle" class="modal-card-title has-text-centered is-size-4 has-txt-value-number">Choose a Condition</p>
-        <button id="conditionsSelectModalCloseButton" class="delete modal-card-close" aria-label="close"></button>
-        </div>
-        <section class="modal-card-body is-paddingless use-invisible-scrollbar p-2">
-            <div id="conditionsSelectModalContent" class="tile is-ancestor is-vertical"></div>
-        </section>
-        <div class="modal-card-foot">
-        </div>
-    </div>
-    </div>
-
-    <!-- Spells Manager Modal -->
-    <div id="manageSpellsModalDefault" name="" class="modal" style="z-index:30;">
-    <div id="manageSpellsModalBackground" class="modal-background"></div>
-    <div id="manageSpellsModalCard" class="modal-card">
-        <div class="modal-card-head">
-        <p id="manageSpellsModalTitle" class="modal-card-title has-text-centered is-size-4 has-txt-value-number">Manage Spells<span class="icon is-size-6 has-text-info has-tooltip-multiline has-tooltip-bottom" data-tooltip="For prepared spellcasters, drag spells from your spell list over to the appropriate slots to prepare them."><i class="far fa-question-circle"></i></span></p>
-        <button id="manageSpellsModalCloseButton" class="delete modal-card-close" aria-label="close"></button>
-        </div>
-        <section class="modal-card-body is-paddingless px-2" style="overflow: hidden;">
-            <div class="tabs is-boxed is-small is-marginless">
-                <ul id="manageSpellsTabs" class="sheet-tabs has-txt-value-number">
-                </ul>
-            </div>
-                <div class="columns is-mobile is-marginless" style="height: 100%; padding-bottom: 2rem;">
-                    <div class="column is-paddingless is-3-desktop is-4-tablet is-6-mobile" style="height: 100%;">
-                        <div class="columns is-mobile is-marginless has-bg-options-header-bold">
-                            <div id="manageSpellsListName" class="column is-10 is-paddingless">
-                            </div>
-                            <div class="column is-2 is-paddingless">
-                                <span id="manageSpellsOpenSpellListsBtn" class="icon is-medium has-text-info pt-2 cursor-clickable">
-                                    <i class="fas fa-lg fa-plus"></i>
-                                </span>
-                            </div>
-                        </div>
-                        <div class="border-top border-bottom border-dark-lighter">
-                            <p class="control has-icons-left">
-                                <input id="manageSpellsSpellBookSearch" class="input" type="text" placeholder="Search">
-                                <span class="icon is-left"><i class="fas fa-search" aria-hidden="true"></i></span>
-                            </p>
-                        </div>
-                        <div id="manageSpellsSpellBook" class="use-custom-scrollbar is-darker" style="overflow-y: auto;height: calc(100% - 80px);">
-                        </div>
-                    </div>
-                    <div class="column is-paddingless is-9-desktop is-8-tablet is-6-mobile pos-relative">
-                        <div id="manageSpellsSlots" class="use-custom-scrollbar is-darker" style="overflow-y: auto; height: 100%;">
-                        </div>
-                        <div class="pos-absolute pos-t-0 pos-r-4">
-                          <span id="manageSpellsAddNewSlotBtn" class="icon is-medium has-text-info cursor-clickable has-tooltip-left" data-tooltip="Add Spell Slot">
-                            <i class="fas fa-lg fa-shapes"></i>
-                          </span>
-                        </div>
-                    </div>
-                </div>
-        </section>
-        <div class="modal-card-foot">
-        </div>
-    </div>
-    </div>
-
-    <!-- Note Page More Modal -->
-    <div id="note-page-more-modal" class="modal" data-page-id="">
-      <div id="note-page-more-modal-background" class="modal-background"></div>
-      <div class="modal-card">
-          <header class="modal-card-head">
-              <p class="modal-card-title is-size-4 has-txt-value-number">Page Options</p>
-              <button id="note-page-more-modal-close" class="delete modal-card-close" aria-label="close"></button>
-          </header>
-          <section id="note-page-more-modal-body" class="modal-card-body pb-2">
-
-            <div class="field">
-              <div class="control">
-                <input id="note-page-more-modal-page-name" class="input" type="text" maxlength="20" spellcheck="false" autocomplete="off" value="" placeholder="Page Name">
-              </div>
-            </div>
-            
-            <div class="field">
-              <div class="control">
-                <div class="select">
-                  <select id="note-page-more-modal-page-color">
-                    <option value="is-info" class="has-text-info">Guide Blue</option>
-                    <option value="is-link" class="has-text-link">Blue</option>
-                    <option value="is-success" class="has-text-success">Green</option>
-                    <option value="is-danger" class="has-text-danger">Red</option>
-                    <option value="is-primary" class="has-text-primary">Turquoise</option>
-                    <option value="is-warning" class="has-text-warning">Yellow</option>
-                  </select>
-                </div>
-              </div>
-            </div>
-
-            <div class="field is-grouped is-grouped-centered">
-              <div class="control">
-                <button id="note-page-more-modal-page-delete" class="button is-small is-danger is-outlined">
-                  <span>Delete</span>
-                  <span class="icon is-small">
-                    <i class="fas fa-times"></i>
-                  </span>
-                </button>
-              </div>
-            </div>
-            
-          </section>
-          <footer class="modal-card-foot">
-          </footer>
+  <!-- Right Quickview -->
+  <div id="quickviewDefault" class="quickview">
+    <div class="quickview-header">
+      <p id="quickViewTitle" class="title is-size-5 has-txt-value-number"></p>
+      <div class="is-inline-flex">
+        <p id="quickViewTitleRight"></p>
+        <p id="quickViewTitleClose"></p>
       </div>
     </div>
+    <div class="quickview-body use-custom-scrollbar">
+      <div id="quickViewContent" class="quickview-block pt-1 pb-3 px-3">
+      </div>
+    </div>
+  </div>
+
+  <!-- Left Quickview -->
+  <div id="quickviewLeftDefault" class="quickview is-left">
+    <div class="quickview-header">
+      <p
+        id="quickViewLeftTitle"
+        class="title is-size-5 has-txt-value-number"
+      >Sheet Tools</p>
+      <div class="is-inline-flex">
+        <p id="quickViewLeftTitleClose"></p>
+      </div>
+    </div>
+    <div class="quickview-body use-custom-scrollbar">
+      <div class="quickview-block pb-3 px-3">
+
+        <div class="tabs is-centered is-marginless">
+          <ul class="quickViewLeft-Tabs">
+            <li><a id="quickViewLeftTab-Toggleables">Toggleables</a></li>
+            <li><a id="quickViewLeftTab-DiceRoller">Dice Roller</a></li>
+            <li class="is-hidden"><a
+                id="quickViewLeftTab-Campaign"
+              >Campaign</a></li>
+          </ul>
+        </div>
+        <div id="quickViewLeftContent" class="pt-3 pos-relative"></div>
+
+      </div>
+    </div>
+    <div id="quickViewLeftOuterExtra" class=""></div>
+  </div>
+
+  <!-- Conditions Modal -->
+  <div id="conditionsModalDefault" name="" class="modal" style="z-index:30;">
+    <div id="conditionsModalBackground" class="modal-background"></div>
+    <div class="modal-card">
+      <div class="modal-card-head">
+        <p
+          id="conditionsModalTitle"
+          class="modal-card-title has-text-centered is-size-4 has-txt-value-number"
+        ></p>
+        <a
+          id="conditionsModalRemoveButton"
+          class="is-pulled-right is-size-6"
+        ><span class="icon is-medium has-text-danger"><i
+              class="fal fa-minus-circle"
+            ></i></span></a>
+      </div>
+      <section class="modal-card-body py-2">
+        <p id="conditionsModalSourceSection" class="has-text-centered"><strong
+            class="has-txt-listing"
+          >From: </strong><em id="conditionsModalSourceContent"></em></p>
+        <p id="conditionsModalContent"></p>
+      </section>
+      <div
+        id="conditionsModalFooter"
+        class="modal-card-foot buttons is-centered"
+      >
+        <button
+          id="conditionsModalSubtractButton"
+          class="button is-very-small is-info is-rounded"
+        >
+          <span class="icon">
+            <i class="fas fa-heading fa-minus"></i>
+          </span>
+        </button>
+        <button
+          id="conditionsModalValueButton"
+          class="button is-static has-bg-selectable-hover border-dark"
+        >
+          <p id="conditionsModalValue" class="has-txt-value-number"></p>
+        </button>
+        <button
+          id="conditionsModalAddButton"
+          class="button is-very-small is-info is-rounded"
+        >
+          <span class="icon">
+            <i class="fas fa-heading fa-plus"></i>
+          </span>
+        </button>
+      </div>
+    </div>
+    <button
+      id="conditionsModalCloseButton"
+      class="modal-close is-large is-hidden-mobile"
+      aria-label="close"
+    ></button>
+  </div>
+
+  <!-- Conditions Select Modal -->
+  <div
+    id="conditionsSelectModalDefault"
+    name=""
+    class="modal"
+    style="z-index:30;"
+  >
+    <div id="conditionsSelectModalBackground" class="modal-background"></div>
+    <div class="modal-card">
+      <div class="modal-card-head">
+        <p
+          id="conditionsSelectModalTitle"
+          class="modal-card-title has-text-centered is-size-4 has-txt-value-number"
+        >Choose a Condition</p>
+        <button
+          id="conditionsSelectModalCloseButton"
+          class="delete modal-card-close"
+          aria-label="close"
+        ></button>
+      </div>
+      <section
+        class="modal-card-body is-paddingless use-invisible-scrollbar p-2"
+      >
+        <div
+          id="conditionsSelectModalContent"
+          class="tile is-ancestor is-vertical"
+        ></div>
+      </section>
+      <div class="modal-card-foot">
+      </div>
+    </div>
+  </div>
+
+  <!-- Spells Manager Modal -->
+  <div id="manageSpellsModalDefault" name="" class="modal" style="z-index:30;">
+    <div id="manageSpellsModalBackground" class="modal-background"></div>
+    <div id="manageSpellsModalCard" class="modal-card">
+      <div class="modal-card-head">
+        <p
+          id="manageSpellsModalTitle"
+          class="modal-card-title has-text-centered is-size-4 has-txt-value-number"
+        >Manage Spells<span
+            class="icon is-size-6 has-text-info has-tooltip-multiline has-tooltip-bottom"
+            data-tooltip="For prepared spellcasters, drag spells from your spell list over to the appropriate slots to prepare them."
+          ><i class="far fa-question-circle"></i></span></p>
+        <button
+          id="manageSpellsModalCloseButton"
+          class="delete modal-card-close"
+          aria-label="close"
+        ></button>
+      </div>
+      <section
+        class="modal-card-body is-paddingless px-2"
+        style="overflow: hidden;"
+      >
+        <div class="tabs is-boxed is-small is-marginless">
+          <ul id="manageSpellsTabs" class="sheet-tabs has-txt-value-number">
+          </ul>
+        </div>
+        <div
+          class="columns is-mobile is-marginless"
+          style="height: 100%; padding-bottom: 2rem;"
+        >
+          <div
+            class="column is-paddingless is-3-desktop is-4-tablet is-6-mobile"
+            style="height: 100%;"
+          >
+            <div
+              class="columns is-mobile is-marginless has-bg-options-header-bold"
+            >
+              <div
+                id="manageSpellsListName"
+                class="column is-10 is-paddingless"
+              >
+              </div>
+              <div class="column is-2 is-paddingless">
+                <span
+                  id="manageSpellsOpenSpellListsBtn"
+                  class="icon is-medium has-text-info pt-2 cursor-clickable"
+                >
+                  <i class="fas fa-lg fa-plus"></i>
+                </span>
+              </div>
+            </div>
+            <div class="border-top border-bottom border-dark-lighter">
+              <p class="control has-icons-left">
+                <input
+                  id="manageSpellsSpellBookSearch"
+                  class="input"
+                  type="text"
+                  placeholder="Search"
+                />
+                <span class="icon is-left"><i
+                    class="fas fa-search"
+                    aria-hidden="true"
+                  ></i></span>
+              </p>
+            </div>
+            <div
+              id="manageSpellsSpellBook"
+              class="use-custom-scrollbar is-darker"
+              style="overflow-y: auto;height: calc(100% - 80px);"
+            >
+            </div>
+          </div>
+          <div
+            class="column is-paddingless is-9-desktop is-8-tablet is-6-mobile pos-relative"
+          >
+            <div
+              id="manageSpellsSlots"
+              class="use-custom-scrollbar is-darker"
+              style="overflow-y: auto; height: 100%;"
+            >
+            </div>
+            <div class="pos-absolute pos-t-0 pos-r-4">
+              <span
+                id="manageSpellsAddNewSlotBtn"
+                class="icon is-medium has-text-info cursor-clickable has-tooltip-left"
+                data-tooltip="Add Spell Slot"
+              >
+                <i class="fas fa-lg fa-shapes"></i>
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+      <div class="modal-card-foot">
+      </div>
+    </div>
+  </div>
+
+  <!-- Note Page More Modal -->
+  <div id="note-page-more-modal" class="modal" data-page-id="">
+    <div id="note-page-more-modal-background" class="modal-background"></div>
+    <div class="modal-card">
+      <header class="modal-card-head">
+        <p class="modal-card-title is-size-4 has-txt-value-number">Page Options</p>
+        <button
+          id="note-page-more-modal-close"
+          class="delete modal-card-close"
+          aria-label="close"
+        ></button>
+      </header>
+      <section id="note-page-more-modal-body" class="modal-card-body pb-2">
+
+        <div class="field">
+          <div class="control">
+            <input
+              id="note-page-more-modal-page-name"
+              class="input"
+              type="text"
+              maxlength="20"
+              spellcheck="false"
+              autocomplete="off"
+              value=""
+              placeholder="Page Name"
+            />
+          </div>
+        </div>
+
+        <div class="field">
+          <div class="control">
+            <div class="select">
+              <select id="note-page-more-modal-page-color">
+                <option value="is-info" class="has-text-info">Guide Blue</option>
+                <option value="is-link" class="has-text-link">Blue</option>
+                <option
+                  value="is-success"
+                  class="has-text-success"
+                >Green</option>
+                <option value="is-danger" class="has-text-danger">Red</option>
+                <option
+                  value="is-primary"
+                  class="has-text-primary"
+                >Turquoise</option>
+                <option
+                  value="is-warning"
+                  class="has-text-warning"
+                >Yellow</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <div class="field is-grouped is-grouped-centered">
+          <div class="control">
+            <button
+              id="note-page-more-modal-page-delete"
+              class="button is-small is-danger is-outlined"
+            >
+              <span>Delete</span>
+              <span class="icon is-small">
+                <i class="fas fa-times"></i>
+              </span>
+            </button>
+          </div>
+        </div>
+
+      </section>
+      <footer class="modal-card-foot">
+      </footer>
+    </div>
+  </div>
 
 {{/section}}
-


### PR DESCRIPTION
## Before Review

Disable white space changes, a bunch of prettier stuff happened while editing and it doesn't really have anything to do with this PR!

# Description

If scripts aren't absolutely required for instant functionality as the page loads, it is better to put them at the bottom of the body instead of the head. This reduces initial load times, and allows to page to render before parsing the JS.

Performance difference on the characters page can be seen here.

![image](https://user-images.githubusercontent.com/26830309/216410174-5e7de902-c0b8-42d6-bcc0-865f7a5a8334.png)
Left: new script in body goodness 🥳
Right: old script in head 🤮

Some pages won't get much benefit from this change, mainly the character editor. There are still a bunch more things to do to fix that one.

# Changes

 - Move `header` section (should probably be renamed) to the bottom of the body
 - Added a new styles section to the bottom of the head
 - Changed the section references in most handlebar pages to use this new pattern (didn't do admin, can be follow up PR)

This is a non breaking change!